### PR TITLE
User UI improvements, fuzzy search, cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "nix 0.31.2",
  "slint",
  "slint-build",
+ "sublime_fuzzy",
  "tokio",
  "tokio-util",
  "tracing",
@@ -227,6 +228,7 @@ dependencies = [
  "ratatui-macros",
  "ratatui-themes",
  "ratatui-widgets",
+ "sublime_fuzzy",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4683,6 +4685,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "sublime_fuzzy"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7986063f7c0ab374407e586d7048a3d5aac94f103f751088bf398e07cd5400"
 
 [[package]]
 name = "svgtypes"

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -186,7 +186,6 @@ pub struct GlobalConfig {
     pub locale: Option<String>,
     #[serde(default = "default_keyboard_layout")]
     pub keyboard_layout: String,
-    pub x11_variant: Option<String>,
     pub timezone: Option<String>,
     #[serde(default = "default_ntp")]
     pub ntp: bool,
@@ -295,7 +294,6 @@ impl Default for GlobalConfig {
             hostname: Some("archzfs".to_string()),
             locale: Some("en_US.UTF-8 UTF-8".to_string()),
             keyboard_layout: default_keyboard_layout(),
-            x11_variant: None,
             timezone: None,
             ntp: true,
             root_password: None,

--- a/core/src/config/validation.rs
+++ b/core/src/config/validation.rs
@@ -13,7 +13,7 @@ fn is_valid_hostname(name: &str) -> bool {
 
 /// Valid Linux username: 1-32 chars, starts with letter or underscore,
 /// rest is alphanumeric + underscore + hyphen.
-fn is_valid_username(name: &str) -> bool {
+pub fn is_valid_username(name: &str) -> bool {
     !name.is_empty()
         && name.len() <= 32
         && name.starts_with(|c: char| c.is_ascii_lowercase() || c == '_')

--- a/core/src/installer/locale.rs
+++ b/core/src/installer/locale.rs
@@ -142,6 +142,34 @@ pub fn list_locales() -> Vec<String> {
     locales
 }
 
+/// List available console keymaps by scanning /usr/share/kbd/keymaps/.
+pub fn list_keymaps() -> Vec<String> {
+    let base = Path::new("/usr/share/kbd/keymaps");
+    let mut keymaps = Vec::new();
+    fn walk(dir: &Path, keymaps: &mut Vec<String>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // Skip "include" directories — they contain partial maps
+                if path.file_name().is_some_and(|n| n == "include") {
+                    continue;
+                }
+                walk(&path, keymaps);
+            } else if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && let Some(stem) = name.strip_suffix(".map.gz") {
+                    keymaps.push(stem.to_string());
+                }
+        }
+    }
+    walk(base, &mut keymaps);
+    keymaps.sort();
+    keymaps.dedup();
+    keymaps
+}
+
 pub fn set_timezone(target: &Path, timezone: &str) -> Result<()> {
     let localtime = target.join("etc/localtime");
     let zoneinfo = format!("/usr/share/zoneinfo/{timezone}");

--- a/core/src/installer/locale.rs
+++ b/core/src/installer/locale.rs
@@ -153,9 +153,10 @@ pub fn list_keymaps() -> Vec<String> {
                 }
                 walk(&path, keymaps);
             } else if let Some(name) = path.file_name().and_then(|n| n.to_str())
-                && let Some(stem) = name.strip_suffix(".map.gz") {
-                    keymaps.push(stem.to_string());
-                }
+                && let Some(stem) = name.strip_suffix(".map.gz")
+            {
+                keymaps.push(stem.to_string());
+            }
         }
     }
     walk(base, &mut keymaps);

--- a/core/src/installer/locale.rs
+++ b/core/src/installer/locale.rs
@@ -48,23 +48,17 @@ pub fn set_keyboard(_runner: &dyn CommandRunner, target: &Path, layout: &str) ->
 }
 
 /// Write /etc/X11/xorg.conf.d/00-keyboard.conf for graphical sessions.
-/// Uses `layout` (same as vconsole by default) with an optional variant.
-pub fn set_x11_keyboard(target: &Path, layout: &str, variant: Option<&str>) -> Result<()> {
+pub fn set_x11_keyboard(target: &Path, layout: &str) -> Result<()> {
     let conf_dir = target.join("etc/X11/xorg.conf.d");
     fs::create_dir_all(&conf_dir).wrap_err("failed to create xorg.conf.d")?;
 
-    let variant_line = match variant {
-        Some(v) => format!("    Option \"XkbVariant\" \"{v}\"\n"),
-        None => String::new(),
-    };
-
     let content = format!(
-        "Section \"InputClass\"\n    Identifier \"system-keyboard\"\n    MatchIsKeyboard \"on\"\n    Option \"XkbLayout\" \"{layout}\"\n{variant_line}EndSection\n"
+        "Section \"InputClass\"\n    Identifier \"system-keyboard\"\n    MatchIsKeyboard \"on\"\n    Option \"XkbLayout\" \"{layout}\"\nEndSection\n"
     );
 
     let conf_path = conf_dir.join("00-keyboard.conf");
     fs::write(&conf_path, content).wrap_err("failed to write 00-keyboard.conf")?;
-    tracing::info!(layout, variant, "set X11 keyboard layout");
+    tracing::info!(layout, "set X11 keyboard layout");
     Ok(())
 }
 
@@ -220,25 +214,13 @@ mod tests {
     }
 
     #[test]
-    fn test_set_x11_keyboard_no_variant() {
+    fn test_set_x11_keyboard() {
         let dir = tempfile::tempdir().unwrap();
-        set_x11_keyboard(dir.path(), "us", None).unwrap();
+        set_x11_keyboard(dir.path(), "us").unwrap();
 
         let content =
             fs::read_to_string(dir.path().join("etc/X11/xorg.conf.d/00-keyboard.conf")).unwrap();
         assert!(content.contains("XkbLayout\" \"us\""));
-        assert!(!content.contains("XkbVariant"));
-    }
-
-    #[test]
-    fn test_set_x11_keyboard_with_variant() {
-        let dir = tempfile::tempdir().unwrap();
-        set_x11_keyboard(dir.path(), "us", Some("intl")).unwrap();
-
-        let content =
-            fs::read_to_string(dir.path().join("etc/X11/xorg.conf.d/00-keyboard.conf")).unwrap();
-        assert!(content.contains("XkbLayout\" \"us\""));
-        assert!(content.contains("XkbVariant\" \"intl\""));
     }
 
     #[test]

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -141,11 +141,7 @@ impl Installer {
         }
 
         locale::set_keyboard(&*self.runner, &self.target, &self.config.keyboard_layout)?;
-        locale::set_x11_keyboard(
-            &self.target,
-            &self.config.keyboard_layout,
-            self.config.x11_variant.as_deref(),
-        )?;
+        locale::set_x11_keyboard(&self.target, &self.config.keyboard_layout)?;
 
         if let Some(ref tz) = self.config.timezone {
             locale::set_timezone(&self.target, tz)?;

--- a/gen_iso/profile/profiledef.sh.j2
+++ b/gen_iso/profile/profiledef.sh.j2
@@ -23,8 +23,8 @@ bootstrap_tarball_compression=('zstd' '-c' '-T0' '--auto-threads=logical' '--lon
 file_permissions=(
   ["/etc/shadow"]="0:0:400"
   ["/root"]="0:0:750"
-  ["/root/archinstall-zfs-tui"]="0:0:755"
-  ["/root/archinstall-zfs-slint"]="0:0:755"
+  ["/usr/local/bin/archinstall-zfs-tui"]="0:0:755"
+  ["/usr/local/bin/archinstall-zfs-slint"]="0:0:755"
   ["/usr/local/bin/choose-mirror"]="0:0:755"
   ["/usr/local/bin/Installation_guide"]="0:0:755"
   ["/usr/local/bin/livecd-sound"]="0:0:755"

--- a/justfile
+++ b/justfile
@@ -148,10 +148,10 @@ ssh:
 # Upload latest binaries to running QEMU VM
 upload:
     scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P 2222 \
-        {{BINARY}} root@localhost:/root/archinstall-zfs-tui
+        {{BINARY}} root@localhost:/usr/local/bin/archinstall-zfs-tui
     @if [ -f {{BINARY_SLINT}} ]; then \
         scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P 2222 \
-            {{BINARY_SLINT}} root@localhost:/root/archinstall-zfs-slint; \
+            {{BINARY_SLINT}} root@localhost:/usr/local/bin/archinstall-zfs-slint; \
     fi
     @echo "Uploaded to QEMU VM"
 

--- a/justfile
+++ b/justfile
@@ -48,10 +48,10 @@ _render-profile MODE="precompiled" KERNEL="linux-lts" FAST="":
 
 # Internal: copy installer binaries into rendered profile
 _prepare-binary:
-    @mkdir -p {{PROFILE_OUT}}/airootfs/root/
-    install -m 0755 {{BINARY}} {{PROFILE_OUT}}/airootfs/root/archinstall-zfs-tui
+    @mkdir -p {{PROFILE_OUT}}/airootfs/usr/local/bin/
+    install -m 0755 {{BINARY}} {{PROFILE_OUT}}/airootfs/usr/local/bin/archinstall-zfs-tui
     @if [ -f {{BINARY_SLINT}} ]; then \
-        install -m 0755 {{BINARY_SLINT}} {{PROFILE_OUT}}/airootfs/root/archinstall-zfs-slint; \
+        install -m 0755 {{BINARY_SLINT}} {{PROFILE_OUT}}/airootfs/usr/local/bin/archinstall-zfs-slint; \
     fi
 
 # Build production ISO

--- a/slint-ui/Cargo.toml
+++ b/slint-ui/Cargo.toml
@@ -16,6 +16,7 @@ slint = { git = "https://github.com/okhsunrog/slint.git", branch = "feat/rendere
     "backend-linuxkms-noseat",
     "renderer-skia-software",
 ] }
+sublime_fuzzy = "0.7.0"
 tokio = { version = "1.51.0", features = ["rt", "rt-multi-thread", "sync", "macros"] }
 tokio-util = { version = "0.7.18", features = ["rt"] }
 tracing = "0.1.44"

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -347,9 +347,10 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
             }
             // Prevent duplicate usernames
             let c = cfg.borrow();
-            if c.users.as_ref().is_some_and(|users| {
-                users.iter().any(|u| u.username == username)
-            }) {
+            if c.users
+                .as_ref()
+                .is_some_and(|users| users.iter().any(|u| u.username == username))
+            {
                 return;
             }
             drop(c);
@@ -756,8 +757,7 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
                     let mut scored: Vec<_> = all_locales
                         .iter()
                         .filter_map(|s| {
-                            sublime_fuzzy::best_match(&filter, s)
-                                .map(|m| (m.score(), s))
+                            sublime_fuzzy::best_match(&filter, s).map(|m| (m.score(), s))
                         })
                         .collect();
                     scored.sort_by(|a, b| b.0.cmp(&a.0));

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -12,7 +12,7 @@ use color_eyre::eyre::{Result, bail};
 use slint::{Model, ModelRc, SharedString, VecModel};
 
 use archinstall_zfs_core::config::types::{
-    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, SwapMode,
+    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, SwapMode, UserConfig,
     ZfsEncryptionMode, ZfsModuleMode,
 };
 
@@ -321,6 +321,83 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
             let Some(app) = weak.upgrade() else { return };
             let mut c = cfg.borrow_mut();
             apply_text(&mut c, &key, &val);
+            refresh_ui(&app, &c, &wiz.borrow());
+        });
+    }
+
+    // ── User management ─────────────────────────────
+    {
+        let weak = app.as_weak();
+        let cfg = config.clone();
+        let wiz = wizard.clone();
+        app.on_user_added(move |username, password, sudo| {
+            let Some(app) = weak.upgrade() else { return };
+            let username = username.to_string();
+            if !archinstall_zfs_core::config::validation::is_valid_username(&username) {
+                return;
+            }
+            // Prevent duplicate usernames
+            let c = cfg.borrow();
+            if c.users.as_ref().is_some_and(|users| {
+                users.iter().any(|u| u.username == username)
+            }) {
+                return;
+            }
+            drop(c);
+            let password = if password.is_empty() {
+                None
+            } else {
+                Some(password.to_string())
+            };
+            let user = UserConfig {
+                username,
+                password,
+                sudo,
+                shell: None,
+                groups: None,
+                ssh_authorized_keys: Vec::new(),
+                autologin: false,
+            };
+            let mut c = cfg.borrow_mut();
+            c.users.get_or_insert_with(Vec::new).push(user);
+            show_users_popup(&app, &c);
+            refresh_ui(&app, &c, &wiz.borrow());
+        });
+    }
+    {
+        let weak = app.as_weak();
+        let cfg = config.clone();
+        let wiz = wizard.clone();
+        app.on_user_removed(move |index| {
+            let Some(app) = weak.upgrade() else { return };
+            let mut c = cfg.borrow_mut();
+            if let Some(ref mut users) = c.users {
+                let idx = index as usize;
+                if idx < users.len() {
+                    users.remove(idx);
+                    if users.is_empty() {
+                        c.users = None;
+                    }
+                }
+            }
+            show_users_popup(&app, &c);
+            refresh_ui(&app, &c, &wiz.borrow());
+        });
+    }
+    {
+        let weak = app.as_weak();
+        let cfg = config.clone();
+        let wiz = wizard.clone();
+        app.on_user_sudo_toggled(move |index| {
+            let Some(app) = weak.upgrade() else { return };
+            let mut c = cfg.borrow_mut();
+            if let Some(ref mut users) = c.users {
+                let idx = index as usize;
+                if let Some(user) = users.get_mut(idx) {
+                    user.sudo = !user.sudo;
+                }
+            }
+            show_users_popup(&app, &c);
             refresh_ui(&app, &c, &wiz.borrow());
         });
     }
@@ -1117,19 +1194,24 @@ fn build_users_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             },
             2,
         ),
-        // Users are shown as read-only summary (no user management popup in slint yet)
         ci(
             "users",
             "User accounts",
             &match &c.users {
                 Some(users) if !users.is_empty() => users
                     .iter()
-                    .map(|u| u.username.as_str())
+                    .map(|u| {
+                        if u.sudo {
+                            format!("{} [sudo]", u.username)
+                        } else {
+                            u.username.clone()
+                        }
+                    })
                     .collect::<Vec<_>>()
                     .join(", "),
                 _ => "None".into(),
             },
-            0, // text input for now
+            0,
         ),
     ]
 }
@@ -1413,6 +1495,10 @@ fn handle_item_activated(
                 true,
             );
         }
+        // User management popup
+        "users" => {
+            show_users_popup(app, config);
+        }
         // Text input popups
         "pool_name"
         | "dataset_prefix"
@@ -1421,8 +1507,7 @@ fn handle_item_activated(
         | "additional_packages"
         | "aur_packages"
         | "extra_services"
-        | "swap_partition_size"
-        | "users" => {
+        | "swap_partition_size" => {
             let current = match key {
                 "pool_name" => config.pool_name.clone().unwrap_or_default(),
                 "dataset_prefix" => config.dataset_prefix.clone(),
@@ -1432,16 +1517,6 @@ fn handle_item_activated(
                 "aur_packages" => config.aur_packages.join(" "),
                 "extra_services" => config.extra_services.join(" "),
                 "swap_partition_size" => config.swap_partition_size.clone().unwrap_or_default(),
-                "users" => config
-                    .users
-                    .as_ref()
-                    .map(|u| {
-                        u.iter()
-                            .map(|u| u.username.as_str())
-                            .collect::<Vec<_>>()
-                            .join(" ")
-                    })
-                    .unwrap_or_default(),
                 _ => String::new(),
             };
             show_text_input(app, key, key, &current, false);
@@ -1486,6 +1561,21 @@ fn show_text_input(app: &App, key: &str, title: &str, current: &str, password: b
     app.set_text_input_password(password);
     app.set_password_strength_score(-1);
     app.set_text_input_visible(true);
+}
+
+fn show_users_popup(app: &App, config: &GlobalConfig) {
+    let entries: Vec<UserEntry> = config
+        .users
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|u| UserEntry {
+            username: SharedString::from(&u.username),
+            has_sudo: u.sudo,
+        })
+        .collect();
+    app.set_users_list(ModelRc::new(VecModel::from(entries)));
+    app.set_users_visible(true);
 }
 
 /// Find the next selectable item index, skipping separators (4), readonly (6), warnings (7).

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -298,9 +298,18 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
             }
 
             if key == "locale_select" {
-                let locales = archinstall_zfs_core::installer::locale::list_locales();
-                if let Some(loc) = locales.get(idx as usize) {
-                    cfg.borrow_mut().locale = Some(loc.clone());
+                let selected_text = app.get_select_options().row_data(idx as usize);
+                if let Some(opt) = selected_text {
+                    cfg.borrow_mut().locale = Some(opt.text.to_string());
+                    refresh_ui(&app, &cfg.borrow(), &wiz.borrow());
+                }
+                return;
+            }
+
+            if key == "keyboard_select" {
+                let selected_text = app.get_select_options().row_data(idx as usize);
+                if let Some(opt) = selected_text {
+                    cfg.borrow_mut().keyboard_layout = opt.text.to_string();
                     refresh_ui(&app, &cfg.borrow(), &wiz.borrow());
                 }
                 return;
@@ -744,10 +753,45 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
                         })
                         .collect()
                 } else {
-                    all_locales
+                    let mut scored: Vec<_> = all_locales
                         .iter()
-                        .filter(|s| s.to_lowercase().contains(&filter))
+                        .filter_map(|s| {
+                            sublime_fuzzy::best_match(&filter, s)
+                                .map(|m| (m.score(), s))
+                        })
+                        .collect();
+                    scored.sort_by(|a, b| b.0.cmp(&a.0));
+                    scored
+                        .into_iter()
+                        .map(|(_, s)| SelectOption {
+                            text: SharedString::from(s.as_str()),
+                        })
+                        .collect()
+                };
+                app.set_select_options(ModelRc::new(VecModel::from(filtered)));
+                app.set_select_index(-1);
+            }
+
+            if key == "keyboard_select" {
+                let all_keymaps = archinstall_zfs_core::installer::locale::list_keymaps();
+                let filtered: Vec<SelectOption> = if filter.is_empty() {
+                    all_keymaps
+                        .iter()
                         .map(|s| SelectOption {
+                            text: SharedString::from(s.as_str()),
+                        })
+                        .collect()
+                } else {
+                    let mut scored: Vec<_> = all_keymaps
+                        .iter()
+                        .filter_map(|s| {
+                            sublime_fuzzy::best_match(&filter, s).map(|m| (m.score(), s))
+                        })
+                        .collect();
+                    scored.sort_by(|a, b| b.0.cmp(&a.0));
+                    scored
+                        .into_iter()
+                        .map(|(_, s)| SelectOption {
                             text: SharedString::from(s.as_str()),
                         })
                         .collect()
@@ -1161,7 +1205,7 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             &c.timezone.clone().unwrap_or("Not set".into()),
             1,
         ),
-        ci("keyboard", "Keyboard layout", &c.keyboard_layout, 0),
+        ci("keyboard", "Keyboard layout", &c.keyboard_layout, 1),
         ci(
             "ntp",
             "NTP (time sync)",
@@ -1170,13 +1214,11 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         ),
     ];
 
-    let dl_options: Vec<String> = (1..=10).map(|n| n.to_string()).collect();
-    let dl_refs: Vec<&str> = dl_options.iter().map(|s| s.as_str()).collect();
-    items.extend(radio_group(
+    items.push(ci(
         "parallel_downloads",
         "Parallel downloads",
-        &dl_refs,
-        (c.parallel_downloads as i32) - 1,
+        &c.parallel_downloads.to_string(),
+        0,
     ));
 
     items
@@ -1499,24 +1541,42 @@ fn handle_item_activated(
         "users" => {
             show_users_popup(app, config);
         }
+        // Keyboard layout (filterable select)
+        "keyboard" => {
+            let keymaps = archinstall_zfs_core::installer::locale::list_keymaps();
+            let keymap_strs: Vec<&str> = keymaps.iter().map(|s| s.as_str()).collect();
+            let current_idx = keymaps
+                .iter()
+                .position(|k| k == &config.keyboard_layout)
+                .map(|i| i as i32)
+                .unwrap_or(0);
+            show_select_with_filter(
+                app,
+                "keyboard_select",
+                "Keyboard layout (type to filter)",
+                &keymap_strs,
+                current_idx,
+                true,
+            );
+        }
         // Text input popups
         "pool_name"
         | "dataset_prefix"
         | "hostname"
-        | "keyboard"
         | "additional_packages"
         | "aur_packages"
         | "extra_services"
-        | "swap_partition_size" => {
+        | "swap_partition_size"
+        | "parallel_downloads" => {
             let current = match key {
                 "pool_name" => config.pool_name.clone().unwrap_or_default(),
                 "dataset_prefix" => config.dataset_prefix.clone(),
                 "hostname" => config.hostname.clone().unwrap_or_default(),
-                "keyboard" => config.keyboard_layout.clone(),
                 "additional_packages" => config.additional_packages.join(" "),
                 "aur_packages" => config.aur_packages.join(" "),
                 "extra_services" => config.extra_services.join(" "),
                 "swap_partition_size" => config.swap_partition_size.clone().unwrap_or_default(),
+                "parallel_downloads" => config.parallel_downloads.to_string(),
                 _ => String::new(),
             };
             show_text_input(app, key, key, &current, false);
@@ -1702,9 +1762,6 @@ fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
                 _ => Some(AudioServer::Pulseaudio),
             }
         }
-        "parallel_downloads" => {
-            config.parallel_downloads = (idx + 1) as u32;
-        }
         _ => {}
     }
 }
@@ -1725,14 +1782,14 @@ fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {
         "hostname" => config.hostname = opt,
         "locale" => config.locale = opt,
         "timezone" => config.timezone = opt,
-        "keyboard" => {
-            if !val.is_empty() {
-                config.keyboard_layout = val.to_string();
-            }
-        }
         "root_password" => config.root_password = opt,
         "encryption_password" => config.zfs_encryption_password = opt,
         "swap_partition_size" => config.swap_partition_size = opt,
+        "parallel_downloads" => {
+            if let Ok(n) = val.parse::<u32>() {
+                config.parallel_downloads = n.clamp(1, 20);
+            }
+        }
         "additional_packages" => {
             config.additional_packages = val
                 .split_whitespace()

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -818,13 +818,26 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
                 let theme = app.global::<Theme>().get_c();
                 let (label, color) = match score {
                     0 => ("Very weak", theme.red),
-                    1 => ("Weak", theme.red),
+                    1 => ("Weak", theme.peach),
                     2 => ("Fair", theme.yellow),
                     3 => ("Strong", theme.green),
                     _ => ("Very strong", theme.teal),
                 };
+
+                let hint = entropy
+                    .feedback()
+                    .and_then(|f| f.suggestions().first().map(|s| s.to_string()))
+                    .unwrap_or_else(|| {
+                        let crack_time = entropy
+                            .crack_times()
+                            .online_no_throttling_10_per_second()
+                            .to_string();
+                        format!("~{crack_time} to crack")
+                    });
+
                 app.set_password_strength_score(score as i32);
                 app.set_password_strength_label(SharedString::from(label));
+                app.set_password_strength_hint(SharedString::from(hint));
                 app.set_password_strength_color(color);
             }
         });
@@ -1620,6 +1633,7 @@ fn show_text_input(app: &App, key: &str, title: &str, current: &str, password: b
     app.set_text_input_value(current.into());
     app.set_text_input_password(password);
     app.set_password_strength_score(-1);
+    app.set_password_strength_hint(SharedString::default());
     app.set_text_input_visible(true);
 }
 

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -85,6 +85,7 @@ component TextInputPopup inherits Rectangle {
     // Password strength (set from Rust)
     in property <int> strength-score: -1; // -1=hidden, 0..4=zxcvbn score
     in property <string> strength-label;
+    in property <string> strength-hint; // crack time or suggestion
     in property <color> strength-color: Theme.c.overlay0;
 
     callback confirmed(string);
@@ -101,7 +102,7 @@ component TextInputPopup inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: min(500px, parent.width - 40px);
-            height: is-password ? 190px : 140px;
+            height: self.preferred-height;
             background: Theme.c.mantle;
             border-radius: 8px;
             border-color: Theme.c.surface1;
@@ -178,11 +179,22 @@ component TextInputPopup inherits Rectangle {
                         }
                     }
 
-                    Text {
-                        text: strength-label;
-                        color: strength-color;
-                        font-size: 12px;
-                        horizontal-alignment: center;
+                    HorizontalLayout {
+                        alignment: center;
+                        spacing: 12px;
+
+                        Text {
+                            text: strength-label;
+                            color: strength-color;
+                            font-size: 12px;
+                            font-weight: FontWeight.semi-bold;
+                        }
+
+                        if strength-hint != "": Text {
+                            text: strength-hint;
+                            color: Theme.c.overlay0;
+                            font-size: 12px;
+                        }
                     }
                 }
 
@@ -775,6 +787,7 @@ export component App inherits Window {
     // Password strength (driven from Rust)
     in-out property <int> password-strength-score: -1;
     in-out property <string> password-strength-label;
+    in-out property <string> password-strength-hint;
     in-out property <color> password-strength-color: Theme.c.overlay0;
 
     // User management popup state
@@ -1418,6 +1431,26 @@ export component App inherits Window {
                         spacing: 8px;
                         alignment: center;
 
+                        // Quit button
+                        Rectangle {
+                            width: 60px;
+                            height: 32px;
+                            background: quit-nav-ta.has-hover ? Theme.c.surface1 : transparent;
+                            border-radius: 4px;
+
+                            quit-nav-ta := TouchArea {
+                                clicked => { quit-requested(); }
+                            }
+
+                            Text {
+                                text: "Quit";
+                                color: Theme.c.overlay0;
+                                font-size: 13px;
+                                horizontal-alignment: center;
+                                vertical-alignment: center;
+                            }
+                        }
+
                         // Back button (not on first wizard step)
                         if current-step > 1: Rectangle {
                             width: 80px;
@@ -1684,6 +1717,7 @@ export component App inherits Window {
         popup-visible: text-input-visible;
         strength-score: password-strength-score;
         strength-label: password-strength-label;
+        strength-hint: password-strength-hint;
         strength-color: password-strength-color;
 
         confirmed(val) => {

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -53,6 +53,11 @@ export struct SelectOption {
     text: string,
 }
 
+export struct UserEntry {
+    username: string,
+    has-sudo: bool,
+}
+
 export struct LogMessage {
     text: string,
     level: int,
@@ -353,6 +358,318 @@ component SelectPopup inherits Rectangle {
     }
 }
 
+// ── User management popup ────────────────────────────
+
+component UserManagePopup inherits Rectangle {
+    in property <[UserEntry]> users;
+    in property <bool> popup-visible;
+
+    callback user-added(string, string, bool); // username, password, sudo
+    callback user-removed(int);
+    callback user-sudo-toggled(int);
+    callback closed();
+
+    if popup-visible: Rectangle {
+        background: #00000080;
+        width: 100%; height: 100%;
+
+        TouchArea { clicked => { closed(); } }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: min(520px, parent.width - 40px);
+            height: min(parent.height - 80px, 480px);
+            background: Theme.c.mantle;
+            border-radius: 8px;
+            border-color: Theme.c.surface1;
+            border-width: 1px;
+            clip: true;
+            accessible-role: groupbox;
+            accessible-label: "User accounts";
+
+            VerticalLayout {
+                padding: 16px;
+                spacing: 12px;
+
+                Text {
+                    text: "User accounts";
+                    color: Theme.c.blue;
+                    font-size: 16px;
+                    font-weight: FontWeight.semi-bold;
+                    height: 24px;
+                }
+
+                // ── Existing users list ──
+                ListView {
+                    vertical-stretch: 1;
+
+                    for user[index] in users: Rectangle {
+                        height: 40px;
+                        background: user-row-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
+                        border-radius: 4px;
+
+                        user-row-ta := TouchArea {
+                            clicked => { user-sudo-toggled(index); }
+                        }
+
+                        HorizontalLayout {
+                            padding-left: 12px;
+                            padding-right: 8px;
+                            spacing: 8px;
+                            alignment: space-between;
+
+                            HorizontalLayout {
+                                spacing: 8px;
+                                alignment: start;
+
+                                Text {
+                                    text: user.username;
+                                    color: Theme.c.text;
+                                    font-size: 14px;
+                                    vertical-alignment: center;
+                                }
+
+                                if user.has-sudo: Rectangle {
+                                    width: sudo-text.preferred-width + 12px;
+                                    height: 20px;
+                                    background: Theme.c.blue;
+                                    border-radius: 3px;
+
+                                    sudo-text := Text {
+                                        text: "sudo";
+                                        color: Theme.c.base;
+                                        font-size: 11px;
+                                        font-weight: FontWeight.semi-bold;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
+                                }
+
+                                if !user.has-sudo: Text {
+                                    text: "(click to toggle sudo)";
+                                    color: Theme.c.overlay0;
+                                    font-size: 12px;
+                                }
+                            }
+
+                            Rectangle {
+                                width: 28px;
+                                height: 28px;
+                                background: del-ta.has-hover ? Theme.c.red : transparent;
+                                border-radius: 4px;
+
+                                del-ta := TouchArea {
+                                    clicked => { user-removed(index); }
+                                }
+
+                                Text {
+                                    text: "\u{2715}"; // ✕
+                                    color: del-ta.has-hover ? Theme.c.base : Theme.c.overlay0;
+                                    font-size: 14px;
+                                    horizontal-alignment: center;
+                                    vertical-alignment: center;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // ── Add user form ──
+                Rectangle {
+                    height: 1px;
+                    background: Theme.c.surface1;
+                }
+
+                Text {
+                    text: "Add user";
+                    color: Theme.c.subtext0;
+                    font-size: 13px;
+                    font-weight: FontWeight.semi-bold;
+                    height: 20px;
+                }
+
+                HorizontalLayout {
+                    spacing: 8px;
+
+                    // Username
+                    Rectangle {
+                        horizontal-stretch: 1;
+                        height: 34px;
+                        background: Theme.c.surface0;
+                        border-radius: 4px;
+                        border-color: username-input.has-focus ? Theme.c.blue : Theme.c.surface1;
+                        border-width: 1px;
+                        clip: true;
+
+                        username-input := TextInput {
+                            width: max(parent.width - 16px, self.preferred-width);
+                            x: 8px;
+                            vertical-alignment: center;
+                            color: Theme.c.text;
+                            font-size: 13px;
+
+                            private property <length> margin: 8px;
+                            cursor-position-changed(cursor-position) => {
+                                if cursor-position.x + self.x < margin {
+                                    self.x = - cursor-position.x + margin;
+                                } else if cursor-position.x + self.x > parent.width - margin - self.text-cursor-width {
+                                    self.x = parent.width - cursor-position.x - margin - self.text-cursor-width;
+                                }
+                            }
+                        }
+
+                        // Placeholder
+                        if username-input.text == "": Text {
+                            x: 8px;
+                            text: "username";
+                            color: Theme.c.overlay0;
+                            font-size: 13px;
+                            vertical-alignment: center;
+                        }
+                    }
+
+                    // Password
+                    Rectangle {
+                        horizontal-stretch: 1;
+                        height: 34px;
+                        background: Theme.c.surface0;
+                        border-radius: 4px;
+                        border-color: password-input.has-focus ? Theme.c.blue : Theme.c.surface1;
+                        border-width: 1px;
+                        clip: true;
+
+                        password-input := TextInput {
+                            width: max(parent.width - 16px, self.preferred-width);
+                            x: 8px;
+                            vertical-alignment: center;
+                            color: Theme.c.text;
+                            font-size: 13px;
+                            input-type: InputType.password;
+
+                            private property <length> margin: 8px;
+                            cursor-position-changed(cursor-position) => {
+                                if cursor-position.x + self.x < margin {
+                                    self.x = - cursor-position.x + margin;
+                                } else if cursor-position.x + self.x > parent.width - margin - self.text-cursor-width {
+                                    self.x = parent.width - cursor-position.x - margin - self.text-cursor-width;
+                                }
+                            }
+                        }
+
+                        // Placeholder
+                        if password-input.text == "": Text {
+                            x: 8px;
+                            text: "password (optional)";
+                            color: Theme.c.overlay0;
+                            font-size: 13px;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+
+                HorizontalLayout {
+                    spacing: 8px;
+                    alignment: end;
+
+                    // Sudo toggle
+                    sudo-toggle := Rectangle {
+                        height: 30px;
+                        width: sudo-check-text.preferred-width + 36px;
+                        background: sudo-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
+                        border-radius: 4px;
+
+                        property <bool> sudo-checked: true;
+
+                        sudo-ta := TouchArea {
+                            clicked => { parent.sudo-checked = !parent.sudo-checked; }
+                        }
+
+                        HorizontalLayout {
+                            padding-left: 10px;
+                            padding-right: 10px;
+                            spacing: 6px;
+                            alignment: center;
+
+                            Text {
+                                text: sudo-toggle.sudo-checked ? "\u{25cf}" : "\u{25cb}";
+                                color: sudo-toggle.sudo-checked ? Theme.c.green : Theme.c.overlay0;
+                                font-size: 14px;
+                                vertical-alignment: center;
+                            }
+
+                            sudo-check-text := Text {
+                                text: "sudo";
+                                color: Theme.c.subtext0;
+                                font-size: 13px;
+                                vertical-alignment: center;
+                            }
+                        }
+                    }
+
+                    // Add button
+                    Rectangle {
+                        width: 80px;
+                        height: 30px;
+                        background: add-ta.has-hover ? Theme.c.sky : Theme.c.blue;
+                        border-radius: 4px;
+                        accessible-role: button;
+                        accessible-label: "Add";
+
+                        add-ta := TouchArea {
+                            clicked => {
+                                if username-input.text != "" {
+                                    user-added(username-input.text, password-input.text, sudo-toggle.sudo-checked);
+                                    sudo-toggle.sudo-checked = true;
+                                    username-input.text = "";
+                                    password-input.text = "";
+                                    username-input.focus();
+                                }
+                            }
+                        }
+
+                        Text {
+                            text: "Add";
+                            color: Theme.c.base;
+                            font-size: 13px;
+                            font-weight: FontWeight.semi-bold;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+
+                // ── Done button ──
+                HorizontalLayout {
+                    alignment: end;
+
+                    Rectangle {
+                        width: 80px;
+                        height: 30px;
+                        background: done-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
+                        border-radius: 4px;
+                        accessible-role: button;
+                        accessible-label: "Done";
+
+                        done-ta := TouchArea {
+                            clicked => { closed(); }
+                        }
+
+                        Text {
+                            text: "Done";
+                            color: Theme.c.subtext0;
+                            font-size: 13px;
+                            font-weight: FontWeight.semi-bold;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // ── Sidebar step item ────────────────────────────────
 
 component SidebarItem inherits Rectangle {
@@ -460,6 +777,10 @@ export component App inherits Window {
     in-out property <string> password-strength-label;
     in-out property <color> password-strength-color: Theme.c.overlay0;
 
+    // User management popup state
+    in-out property <bool> users-visible: false;
+    in property <[UserEntry]> users-list;
+
     // Install state: 0=config, 1=installing, 2=done, 3=failed
     in-out property <int> install-state: 0;
 
@@ -493,6 +814,9 @@ export component App inherits Window {
     callback install-requested();
     callback quit-requested();
     callback step-clicked(int);
+    callback user-added(string, string, bool); // username, password, sudo
+    callback user-removed(int);
+    callback user-sudo-toggled(int);
     callback next-step();
     callback prev-step();
     callback key-nav-down();
@@ -501,7 +825,7 @@ export component App inherits Window {
 
     // ── Keyboard navigation ─────────────────────────
     main-focus-scope := FocusScope {
-        enabled: install-state == 0 && !select-visible && !text-input-visible;
+        enabled: install-state == 0 && !select-visible && !text-input-visible && !users-visible;
         key-pressed(e) => {
             if e.text == Key.DownArrow || e.text == "j" {
                 key-nav-down();
@@ -1371,6 +1695,24 @@ export component App inherits Window {
         }
         text-edited(val) => {
             text-input-edited(text-input-key, val);
+        }
+    }
+
+    UserManagePopup {
+        users: users-list;
+        popup-visible: users-visible;
+
+        user-added(username, password, sudo) => {
+            root.user-added(username, password, sudo);
+        }
+        user-removed(index) => {
+            root.user-removed(index);
+        }
+        user-sudo-toggled(index) => {
+            root.user-sudo-toggled(index);
+        }
+        closed() => {
+            users-visible = false;
         }
     }
 }

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -14,6 +14,7 @@ ratatui = "0.30.0"
 ratatui-macros = "0.7.0"
 ratatui-themes = "0.2.0"
 ratatui-widgets = "0.3.0"
+sublime_fuzzy = "0.7.0"
 tokio = { version = "1.51.0", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7.18", features = ["rt"] }
 tracing = "0.1.44"

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -471,6 +471,13 @@ pub fn manage_users(
             if let Some(username) = result.value
                 && !username.is_empty()
             {
+                if !archinstall_zfs_core::config::validation::is_valid_username(&username) {
+                    continue;
+                }
+                if users.iter().any(|u| u.username == username) {
+                    continue;
+                }
+
                 let pw_result = run_edit(terminal, "Password (empty=no password)", "", true)?;
                 let password = pw_result.value.filter(|p| !p.is_empty());
 

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -9,7 +9,7 @@ use archinstall_zfs_core::config::types::{
 use archinstall_zfs_core::system::gpu::{GfxDriver, detect_gpus, suggested_driver};
 
 use super::edit::run_edit;
-use super::select::{run_multiselect, run_select};
+use super::select::{run_multiselect, run_select, run_select_fuzzy};
 
 // ── Pickers ─────────────────────────────────────────
 
@@ -34,14 +34,32 @@ pub fn pick_timezone(terminal: &mut ratatui::DefaultTerminal) -> Result<Option<S
     Ok(Some(format!("{region}/{}", cities[city_idx])))
 }
 
-pub fn pick_locale(terminal: &mut ratatui::DefaultTerminal) -> Result<Option<String>> {
+pub fn pick_locale(
+    terminal: &mut ratatui::DefaultTerminal,
+    current: &str,
+) -> Result<Option<String>> {
     use archinstall_zfs_core::installer::locale;
 
     let locales = locale::list_locales();
     let locale_strs: Vec<&str> = locales.iter().map(|s| s.as_str()).collect();
-    let result = run_select(terminal, "Locale", &locale_strs, 0)?;
+    let result = run_select_fuzzy(terminal, "Locale", &locale_strs, current)?;
     match result.selected {
         Some(idx) => Ok(Some(locales[idx].clone())),
+        None => Ok(None),
+    }
+}
+
+pub fn pick_keyboard(
+    terminal: &mut ratatui::DefaultTerminal,
+    current: &str,
+) -> Result<Option<String>> {
+    use archinstall_zfs_core::installer::locale;
+
+    let keymaps = locale::list_keymaps();
+    let keymap_strs: Vec<&str> = keymaps.iter().map(|s| s.as_str()).collect();
+    let result = run_select_fuzzy(terminal, "Keyboard layout", &keymap_strs, current)?;
+    match result.selected {
+        Some(idx) => Ok(Some(keymaps[idx].clone())),
         None => Ok(None),
     }
 }
@@ -421,20 +439,6 @@ pub fn pick_seat_access(terminal: &mut ratatui::DefaultTerminal) -> Result<Optio
     }
 }
 
-pub fn pick_parallel_downloads(
-    config: &GlobalConfig,
-    terminal: &mut ratatui::DefaultTerminal,
-) -> Result<Option<u32>> {
-    let options: Vec<String> = (1..=10).map(|n| n.to_string()).collect();
-    let opt_refs: Vec<&str> = options.iter().map(|s| s.as_str()).collect();
-    let current = (config.parallel_downloads as usize).saturating_sub(1);
-    let result = run_select(terminal, "Parallel downloads", &opt_refs, current)?;
-    match result.selected {
-        Some(idx) => Ok(Some((idx + 1) as u32)),
-        None => Ok(None),
-    }
-}
-
 pub fn manage_users(
     config: &mut GlobalConfig,
     terminal: &mut ratatui::DefaultTerminal,
@@ -640,15 +644,14 @@ pub fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {
         "hostname" => config.hostname = val_opt,
         "locale" => config.locale = val_opt,
         "timezone" => config.timezone = val_opt,
-        "keyboard" => {
-            if !val.is_empty() {
-                config.keyboard_layout = val.to_string();
-            }
-        }
-        "x11_variant" => config.x11_variant = val_opt,
         "root_password" => config.root_password = val_opt,
         "encryption_password" => config.zfs_encryption_password = val_opt,
         "swap_partition_size" => config.swap_partition_size = val_opt,
+        "parallel_downloads" => {
+            if let Ok(n) = val.parse::<u32>() {
+                config.parallel_downloads = n.clamp(1, 20);
+            }
+        }
         "additional_packages" => {
             config.additional_packages = val
                 .split_whitespace()

--- a/tui/src/tui/screens/select.rs
+++ b/tui/src/tui/screens/select.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{Event, KeyCode, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Modifier, Style};
@@ -251,6 +251,176 @@ fn render_select(frame: &mut Frame, title: &str, items: &[&str], state: &mut Lis
     frame.render_stateful_widget(list, popup, state);
 
     // Footer
+    let footer_area = Rect::new(popup.x, popup.y + popup.height, popup.width, 1);
+    if footer_area.y < area.height {
+        let footer = Paragraph::new(Line::from(vec![
+            Span::styled(" Enter", theme::ACCENT_STYLE),
+            Span::styled(" select  ", theme::DIMMED_STYLE),
+            Span::styled("Esc", theme::ACCENT_STYLE),
+            Span::styled(" cancel ", theme::DIMMED_STYLE),
+        ]))
+        .alignment(Alignment::Center);
+        frame.render_widget(footer, footer_area);
+    }
+}
+
+/// Show a modal select with a fuzzy filter input. Returns the selected item's original index.
+pub fn run_select_fuzzy(
+    terminal: &mut ratatui::DefaultTerminal,
+    title: &str,
+    items: &[&str],
+    initial: &str,
+) -> color_eyre::eyre::Result<SelectResult> {
+    let mut filter = String::new();
+    let mut filtered: Vec<&str> = items.to_vec();
+    let initial_idx = items.iter().position(|s| *s == initial).unwrap_or(0);
+    let mut state = ListState::default().with_selected(Some(initial_idx));
+
+    loop {
+        terminal.draw(|frame| {
+            render_select_fuzzy(frame, title, &filtered, &mut state, &filter);
+        })?;
+
+        if crossterm::event::poll(std::time::Duration::from_millis(50))? {
+            let ev = crossterm::event::read()?;
+            if let Event::Key(key) = ev {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match (key.code, key.modifiers) {
+                    (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                        return Ok(SelectResult { selected: None });
+                    }
+                    (KeyCode::Enter, _) => {
+                        if let Some(sel) = state.selected()
+                            && let Some(text) = filtered.get(sel) {
+                                let orig_idx = items.iter().position(|s| s == text);
+                                return Ok(SelectResult {
+                                    selected: orig_idx,
+                                });
+                            }
+                        return Ok(SelectResult { selected: None });
+                    }
+                    (KeyCode::Up, _) => {
+                        let i = state.selected().unwrap_or(0);
+                        state.select(Some(if i == 0 {
+                            filtered.len().saturating_sub(1)
+                        } else {
+                            i - 1
+                        }));
+                    }
+                    (KeyCode::Down, _) => {
+                        let i = state.selected().unwrap_or(0);
+                        state.select(Some(if i >= filtered.len().saturating_sub(1) {
+                            0
+                        } else {
+                            i + 1
+                        }));
+                    }
+                    (KeyCode::Backspace, _) => {
+                        filter.pop();
+                        update_fuzzy_filter(items, &filter, &mut filtered, &mut state);
+                    }
+                    (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                        filter.push(c);
+                        update_fuzzy_filter(items, &filter, &mut filtered, &mut state);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn update_fuzzy_filter<'a>(
+    items: &[&'a str],
+    filter: &str,
+    filtered: &mut Vec<&'a str>,
+    state: &mut ListState,
+) {
+    if filter.is_empty() {
+        *filtered = items.to_vec();
+    } else {
+        let mut scored: Vec<_> = items
+            .iter()
+            .filter_map(|s| sublime_fuzzy::best_match(filter, s).map(|m| (m.score(), *s)))
+            .collect();
+        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        *filtered = scored.into_iter().map(|(_, s)| s).collect();
+    }
+    state.select(if filtered.is_empty() { None } else { Some(0) });
+}
+
+fn render_select_fuzzy(
+    frame: &mut Frame,
+    title: &str,
+    items: &[&str],
+    state: &mut ListState,
+    filter: &str,
+) {
+    let area = frame.area();
+    let bg = Paragraph::new("").style(Style::default().add_modifier(Modifier::DIM));
+    frame.render_widget(bg, area);
+
+    let content_width = items.iter().map(|s| s.len()).max().unwrap_or(20) + 8;
+    let title_width = title.len() + 4;
+    let popup_width = content_width.max(title_width).clamp(30, 70) as u16;
+    let popup_height = (items.len() as u16 + 6).min(area.height.saturating_sub(4));
+    let popup = super::centered_rect(popup_width, popup_height, area);
+
+    frame.render_widget(Clear, popup);
+
+    let chunks = ratatui::layout::Layout::default()
+        .direction(ratatui::layout::Direction::Vertical)
+        .constraints([
+            ratatui::layout::Constraint::Length(3),
+            ratatui::layout::Constraint::Min(1),
+        ])
+        .split(popup);
+
+    // Filter input
+    let filter_block = Block::default()
+        .title(format!(" {title} "))
+        .title_style(theme::HEADER_STYLE)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(theme::BORDER_STYLE)
+        .style(theme::BG_STYLE);
+    let filter_text = Paragraph::new(Line::from(vec![Span::styled(
+        if filter.is_empty() {
+            " type to filter...".to_string()
+        } else {
+            format!(" {filter}\u{258f}")
+        },
+        if filter.is_empty() {
+            theme::DIMMED_STYLE
+        } else {
+            theme::ACCENT_STYLE
+        },
+    )]))
+    .block(filter_block);
+    frame.render_widget(filter_text, chunks[0]);
+
+    // List
+    let list_block = Block::default()
+        .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+        .border_type(BorderType::Rounded)
+        .border_style(theme::BORDER_STYLE)
+        .style(theme::BG_STYLE);
+
+    let list_items: Vec<ListItem> = items
+        .iter()
+        .map(|s| ListItem::new(Line::from(format!("  {s}"))))
+        .collect();
+
+    let list = List::new(list_items)
+        .block(list_block)
+        .highlight_style(theme::SELECTED_STYLE)
+        .highlight_symbol(" \u{25b8} ")
+        .highlight_spacing(HighlightSpacing::Always);
+
+    frame.render_stateful_widget(list, chunks[1], state);
+
     let footer_area = Rect::new(popup.x, popup.y + popup.height, popup.width, 1);
     if footer_area.y < area.height {
         let footer = Paragraph::new(Line::from(vec![

--- a/tui/src/tui/screens/select.rs
+++ b/tui/src/tui/screens/select.rs
@@ -103,7 +103,9 @@ fn render_multiselect(
     let bg = Paragraph::new("").style(Style::default().add_modifier(Modifier::DIM));
     frame.render_widget(bg, area);
 
-    let popup_width = (items.iter().map(|s| s.len() + 8).max().unwrap_or(30) + 4).min(72) as u16;
+    let content_width = items.iter().map(|s| s.len() + 8).max().unwrap_or(30) + 4;
+    let title_width = title.len() + 4;
+    let popup_width = content_width.max(title_width).clamp(24, 72) as u16;
     let popup_height = (items.len() as u16 + 4).min(area.height.saturating_sub(4));
     let popup = super::centered_rect(popup_width, popup_height, area);
 
@@ -219,7 +221,9 @@ fn render_select(frame: &mut Frame, title: &str, items: &[&str], state: &mut Lis
     frame.render_widget(bg, area);
 
     // Center popup
-    let popup_width = (items.iter().map(|s| s.len()).max().unwrap_or(20) + 8).min(70) as u16;
+    let content_width = items.iter().map(|s| s.len()).max().unwrap_or(20) + 8;
+    let title_width = title.len() + 4;
+    let popup_width = content_width.max(title_width).clamp(24, 70) as u16;
     let popup_height = (items.len() as u16 + 4).min(area.height - 4);
     let popup = super::centered_rect(popup_width, popup_height, area);
 

--- a/tui/src/tui/screens/select.rs
+++ b/tui/src/tui/screens/select.rs
@@ -293,12 +293,11 @@ pub fn run_select_fuzzy(
                     }
                     (KeyCode::Enter, _) => {
                         if let Some(sel) = state.selected()
-                            && let Some(text) = filtered.get(sel) {
-                                let orig_idx = items.iter().position(|s| s == text);
-                                return Ok(SelectResult {
-                                    selected: orig_idx,
-                                });
-                            }
+                            && let Some(text) = filtered.get(sel)
+                        {
+                            let orig_idx = items.iter().position(|s| s == text);
+                            return Ok(SelectResult { selected: orig_idx });
+                        }
                         return Ok(SelectResult { selected: None });
                     }
                     (KeyCode::Up, _) => {

--- a/tui/src/tui/screens/steps/system.rs
+++ b/tui/src/tui/screens/steps/system.rs
@@ -36,13 +36,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             key: "keyboard",
             label: "Keyboard layout",
             value: config.keyboard_layout.clone(),
-            kind: MenuKind::Text,
-        },
-        MenuItem {
-            key: "x11_variant",
-            label: "X11 kb variant",
-            value: config.x11_variant.clone().unwrap_or("None".into()),
-            kind: MenuKind::Text,
+            kind: MenuKind::Custom,
         },
         MenuItem {
             key: "ntp",
@@ -63,7 +57,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         key: "parallel_downloads",
         label: "Parallel downloads",
         value: config.parallel_downloads.to_string(),
-        kind: MenuKind::Custom,
+        kind: MenuKind::Text,
     });
 
     items

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -228,8 +228,15 @@ impl Wizard {
                     }
                 }
                 "locale" => {
-                    if let Some(loc) = pickers::pick_locale(terminal)? {
+                    let current = self.config.locale.as_deref().unwrap_or("");
+                    if let Some(loc) = pickers::pick_locale(terminal, current)? {
                         self.config.locale = Some(loc);
+                    }
+                }
+                "keyboard" => {
+                    if let Some(km) = pickers::pick_keyboard(terminal, &self.config.keyboard_layout)?
+                    {
+                        self.config.keyboard_layout = km;
                     }
                 }
                 "disk_by_id" => {
@@ -281,11 +288,6 @@ impl Wizard {
                 }
                 "users" => {
                     pickers::manage_users(&mut self.config, terminal)?;
-                }
-                "parallel_downloads" => {
-                    if let Some(n) = pickers::pick_parallel_downloads(&self.config, terminal)? {
-                        self.config.parallel_downloads = n;
-                    }
                 }
                 "pool_name" => {
                     pickers::pick_existing_pool(&mut self.config, terminal)?;

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -234,7 +234,8 @@ impl Wizard {
                     }
                 }
                 "keyboard" => {
-                    if let Some(km) = pickers::pick_keyboard(terminal, &self.config.keyboard_layout)?
+                    if let Some(km) =
+                        pickers::pick_keyboard(terminal, &self.config.keyboard_layout)?
                     {
                         self.config.keyboard_layout = km;
                     }


### PR DESCRIPTION
Batch of UI improvements across both Slint GUI and ratatui TUI.

- Add user management popup to Slint GUI (add/remove users, toggle sudo, password, validation)
- Add username validation and duplicate prevention to both UIs
- Replace locale and keyboard layout pickers with fuzzy-searchable selects (sublime_fuzzy)
- Add list_keymaps() to core, keyboard is now a select instead of raw text input
- Change parallel downloads from 10-item radio/select to simple text input
- Remove x11_variant field (not present in archinstall, added by mistake)
- Fix TUI select popup clipping title when items are short
- Improve Slint password strength: show crack time/suggestion hint, adaptive popup height
- Add Quit button to Slint bottom nav bar
- Move ISO binaries to /usr/local/bin/ so they're in PATH on the live ISO
- Fix filtered select returning wrong item when filter was active (locale/keyboard)