### PR TITLE
fix: validate ZFS encryption passphrase minimum length

### DIFF
--- a/archinstall_zfs/menu/global_config.py
+++ b/archinstall_zfs/menu/global_config.py
@@ -39,7 +39,7 @@ from archinstall_zfs.initramfs.dracut import DracutInitramfsHandler
 from archinstall_zfs.initramfs.mkinitcpio import MkinitcpioInitramfsHandler
 from archinstall_zfs.kernel import get_menu_options
 from archinstall_zfs.menu.models import CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, SwapMode, ZFSEncryptionMode
-from archinstall_zfs.shared import ZFSModuleMode
+from archinstall_zfs.shared import ZFS_PASSPHRASE_MIN_LENGTH, ZFSModuleMode
 from archinstall_zfs.zfs import detect_pool_encryption, verify_pool_passphrase
 
 
@@ -579,9 +579,20 @@ class GlobalConfigMenu:
     def _get_encryption_password(self) -> None:
         """Get encryption password for ZFS."""
         while True:
-            password_result = EditMenu("ZFS Encryption Password", header="Enter password for ZFS encryption", hide_input=True).input()
+            password_result = EditMenu(
+                "ZFS Encryption Password",
+                header=f"Enter password for ZFS encryption (minimum {ZFS_PASSPHRASE_MIN_LENGTH} characters)",
+                hide_input=True,
+            ).input()
 
             if not password_result.text():
+                continue
+
+            if len(password_result.text()) < ZFS_PASSPHRASE_MIN_LENGTH:
+                SelectMenu(
+                    MenuItemGroup([MenuItem("OK", None)]),
+                    header=f"Password too short. ZFS requires at least {ZFS_PASSPHRASE_MIN_LENGTH} characters.",
+                ).run()
                 continue
 
             verify_result = EditMenu("Verify Password", header="Enter password again", hide_input=True).input()

--- a/archinstall_zfs/menu/models.py
+++ b/archinstall_zfs/menu/models.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
 
-from ..shared import ZFSModuleMode
+from ..shared import ZFS_PASSPHRASE_MIN_LENGTH, ZFSModuleMode
 
 
 class InstallationMode(Enum):
@@ -97,8 +97,11 @@ class GlobalConfig(BaseModel):
         """Return a list of validation errors; empty when valid."""
         errors: list[str] = []
 
-        if self.zfs_encryption_mode is not ZFSEncryptionMode.NONE and not self.zfs_encryption_password:
-            errors.append("ZFS encryption password is required when encryption is enabled")
+        if self.zfs_encryption_mode is not ZFSEncryptionMode.NONE:
+            if not self.zfs_encryption_password:
+                errors.append("ZFS encryption password is required when encryption is enabled")
+            elif len(self.zfs_encryption_password) < ZFS_PASSPHRASE_MIN_LENGTH:
+                errors.append(f"ZFS encryption password must be at least {ZFS_PASSPHRASE_MIN_LENGTH} characters")
 
         if not self.installation_mode:
             errors.append("Installation mode is required")

--- a/archinstall_zfs/shared.py
+++ b/archinstall_zfs/shared.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from enum import Enum
 
+# ZFS passphrase minimum length requirement
+ZFS_PASSPHRASE_MIN_LENGTH = 8
+
 
 class ZFSModuleMode(Enum):
     """ZFS module installation mode."""

--- a/archinstall_zfs/zfs/__init__.py
+++ b/archinstall_zfs/zfs/__init__.py
@@ -12,6 +12,7 @@ from archinstall.lib.general import SysCommand
 from archinstall.tui import EditMenu, MenuItem, MenuItemGroup, SelectMenu
 from pydantic import BaseModel, Field, field_validator
 
+from archinstall_zfs.shared import ZFS_PASSPHRASE_MIN_LENGTH
 from archinstall_zfs.utils import modify_zfs_cache_mountpoints
 
 
@@ -200,16 +201,26 @@ class ZFSEncryption:
                 str,
                 EditMenu(
                     "ZFS Encryption Password",
-                    header="Enter password for ZFS encryption",
+                    header=f"Enter password for ZFS encryption (minimum {ZFS_PASSPHRASE_MIN_LENGTH} characters)",
                     hide_input=True,
                 )
                 .input()
                 .text(),
             )
 
+            if not password:
+                continue
+
+            if len(password) < ZFS_PASSPHRASE_MIN_LENGTH:
+                SelectMenu(
+                    MenuItemGroup([MenuItem("OK", None)]),
+                    header=f"Password too short. ZFS requires at least {ZFS_PASSPHRASE_MIN_LENGTH} characters.",
+                ).run()
+                continue
+
             verify = cast(str, EditMenu("Verify Password", header="Enter password again", hide_input=True).input().text())
 
-            if password == verify and password:
+            if password == verify:
                 return password
 
 


### PR DESCRIPTION
## Summary
- Adds validation for ZFS encryption passphrase minimum length (8 characters)
- Shows user-friendly error message when passphrase is too short
- Validates in both password input dialogs and as fallback in `validate_for_install()`

Fixes #29