### PR TITLE
Unified package search UI, workspace deps, sig download cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.11.0",
+ "sublime_fuzzy",
  "sysinfo",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,18 @@
 [workspace]
 members = ["core", "tui", "slint-ui", "xtask"]
 resolver = "3"
+
+[workspace.dependencies]
+clap = { version = "4.6.0", features = ["derive"] }
+color-eyre = "0.6.5"
+futures = "0.3.32"
+nix = { version = "0.31.2", features = ["fs"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+sublime_fuzzy = "0.7.0"
+tokio = { version = "1.51.0", features = ["rt", "rt-multi-thread", "macros"] }
+tokio-util = { version = "0.7.18", features = ["rt"] }
+tracing = "0.1.44"
+tracing-appender = "0.2.4"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+zxcvbn = "3.1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml_ng = "0.10.0"
 sha2 = "0.11.0"
+sublime_fuzzy = "0.7.0"
 sysinfo = "0.38.4"
 tar = "0.4.45"
 thiserror = "2.0.18"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,28 +9,28 @@ alpm-utils = "5"
 aur-depends = { version = "5.0.0", default-features = false }
 aur-fetch = "0.11.3"
 blockdev = "0.3.1"
-color-eyre = "0.6.5"
+color-eyre.workspace = true
 fs_extra = "1.3.0"
-futures = "0.3.32"
+futures.workspace = true
 hex = "0.4.3"
 lzma-rs = "0.3.0"
 minijinja = { version = "2.19.0", features = ["builtins"] }
-nix = { version = "0.31.2", features = ["fs", "mount", "process", "signal"] }
+nix = { workspace = true, features = ["fs", "mount", "process", "signal"] }
 pacmanconf = "3.1.0"
 raur = { version = "7", default-features = false, features = ["async", "reqwest"] }
 regex = "1.12.3"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 serde_yaml_ng = "0.10.0"
 sha2 = "0.11.0"
-sublime_fuzzy = "0.7.0"
+sublime_fuzzy.workspace = true
 sysinfo = "0.38.4"
 tar = "0.4.45"
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["rt", "rt-multi-thread", "macros", "io-util", "fs", "sync", "time"] }
-tokio-util = { version = "0.7.18", features = ["rt"] }
-tracing = "0.1.44"
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "io-util", "fs", "sync", "time"] }
+tokio-util.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/core/src/kernel/mod.rs
+++ b/core/src/kernel/mod.rs
@@ -80,7 +80,7 @@ pub async fn query_package_version(package: &str) -> Result<Option<String>> {
 }
 
 /// Initialize an alpm handle from the system pacman.conf.
-fn init_alpm() -> Result<alpm::Alpm> {
+pub(crate) fn init_alpm() -> Result<alpm::Alpm> {
     let pacman_conf = pacmanconf::Config::from_file("/etc/pacman.conf")
         .wrap_err("failed to parse pacman.conf")?;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod disk;
 pub mod installer;
 pub mod iso;
 pub mod kernel;
+pub mod packages;
 pub mod profile;
 pub mod swap;
 pub mod system;

--- a/core/src/packages.rs
+++ b/core/src/packages.rs
@@ -45,30 +45,19 @@ fn search_repo_sync(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         }
     }
 
-    // Sort: exact name match first, then starts-with, then contains
-    let query_lower = query.to_lowercase();
-    results.sort_by(|a, b| {
-        let a_name = a.name.to_lowercase();
-        let b_name = b.name.to_lowercase();
-        let a_score = if a_name == query_lower {
-            0
-        } else if a_name.starts_with(&query_lower) {
-            1
-        } else {
-            2
-        };
-        let b_score = if b_name == query_lower {
-            0
-        } else if b_name.starts_with(&query_lower) {
-            1
-        } else {
-            2
-        };
-        a_score.cmp(&b_score).then(a_name.cmp(&b_name))
-    });
+    // Sort by fuzzy match score against package name
+    let mut scored: Vec<_> = results
+        .into_iter()
+        .map(|pkg| {
+            let score = sublime_fuzzy::best_match(query, &pkg.name)
+                .map(|m| m.score())
+                .unwrap_or(0);
+            (score, pkg)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0));
 
-    results.truncate(limit);
-    Ok(results)
+    Ok(scored.into_iter().map(|(_, pkg)| pkg).take(limit).collect())
 }
 
 /// Search AUR packages via raur. Returns up to `limit` results sorted by popularity.
@@ -81,7 +70,7 @@ pub async fn search_aur(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         .await
         .map_err(|e| color_eyre::eyre::eyre!("AUR search failed: {e}"))?;
 
-    let mut packages: Vec<PackageInfo> = results
+    let packages: Vec<PackageInfo> = results
         .into_iter()
         .map(|pkg| PackageInfo {
             name: pkg.name,
@@ -91,7 +80,16 @@ pub async fn search_aur(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         })
         .collect();
 
-    // raur results are already sorted by relevance, but let's cap
-    packages.truncate(limit);
-    Ok(packages)
+    let mut scored: Vec<_> = packages
+        .into_iter()
+        .map(|pkg| {
+            let score = sublime_fuzzy::best_match(query, &pkg.name)
+                .map(|m| m.score())
+                .unwrap_or(0);
+            (score, pkg)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0));
+
+    Ok(scored.into_iter().map(|(_, pkg)| pkg).take(limit).collect())
 }

--- a/core/src/packages.rs
+++ b/core/src/packages.rs
@@ -1,0 +1,97 @@
+use color_eyre::eyre::Result;
+
+/// A package found by search.
+#[derive(Debug, Clone)]
+pub struct PackageInfo {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub repo: String, // e.g. "extra", "core", "aur"
+}
+
+/// Search official repo packages via alpm. Runs in a blocking task.
+/// Returns up to `limit` results sorted by relevance (name match first).
+pub async fn search_repo(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
+    let query = query.to_string();
+    tokio::task::spawn_blocking(move || search_repo_sync(&query, limit)).await?
+}
+
+fn search_repo_sync(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
+    let handle = crate::kernel::init_alpm()?;
+
+    let mut results = Vec::new();
+    let search_terms = [query];
+
+    for db in handle.syncdbs() {
+        if let Ok(pkgs) = db.search(search_terms.iter().copied()) {
+            let repo_name = std::str::from_utf8(db.name().as_bytes()).unwrap_or("?");
+            for pkg in pkgs {
+                let name = std::str::from_utf8(pkg.name().as_bytes())
+                    .unwrap_or("")
+                    .to_string();
+                let version = pkg.version().to_string();
+                let description = pkg
+                    .desc()
+                    .map(|d| std::str::from_utf8(d.as_bytes()).unwrap_or(""))
+                    .unwrap_or("")
+                    .to_string();
+                results.push(PackageInfo {
+                    name,
+                    version,
+                    description,
+                    repo: repo_name.to_string(),
+                });
+            }
+        }
+    }
+
+    // Sort: exact name match first, then starts-with, then contains
+    let query_lower = query.to_lowercase();
+    results.sort_by(|a, b| {
+        let a_name = a.name.to_lowercase();
+        let b_name = b.name.to_lowercase();
+        let a_score = if a_name == query_lower {
+            0
+        } else if a_name.starts_with(&query_lower) {
+            1
+        } else {
+            2
+        };
+        let b_score = if b_name == query_lower {
+            0
+        } else if b_name.starts_with(&query_lower) {
+            1
+        } else {
+            2
+        };
+        a_score.cmp(&b_score).then(a_name.cmp(&b_name))
+    });
+
+    results.truncate(limit);
+    Ok(results)
+}
+
+/// Search AUR packages via raur. Returns up to `limit` results sorted by popularity.
+pub async fn search_aur(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
+    use raur::Raur;
+
+    let handle = raur::Handle::new();
+    let results = handle
+        .search(query)
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!("AUR search failed: {e}"))?;
+
+    let mut packages: Vec<PackageInfo> = results
+        .into_iter()
+        .map(|pkg| PackageInfo {
+            name: pkg.name,
+            version: pkg.version,
+            description: pkg.description.unwrap_or_default(),
+            repo: "aur".to_string(),
+        })
+        .collect();
+
+    // raur results are already sorted by relevance, but let's cap
+    packages.truncate(limit);
+    Ok(packages)
+}

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -176,7 +176,6 @@ impl AlpmContext {
                     servers: db.servers().iter().map(|s| s.to_string()).collect(),
                     sha256: pkg.sha256sum().map(|s| s.to_string()),
                     size: pkg.size(),
-                    sig_required: db.siglevel().contains(SigLevel::PACKAGE),
                 })
             })
             .collect();
@@ -366,8 +365,10 @@ impl AlpmContext {
             match event.event() {
                 Event::TransactionStart => tracing::info!("transaction starting"),
                 Event::TransactionDone => tracing::info!("transaction complete"),
-                Event::PkgRetrieveStart(_) => tracing::info!("downloading packages..."),
-                Event::PkgRetrieveDone(_) => tracing::info!("all packages downloaded"),
+                Event::PkgRetrieveStart(_) => {
+                    tracing::info!("retrieving package signatures...")
+                }
+                Event::PkgRetrieveDone(_) => tracing::info!("package signatures verified"),
                 Event::IntegrityStart => tracing::info!("checking package integrity..."),
                 Event::IntegrityDone => tracing::info!("integrity check complete"),
                 Event::KeyringStart => tracing::info!("checking keyring..."),

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -337,6 +337,13 @@ impl AlpmContext {
                         total = p.total,
                     );
                 }
+                DownloadEvent::Init(_) => {
+                    tracing::info!(
+                        target: "pacman.download",
+                        file = filename,
+                        "alpm downloading file (not from cache)"
+                    );
+                }
                 DownloadEvent::Completed(c) => {
                     tracing::debug!(
                         target: "pacman.download",
@@ -366,8 +373,8 @@ impl AlpmContext {
             match event.event() {
                 Event::TransactionStart => tracing::info!("transaction starting"),
                 Event::TransactionDone => tracing::info!("transaction complete"),
-                Event::PkgRetrieveStart(_) => tracing::info!("downloading packages..."),
-                Event::PkgRetrieveDone(_) => tracing::info!("all packages downloaded"),
+                Event::PkgRetrieveStart(_) => tracing::info!("verifying cached packages..."),
+                Event::PkgRetrieveDone(_) => tracing::info!("package verification complete"),
                 Event::IntegrityStart => tracing::info!("checking package integrity..."),
                 Event::IntegrityDone => tracing::info!("integrity check complete"),
                 Event::KeyringStart => tracing::info!("checking keyring..."),

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -337,13 +337,6 @@ impl AlpmContext {
                         total = p.total,
                     );
                 }
-                DownloadEvent::Init(_) => {
-                    tracing::info!(
-                        target: "pacman.download",
-                        file = filename,
-                        "alpm downloading file (not from cache)"
-                    );
-                }
                 DownloadEvent::Completed(c) => {
                     tracing::debug!(
                         target: "pacman.download",
@@ -373,8 +366,8 @@ impl AlpmContext {
             match event.event() {
                 Event::TransactionStart => tracing::info!("transaction starting"),
                 Event::TransactionDone => tracing::info!("transaction complete"),
-                Event::PkgRetrieveStart(_) => tracing::info!("verifying cached packages..."),
-                Event::PkgRetrieveDone(_) => tracing::info!("package verification complete"),
+                Event::PkgRetrieveStart(_) => tracing::info!("downloading packages..."),
+                Event::PkgRetrieveDone(_) => tracing::info!("all packages downloaded"),
                 Event::IntegrityStart => tracing::info!("checking package integrity..."),
                 Event::IntegrityDone => tracing::info!("integrity check complete"),
                 Event::KeyringStart => tracing::info!("checking keyring..."),

--- a/core/src/system/async_download.rs
+++ b/core/src/system/async_download.rs
@@ -18,7 +18,6 @@ pub struct DownloadTask {
     pub servers: Vec<String>,
     pub sha256: Option<String>,
     pub size: i64,
-    pub sig_required: bool,
 }
 
 /// Configuration for the download manager.
@@ -357,13 +356,9 @@ async fn download_single(
     shared: &SharedProgress,
 ) -> Result<()> {
     let dest = cache_dir.join(&task.filename);
-    let dest_sig = cache_dir.join(format!("{}.sig", &task.filename));
 
     // Skip if already cached and valid
-    if dest.exists()
-        && verify_sha256_sync(&dest, task.sha256.as_deref())
-        && (!task.sig_required || dest_sig.exists())
-    {
+    if dest.exists() && verify_sha256_sync(&dest, task.sha256.as_deref()) {
         tracing::debug!(file = %task.filename, "already cached, skipping");
         shared.update_package(
             index,
@@ -416,21 +411,8 @@ async fn download_single(
             .await
             {
                 Ok(()) => {
-                    // Download signature if required
-                    if task.sig_required {
-                        let sig_url = format!("{}.sig", url);
-                        if let Err(e) =
-                            download_file_simple(client, &sig_url, &dest_sig, cancel).await
-                        {
-                            tracing::warn!(
-                                file = %task.filename,
-                                server,
-                                "failed to download signature: {e}"
-                            );
-                            last_error = Some(e);
-                            continue;
-                        }
-                    }
+                    // Signatures (.sig) are not downloaded here — libalpm
+                    // fetches and verifies them during trans_commit().
 
                     shared.update_package(
                         index,
@@ -639,36 +621,6 @@ async fn download_file_with_progress(
     tokio::fs::rename(&part_path, dest)
         .await
         .wrap_err_with(|| format!("failed to rename to {}", dest.display()))?;
-
-    Ok(())
-}
-
-/// Simple download without progress tracking (for .sig files).
-async fn download_file_simple(
-    client: &reqwest::Client,
-    url: &str,
-    dest: &Path,
-    cancel: &CancellationToken,
-) -> Result<()> {
-    let resp = client
-        .get(url)
-        .send()
-        .await
-        .wrap_err_with(|| format!("HTTP request failed: {url}"))?;
-
-    if !resp.status().is_success() {
-        bail!("HTTP {} for {url}", resp.status());
-    }
-
-    let bytes = tokio::select! {
-        biased;
-        _ = cancel.cancelled() => bail!("download cancelled"),
-        result = resp.bytes() => result.wrap_err("failed to read response body")?,
-    };
-
-    tokio::fs::write(dest, &bytes)
-        .await
-        .wrap_err_with(|| format!("failed to write {}", dest.display()))?;
 
     Ok(())
 }

--- a/slint-ui/Cargo.toml
+++ b/slint-ui/Cargo.toml
@@ -6,23 +6,23 @@ build = "build.rs"
 
 [dependencies]
 archinstall-zfs-core = { path = "../core" }
-clap = { version = "4.6.0", features = ["derive"] }
-color-eyre = "0.6.5"
+clap.workspace = true
+color-eyre.workspace = true
 crossbeam-channel = "0.5"
-nix = { version = "0.31.2", features = ["fs"] }
+nix.workspace = true
 slint = { git = "https://github.com/okhsunrog/slint.git", branch = "feat/renderer-skia-software-linuxkms", default-features = false, features = [
     "std",
     "compat-1-2",
     "backend-linuxkms-noseat",
     "renderer-skia-software",
 ] }
-sublime_fuzzy = "0.7.0"
-tokio = { version = "1.51.0", features = ["rt", "rt-multi-thread", "sync", "macros"] }
-tokio-util = { version = "0.7.18", features = ["rt"] }
-tracing = "0.1.44"
-tracing-appender = "0.2.4"
-tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-zxcvbn = "3.1.0"
+sublime_fuzzy.workspace = true
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros"] }
+tokio-util.workspace = true
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-subscriber.workspace = true
+zxcvbn.workspace = true
 
 [build-dependencies]
 slint-build = { git = "https://github.com/okhsunrog/slint.git", branch = "feat/renderer-skia-software-linuxkms" }

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -421,6 +421,126 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
         });
     }
 
+    // ── Package search ───────────────────────────────
+    {
+        let weak = app.as_weak();
+        let _cfg = config.clone();
+        let _wiz = wizard.clone();
+        app.on_pkg_search_changed(move |text| {
+            let Some(app) = weak.upgrade() else { return };
+            if text.is_empty() {
+                app.set_pkg_search_results(ModelRc::new(VecModel::from(
+                    Vec::<PackageSearchResult>::new(),
+                )));
+                app.set_pkg_status_text(SharedString::default());
+                return;
+            }
+            app.set_pkg_searching_aur(false);
+            let query = text.to_string();
+            let weak2 = app.as_weak();
+            // Repo search is blocking (alpm) — run async
+            tokio::spawn(async move {
+                let results = archinstall_zfs_core::packages::search_repo(&query, 20)
+                    .await
+                    .unwrap_or_default();
+                let items: Vec<PackageSearchResult> = results
+                    .into_iter()
+                    .map(|p| PackageSearchResult {
+                        name: SharedString::from(&p.name),
+                        description: SharedString::from(&p.description),
+                        repo: SharedString::from(&p.repo),
+                    })
+                    .collect();
+                let _ = weak2.upgrade_in_event_loop(move |app| {
+                    app.set_pkg_search_results(ModelRc::new(VecModel::from(items)));
+                    app.set_pkg_status_text(SharedString::default());
+                });
+            });
+        });
+    }
+    {
+        let weak = app.as_weak();
+        app.on_pkg_search_aur(move |text| {
+            let Some(app) = weak.upgrade() else { return };
+            if text.is_empty() {
+                return;
+            }
+            app.set_pkg_searching_aur(true);
+            app.set_pkg_status_text(SharedString::from("Searching AUR..."));
+            let query = text.to_string();
+            let weak2 = app.as_weak();
+            tokio::spawn(async move {
+                match archinstall_zfs_core::packages::search_aur(&query, 20).await {
+                    Ok(results) => {
+                        let items: Vec<PackageSearchResult> = results
+                            .into_iter()
+                            .map(|p| PackageSearchResult {
+                                name: SharedString::from(&p.name),
+                                description: SharedString::from(&p.description),
+                                repo: SharedString::from(&p.repo),
+                            })
+                            .collect();
+                        let _ = weak2.upgrade_in_event_loop(move |app| {
+                            app.set_pkg_search_results(ModelRc::new(VecModel::from(items)));
+                            app.set_pkg_status_text(SharedString::default());
+                        });
+                    }
+                    Err(e) => {
+                        let msg = format!("AUR error: {e}");
+                        let _ = weak2.upgrade_in_event_loop(move |app| {
+                            app.set_pkg_status_text(SharedString::from(&msg));
+                        });
+                    }
+                }
+            });
+        });
+    }
+    {
+        let weak = app.as_weak();
+        let cfg = config.clone();
+        let wiz = wizard.clone();
+        app.on_pkg_added(move |index| {
+            let Some(app) = weak.upgrade() else { return };
+            let result = app.get_pkg_search_results().row_data(index as usize);
+            if let Some(pkg) = result {
+                let name = pkg.name.to_string();
+                let mut c = cfg.borrow_mut();
+                // Check duplicates
+                if c.additional_packages.contains(&name) || c.aur_packages.contains(&name) {
+                    return;
+                }
+                if pkg.repo == "aur" {
+                    c.aur_packages.push(name);
+                } else {
+                    c.additional_packages.push(name);
+                }
+                refresh_pkg_selected(&app, &c);
+                refresh_ui(&app, &c, &wiz.borrow());
+            }
+        });
+    }
+    {
+        let weak = app.as_weak();
+        let cfg = config.clone();
+        let wiz = wizard.clone();
+        app.on_pkg_removed(move |index| {
+            let Some(app) = weak.upgrade() else { return };
+            let mut c = cfg.borrow_mut();
+            let idx = index as usize;
+            let repo_len = c.additional_packages.len();
+            if idx < repo_len {
+                c.additional_packages.remove(idx);
+            } else {
+                let aur_idx = idx - repo_len;
+                if aur_idx < c.aur_packages.len() {
+                    c.aur_packages.remove(aur_idx);
+                }
+            }
+            refresh_pkg_selected(&app, &c);
+            refresh_ui(&app, &c, &wiz.borrow());
+        });
+    }
+
     // ── Step navigation ──────────────────────────────
     {
         let weak = app.as_weak();
@@ -1307,22 +1427,18 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             3,
         ),
         ci(
-            "additional_packages",
-            "Additional packages",
-            &if c.additional_packages.is_empty() {
-                "None".to_string()
-            } else {
-                c.additional_packages.join(", ")
-            },
-            0,
-        ),
-        ci(
-            "aur_packages",
-            "AUR packages",
-            &if c.aur_packages.is_empty() {
-                "None".to_string()
-            } else {
-                c.aur_packages.join(", ")
+            "packages",
+            "Extra packages",
+            &{
+                let total = c.additional_packages.len() + c.aur_packages.len();
+                if total == 0 {
+                    "None".to_string()
+                } else {
+                    let mut parts: Vec<&str> =
+                        c.additional_packages.iter().map(|s| s.as_str()).collect();
+                    parts.extend(c.aur_packages.iter().map(|s| s.as_str()));
+                    parts.join(", ")
+                }
             },
             0,
         ),
@@ -1576,11 +1692,14 @@ fn handle_item_activated(
             );
         }
         // Text input popups
+        // Package search popup
+        "packages" => {
+            show_package_search(app, config);
+        }
+        // Text input popups
         "pool_name"
         | "dataset_prefix"
         | "hostname"
-        | "additional_packages"
-        | "aur_packages"
         | "extra_services"
         | "swap_partition_size"
         | "parallel_downloads" => {
@@ -1588,8 +1707,6 @@ fn handle_item_activated(
                 "pool_name" => config.pool_name.clone().unwrap_or_default(),
                 "dataset_prefix" => config.dataset_prefix.clone(),
                 "hostname" => config.hostname.clone().unwrap_or_default(),
-                "additional_packages" => config.additional_packages.join(" "),
-                "aur_packages" => config.aur_packages.join(" "),
                 "extra_services" => config.extra_services.join(" "),
                 "swap_partition_size" => config.swap_partition_size.clone().unwrap_or_default(),
                 "parallel_downloads" => config.parallel_downloads.to_string(),
@@ -1653,6 +1770,44 @@ fn show_users_popup(app: &App, config: &GlobalConfig) {
         .collect();
     app.set_users_list(ModelRc::new(VecModel::from(entries)));
     app.set_users_visible(true);
+}
+
+fn show_package_search(app: &App, config: &GlobalConfig) {
+    let selected: Vec<PackageEntry> = config
+        .additional_packages
+        .iter()
+        .map(|s| PackageEntry {
+            name: SharedString::from(s.as_str()),
+            repo: SharedString::from("repo"),
+        })
+        .chain(config.aur_packages.iter().map(|s| PackageEntry {
+            name: SharedString::from(s.as_str()),
+            repo: SharedString::from("aur"),
+        }))
+        .collect();
+    app.set_pkg_selected(ModelRc::new(VecModel::from(selected)));
+    app.set_pkg_search_results(ModelRc::new(VecModel::from(
+        Vec::<PackageSearchResult>::new(),
+    )));
+    app.set_pkg_searching_aur(false);
+    app.set_pkg_status_text(SharedString::default());
+    app.set_pkg_search_visible(true);
+}
+
+fn refresh_pkg_selected(app: &App, config: &GlobalConfig) {
+    let selected: Vec<PackageEntry> = config
+        .additional_packages
+        .iter()
+        .map(|s| PackageEntry {
+            name: SharedString::from(s.as_str()),
+            repo: SharedString::from("repo"),
+        })
+        .chain(config.aur_packages.iter().map(|s| PackageEntry {
+            name: SharedString::from(s.as_str()),
+            repo: SharedString::from("aur"),
+        }))
+        .collect();
+    app.set_pkg_selected(ModelRc::new(VecModel::from(selected)));
 }
 
 /// Find the next selectable item index, skipping separators (4), readonly (6), warnings (7).
@@ -1800,20 +1955,6 @@ fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {
             if let Ok(n) = val.parse::<u32>() {
                 config.parallel_downloads = n.clamp(1, 20);
             }
-        }
-        "additional_packages" => {
-            config.additional_packages = val
-                .split_whitespace()
-                .map(|s| s.trim_matches(',').to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-        }
-        "aur_packages" => {
-            config.aur_packages = val
-                .split_whitespace()
-                .map(|s| s.trim_matches(',').to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
         }
         "extra_services" => {
             config.extra_services = val

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -421,6 +421,57 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
         });
     }
 
+    // ── String list (extra_services etc.) ─────────────
+    {
+        let weak = app.as_weak();
+        let cfg = config.clone();
+        let wiz = wizard.clone();
+        app.on_strlist_added(move |key, val| {
+            let Some(app) = weak.upgrade() else { return };
+            let val = val.to_string();
+            if val.is_empty() {
+                return;
+            }
+            let mut c = cfg.borrow_mut();
+            if key.as_str() == "extra_services" && !c.extra_services.contains(&val) {
+                c.extra_services.push(val);
+            }
+            show_string_list(
+                &app,
+                &key,
+                &app.get_strlist_title(),
+                match key.as_str() {
+                    "extra_services" => &c.extra_services,
+                    _ => return,
+                },
+            );
+            refresh_ui(&app, &c, &wiz.borrow());
+        });
+    }
+    {
+        let weak = app.as_weak();
+        let cfg = config.clone();
+        let wiz = wizard.clone();
+        app.on_strlist_removed(move |key, index| {
+            let Some(app) = weak.upgrade() else { return };
+            let mut c = cfg.borrow_mut();
+            let idx = index as usize;
+            if key.as_str() == "extra_services" && idx < c.extra_services.len() {
+                c.extra_services.remove(idx);
+            }
+            show_string_list(
+                &app,
+                &key,
+                &app.get_strlist_title(),
+                match key.as_str() {
+                    "extra_services" => &c.extra_services,
+                    _ => return,
+                },
+            );
+            refresh_ui(&app, &c, &wiz.borrow());
+        });
+    }
+
     // ── Package search ───────────────────────────────
     {
         let weak = app.as_weak();
@@ -1703,26 +1754,36 @@ fn handle_item_activated(
         "packages" => {
             show_package_search(app, config);
         }
+        // String list popup
+        "extra_services" => {
+            show_string_list(app, key, "Extra systemd services", &config.extra_services);
+        }
         // Text input popups
         "pool_name"
         | "dataset_prefix"
         | "hostname"
-        | "extra_services"
         | "swap_partition_size"
         | "parallel_downloads" => {
-            let current = match key {
-                "pool_name" => config.pool_name.clone().unwrap_or_default(),
-                "dataset_prefix" => config.dataset_prefix.clone(),
-                "hostname" => config.hostname.clone().unwrap_or_default(),
-                "extra_services" => config.extra_services.join(" "),
-                "swap_partition_size" => config.swap_partition_size.clone().unwrap_or_default(),
-                "parallel_downloads" => config.parallel_downloads.to_string(),
-                _ => String::new(),
+            let (title, current) = match key {
+                "pool_name" => ("Pool name", config.pool_name.clone().unwrap_or_default()),
+                "dataset_prefix" => ("Dataset prefix", config.dataset_prefix.clone()),
+                "hostname" => ("Hostname", config.hostname.clone().unwrap_or_default()),
+                "swap_partition_size" => (
+                    "Swap partition size",
+                    config.swap_partition_size.clone().unwrap_or_default(),
+                ),
+                "parallel_downloads" => {
+                    ("Parallel downloads", config.parallel_downloads.to_string())
+                }
+                _ => ("", String::new()),
             };
-            show_text_input(app, key, key, &current, false);
+            show_text_input(app, key, title, &current, false);
         }
-        "root_password" | "encryption_password" => {
-            show_text_input(app, key, key, "", true);
+        "root_password" => {
+            show_text_input(app, key, "Root password", "", true);
+        }
+        "encryption_password" => {
+            show_text_input(app, key, "Encryption password", "", true);
         }
         _ => {}
     }
@@ -1777,6 +1838,19 @@ fn show_users_popup(app: &App, config: &GlobalConfig) {
         .collect();
     app.set_users_list(ModelRc::new(VecModel::from(entries)));
     app.set_users_visible(true);
+}
+
+fn show_string_list(app: &App, key: &str, title: &str, items: &[String]) {
+    let opts: Vec<SelectOption> = items
+        .iter()
+        .map(|s| SelectOption {
+            text: SharedString::from(s.as_str()),
+        })
+        .collect();
+    app.set_strlist_key(key.into());
+    app.set_strlist_title(title.into());
+    app.set_strlist_items(ModelRc::new(VecModel::from(opts)));
+    app.set_strlist_visible(true);
 }
 
 fn show_package_search(app: &App, config: &GlobalConfig) {
@@ -1962,13 +2036,6 @@ fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {
             if let Ok(n) = val.parse::<u32>() {
                 config.parallel_downloads = n.clamp(1, 20);
             }
-        }
-        "extra_services" => {
-            config.extra_services = val
-                .split_whitespace()
-                .map(|s| s.trim_matches(',').to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
         }
         _ => {}
     }

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -1395,18 +1395,12 @@ fn build_users_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 }
 
 fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
-    let profiles = archinstall_zfs_core::profile::all_profiles();
-    let mut profile_names: Vec<String> = vec!["None".to_string()];
-    profile_names.extend(profiles.iter().map(|p| p.name.to_string()));
-    let profile_refs: Vec<&str> = profile_names.iter().map(|s| s.as_str()).collect();
-    let profile_selected = c
-        .profile
-        .as_ref()
-        .and_then(|sel| profiles.iter().position(|p| p.name == *sel))
-        .map(|i| (i + 1) as i32) // +1 because "None" is at index 0
-        .unwrap_or(0);
-
-    let mut items = radio_group("profile", "Profile", &profile_refs, profile_selected);
+    let mut items = vec![ci(
+        "profile",
+        "Profile",
+        c.profile.as_deref().unwrap_or("None"),
+        1,
+    )];
 
     items.extend(radio_group(
         "audio",
@@ -1646,6 +1640,19 @@ fn handle_item_activated(
                 &opt_refs,
                 current_idx as i32,
             );
+        }
+        "profile" => {
+            let profiles = archinstall_zfs_core::profile::all_profiles();
+            let mut names: Vec<String> = vec!["None".to_string()];
+            names.extend(profiles.iter().map(|p| p.name.to_string()));
+            let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+            let current = config
+                .profile
+                .as_ref()
+                .and_then(|sel| profiles.iter().position(|p| p.name == *sel))
+                .map(|i| (i + 1) as i32)
+                .unwrap_or(0);
+            show_select(app, "profile", "Profile", &refs, current);
         }
         "timezone" => {
             let regions = archinstall_zfs_core::installer::locale::list_timezone_regions();

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -714,7 +714,7 @@ component StringListPopup inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: min(460px, parent.width - 40px);
-            height: min(self.preferred-height, parent.height - 80px);
+            height: min(360px, parent.height - 80px);
             background: Theme.c.mantle;
             border-radius: 8px;
             border-color: Theme.c.surface1;
@@ -736,10 +736,8 @@ component StringListPopup inherits Rectangle {
                 }
 
                 // Existing items
-                if items.length > 0: ListView {
+                ListView {
                     vertical-stretch: 1;
-                    min-height: 40px;
-                    max-height: 200px;
 
                     for item[index] in items: Rectangle {
                         height: 36px;

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -58,6 +58,17 @@ export struct UserEntry {
     has-sudo: bool,
 }
 
+export struct PackageEntry {
+    name: string,
+    repo: string,  // "extra", "core", "aur", etc.
+}
+
+export struct PackageSearchResult {
+    name: string,
+    description: string,
+    repo: string,
+}
+
 export struct LogMessage {
     text: string,
     level: int,
@@ -682,6 +693,272 @@ component UserManagePopup inherits Rectangle {
     }
 }
 
+// ── Package search popup ─────────────────────────────
+
+component PackageSearchPopup inherits Rectangle {
+    in property <[PackageSearchResult]> search-results;
+    in property <[PackageEntry]> selected-packages;
+    in property <bool> popup-visible;
+    in property <bool> searching-aur: false;
+    in property <string> status-text;
+
+    callback search-changed(string);  // fired on each keystroke
+    callback search-aur(string);      // fired on Tab
+    callback package-added(int);      // index in search-results
+    callback package-removed(int);    // index in selected-packages
+    callback closed();
+
+    if popup-visible: Rectangle {
+        background: #00000080;
+        width: 100%; height: 100%;
+
+        TouchArea { clicked => { closed(); } }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: min(600px, parent.width - 40px);
+            height: min(parent.height - 60px, 520px);
+            background: Theme.c.mantle;
+            border-radius: 8px;
+            border-color: Theme.c.surface1;
+            border-width: 1px;
+            clip: true;
+            accessible-role: groupbox;
+            accessible-label: "Package search";
+
+            FocusScope {
+                key-pressed(e) => {
+                    if e.text == Key.Tab {
+                        search-aur(pkg-search-input.text);
+                        return accept;
+                    }
+                    if e.text == Key.Escape {
+                        closed();
+                        return accept;
+                    }
+                    return reject;
+                }
+            }
+
+            VerticalLayout {
+                padding: 16px;
+                spacing: 10px;
+
+                // Title
+                HorizontalLayout {
+                    alignment: space-between;
+
+                    Text {
+                        text: searching-aur ? "AUR search" : "Package search";
+                        color: Theme.c.blue;
+                        font-size: 16px;
+                        font-weight: FontWeight.semi-bold;
+                    }
+
+                    Text {
+                        text: "Tab: AUR";
+                        color: Theme.c.overlay0;
+                        font-size: 12px;
+                        vertical-alignment: center;
+                    }
+                }
+
+                // Search input
+                Rectangle {
+                    height: 36px;
+                    background: Theme.c.surface0;
+                    border-radius: 4px;
+                    border-color: pkg-search-input.has-focus ? Theme.c.blue : Theme.c.surface1;
+                    border-width: 1px;
+                    clip: true;
+
+                    pkg-search-input := TextInput {
+                        width: max(parent.width - 16px, self.preferred-width);
+                        x: 8px;
+                        vertical-alignment: center;
+                        color: Theme.c.text;
+                        font-size: 14px;
+
+                        private property <length> margin: 8px;
+                        cursor-position-changed(cursor-position) => {
+                            if cursor-position.x + self.x < margin {
+                                self.x = - cursor-position.x + margin;
+                            } else if cursor-position.x + self.x > parent.width - margin - self.text-cursor-width {
+                                self.x = parent.width - cursor-position.x - margin - self.text-cursor-width;
+                            }
+                        }
+
+                        edited => {
+                            search-changed(self.text);
+                        }
+                    }
+
+                    // Placeholder
+                    if pkg-search-input.text == "": Text {
+                        x: 8px;
+                        text: "type to search packages...";
+                        color: Theme.c.overlay0;
+                        font-size: 14px;
+                        vertical-alignment: center;
+                    }
+
+                    init => { pkg-search-input.focus(); }
+                }
+
+                // Status / hint
+                if status-text != "": Text {
+                    text: status-text;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    height: 16px;
+                }
+
+                // Search results
+                ListView {
+                    vertical-stretch: 1;
+
+                    for result[index] in search-results: Rectangle {
+                        height: 36px;
+                        background: result-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
+                        border-radius: 4px;
+
+                        result-ta := TouchArea {
+                            clicked => {
+                                package-added(index);
+                                pkg-search-input.text = "";
+                                pkg-search-input.focus();
+                            }
+                        }
+
+                        HorizontalLayout {
+                            padding-left: 12px;
+                            padding-right: 12px;
+                            spacing: 8px;
+
+                            Text {
+                                text: result.name;
+                                color: Theme.c.text;
+                                font-size: 13px;
+                                vertical-alignment: center;
+                            }
+
+                            // Repo badge
+                            Rectangle {
+                                width: repo-badge-text.preferred-width + 10px;
+                                height: 18px;
+                                background: result.repo == "aur" ? Theme.c.mauve : Theme.c.blue;
+                                border-radius: 3px;
+
+                                repo-badge-text := Text {
+                                    text: result.repo;
+                                    color: Theme.c.base;
+                                    font-size: 10px;
+                                    font-weight: FontWeight.semi-bold;
+                                    horizontal-alignment: center;
+                                    vertical-alignment: center;
+                                }
+                            }
+
+                            Text {
+                                text: result.description;
+                                color: Theme.c.overlay0;
+                                font-size: 12px;
+                                vertical-alignment: center;
+                                overflow: elide;
+                                horizontal-stretch: 1;
+                            }
+                        }
+                    }
+                }
+
+                // Separator
+                if selected-packages.length > 0: Rectangle {
+                    height: 1px;
+                    background: Theme.c.surface1;
+                }
+
+                // Selected packages
+                if selected-packages.length > 0: VerticalLayout {
+                    spacing: 4px;
+                    height: min(self.preferred-height, 100px);
+
+                    Text {
+                        text: "Selected";
+                        color: Theme.c.subtext0;
+                        font-size: 12px;
+                        font-weight: FontWeight.semi-bold;
+                        height: 16px;
+                    }
+
+                    Flickable {
+                        HorizontalLayout {
+                            spacing: 6px;
+                            alignment: start;
+
+                            for pkg[index] in selected-packages: Rectangle {
+                                width: pkg-chip-layout.preferred-width;
+                                height: 26px;
+                                background: pkg-del-ta.has-hover ? Theme.c.red : Theme.c.surface0;
+                                border-radius: 4px;
+
+                                pkg-del-ta := TouchArea {
+                                    clicked => { package-removed(index); }
+                                }
+
+                                pkg-chip-layout := HorizontalLayout {
+                                    padding-left: 8px;
+                                    padding-right: 8px;
+                                    spacing: 4px;
+
+                                    Text {
+                                        text: pkg.name;
+                                        color: pkg-del-ta.has-hover ? Theme.c.base : Theme.c.text;
+                                        font-size: 12px;
+                                        vertical-alignment: center;
+                                    }
+
+                                    Text {
+                                        text: pkg.repo == "aur" ? "[aur]" : "[repo]";
+                                        color: pkg-del-ta.has-hover ? Theme.c.base : Theme.c.overlay0;
+                                        font-size: 10px;
+                                        vertical-alignment: center;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Done button
+                HorizontalLayout {
+                    alignment: end;
+
+                    Rectangle {
+                        width: 80px;
+                        height: 30px;
+                        background: pkg-done-ta.has-hover ? Theme.c.sky : Theme.c.blue;
+                        border-radius: 4px;
+
+                        pkg-done-ta := TouchArea {
+                            clicked => { closed(); }
+                        }
+
+                        Text {
+                            text: "Done";
+                            color: Theme.c.base;
+                            font-size: 13px;
+                            font-weight: FontWeight.semi-bold;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // ── Sidebar step item ────────────────────────────────
 
 component SidebarItem inherits Rectangle {
@@ -794,6 +1071,18 @@ export component App inherits Window {
     in-out property <bool> users-visible: false;
     in property <[UserEntry]> users-list;
 
+    // Package search popup state
+    in-out property <bool> pkg-search-visible: false;
+    in property <[PackageSearchResult]> pkg-search-results;
+    in property <[PackageEntry]> pkg-selected;
+    in-out property <bool> pkg-searching-aur: false;
+    in-out property <string> pkg-status-text;
+
+    callback pkg-search-changed(string);
+    callback pkg-search-aur(string);
+    callback pkg-added(int);
+    callback pkg-removed(int);
+
     // Install state: 0=config, 1=installing, 2=done, 3=failed
     in-out property <int> install-state: 0;
 
@@ -838,7 +1127,7 @@ export component App inherits Window {
 
     // ── Keyboard navigation ─────────────────────────
     main-focus-scope := FocusScope {
-        enabled: install-state == 0 && !select-visible && !text-input-visible && !users-visible;
+        enabled: install-state == 0 && !select-visible && !text-input-visible && !users-visible && !pkg-search-visible;
         key-pressed(e) => {
             if e.text == Key.DownArrow || e.text == "j" {
                 key-nav-down();
@@ -1747,6 +2036,30 @@ export component App inherits Window {
         }
         closed() => {
             users-visible = false;
+        }
+    }
+
+    PackageSearchPopup {
+        search-results: pkg-search-results;
+        selected-packages: pkg-selected;
+        popup-visible: pkg-search-visible;
+        searching-aur: pkg-searching-aur;
+        status-text: pkg-status-text;
+
+        search-changed(text) => {
+            root.pkg-search-changed(text);
+        }
+        search-aur(text) => {
+            root.pkg-search-aur(text);
+        }
+        package-added(index) => {
+            root.pkg-added(index);
+        }
+        package-removed(index) => {
+            root.pkg-removed(index);
+        }
+        closed() => {
+            pkg-search-visible = false;
         }
     }
 }

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -714,7 +714,8 @@ component StringListPopup inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: min(460px, parent.width - 40px);
-            height: self.preferred-height;
+            // 130px base (title + input + buttons + padding) + 40px per item, max 400px
+            height: min(130px + items.length * 40px, min(400px, parent.height - 80px));
             background: Theme.c.mantle;
             border-radius: 8px;
             border-color: Theme.c.surface1;

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -693,6 +693,189 @@ component UserManagePopup inherits Rectangle {
     }
 }
 
+// ── String list popup (for extra_services, etc.) ────
+
+component StringListPopup inherits Rectangle {
+    in property <string> title;
+    in property <[SelectOption]> items;
+    in property <bool> popup-visible;
+
+    callback item-added(string);
+    callback item-removed(int);
+    callback closed();
+
+    if popup-visible: Rectangle {
+        background: #00000080;
+        width: 100%; height: 100%;
+
+        TouchArea { clicked => { closed(); } }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: min(460px, parent.width - 40px);
+            height: min(self.preferred-height, parent.height - 80px);
+            background: Theme.c.mantle;
+            border-radius: 8px;
+            border-color: Theme.c.surface1;
+            border-width: 1px;
+            clip: true;
+            accessible-role: groupbox;
+            accessible-label: title;
+
+            VerticalLayout {
+                padding: 16px;
+                spacing: 10px;
+
+                Text {
+                    text: title;
+                    color: Theme.c.blue;
+                    font-size: 16px;
+                    font-weight: FontWeight.semi-bold;
+                    height: 24px;
+                }
+
+                // Existing items
+                if items.length > 0: ListView {
+                    vertical-stretch: 1;
+                    min-height: 40px;
+                    max-height: 200px;
+
+                    for item[index] in items: Rectangle {
+                        height: 36px;
+                        background: Theme.c.surface0;
+                        border-radius: 4px;
+
+                        HorizontalLayout {
+                            padding-left: 12px;
+                            padding-right: 8px;
+                            alignment: space-between;
+
+                            Text {
+                                text: item.text;
+                                color: Theme.c.text;
+                                font-size: 14px;
+                                vertical-alignment: center;
+                                horizontal-stretch: 1;
+                            }
+
+                            Rectangle {
+                                width: 28px;
+                                height: 28px;
+                                background: sl-del-ta.has-hover ? Theme.c.red : transparent;
+                                border-radius: 4px;
+
+                                sl-del-ta := TouchArea {
+                                    clicked => { item-removed(index); }
+                                }
+
+                                Text {
+                                    text: "\u{2715}";
+                                    color: sl-del-ta.has-hover ? Theme.c.base : Theme.c.overlay0;
+                                    font-size: 14px;
+                                    horizontal-alignment: center;
+                                    vertical-alignment: center;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Add new item
+                HorizontalLayout {
+                    spacing: 8px;
+
+                    Rectangle {
+                        horizontal-stretch: 1;
+                        height: 34px;
+                        background: Theme.c.surface0;
+                        border-radius: 4px;
+                        border-color: sl-add-input.has-focus ? Theme.c.blue : Theme.c.surface1;
+                        border-width: 1px;
+                        clip: true;
+
+                        sl-add-input := TextInput {
+                            width: max(parent.width - 16px, self.preferred-width);
+                            x: 8px;
+                            vertical-alignment: center;
+                            color: Theme.c.text;
+                            font-size: 13px;
+
+                            accepted => {
+                                if self.text != "" {
+                                    item-added(self.text);
+                                    self.text = "";
+                                }
+                            }
+                        }
+
+                        if sl-add-input.text == "": Text {
+                            x: 8px;
+                            text: "add new entry...";
+                            color: Theme.c.overlay0;
+                            font-size: 13px;
+                            vertical-alignment: center;
+                        }
+
+                        init => { sl-add-input.focus(); }
+                    }
+
+                    Rectangle {
+                        width: 60px;
+                        height: 34px;
+                        background: sl-add-ta.has-hover ? Theme.c.sky : Theme.c.blue;
+                        border-radius: 4px;
+
+                        sl-add-ta := TouchArea {
+                            clicked => {
+                                if sl-add-input.text != "" {
+                                    item-added(sl-add-input.text);
+                                    sl-add-input.text = "";
+                                    sl-add-input.focus();
+                                }
+                            }
+                        }
+
+                        Text {
+                            text: "Add";
+                            color: Theme.c.base;
+                            font-size: 13px;
+                            font-weight: FontWeight.semi-bold;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+
+                // Done button
+                HorizontalLayout {
+                    alignment: end;
+
+                    Rectangle {
+                        width: 80px;
+                        height: 30px;
+                        background: sl-done-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
+                        border-radius: 4px;
+
+                        sl-done-ta := TouchArea {
+                            clicked => { closed(); }
+                        }
+
+                        Text {
+                            text: "Done";
+                            color: Theme.c.subtext0;
+                            font-size: 13px;
+                            font-weight: FontWeight.semi-bold;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // ── Package search popup ─────────────────────────────
 
 component PackageSearchPopup inherits Rectangle {
@@ -1076,6 +1259,15 @@ export component App inherits Window {
     in-out property <bool> users-visible: false;
     in property <[UserEntry]> users-list;
 
+    // String list popup state
+    in-out property <bool> strlist-visible: false;
+    in-out property <string> strlist-title;
+    in-out property <string> strlist-key;
+    in property <[SelectOption]> strlist-items;
+
+    callback strlist-added(string, string); // key, value
+    callback strlist-removed(string, int);  // key, index
+
     // Package search popup state
     in-out property <bool> pkg-search-visible: false;
     in property <[PackageSearchResult]> pkg-search-results;
@@ -1132,7 +1324,7 @@ export component App inherits Window {
 
     // ── Keyboard navigation ─────────────────────────
     main-focus-scope := FocusScope {
-        enabled: install-state == 0 && !select-visible && !text-input-visible && !users-visible && !pkg-search-visible;
+        enabled: install-state == 0 && !select-visible && !text-input-visible && !users-visible && !pkg-search-visible && !strlist-visible;
         key-pressed(e) => {
             if e.text == Key.DownArrow || e.text == "j" {
                 key-nav-down();
@@ -2041,6 +2233,22 @@ export component App inherits Window {
         }
         closed() => {
             users-visible = false;
+        }
+    }
+
+    StringListPopup {
+        title: strlist-title;
+        items: strlist-items;
+        popup-visible: strlist-visible;
+
+        item-added(val) => {
+            strlist-added(strlist-key, val);
+        }
+        item-removed(index) => {
+            strlist-removed(strlist-key, index);
+        }
+        closed() => {
+            strlist-visible = false;
         }
     }
 

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -714,8 +714,8 @@ component StringListPopup inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: min(540px, parent.width - 40px);
-            // 140px base (title + input row + padding) + 40px per item
-            height: min(140px + items.length * 40px, parent.height - 80px);
+            // 160px base + items capped at 300px (ScrollView max-height)
+            height: min(160px + min(items.length * 40px, 300px), parent.height - 80px);
             background: Theme.c.mantle;
             border-radius: 8px;
             border-color: Theme.c.surface1;

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -727,83 +727,88 @@ component PackageSearchPopup inherits Rectangle {
             accessible-role: groupbox;
             accessible-label: "Package search";
 
-            FocusScope {
-                key-pressed(e) => {
-                    if e.text == Key.Tab {
-                        search-aur(pkg-search-input.text);
-                        return accept;
-                    }
-                    if e.text == Key.Escape {
-                        closed();
-                        return accept;
-                    }
-                    return reject;
-                }
-            }
-
             VerticalLayout {
                 padding: 16px;
                 spacing: 10px;
 
                 // Title
-                HorizontalLayout {
-                    alignment: space-between;
-
-                    Text {
-                        text: searching-aur ? "AUR search" : "Package search";
-                        color: Theme.c.blue;
-                        font-size: 16px;
-                        font-weight: FontWeight.semi-bold;
-                    }
-
-                    Text {
-                        text: "Tab: AUR";
-                        color: Theme.c.overlay0;
-                        font-size: 12px;
-                        vertical-alignment: center;
-                    }
+                Text {
+                    text: searching-aur ? "AUR search" : "Package search";
+                    color: Theme.c.blue;
+                    font-size: 16px;
+                    font-weight: FontWeight.semi-bold;
                 }
 
-                // Search input
-                Rectangle {
-                    height: 36px;
-                    background: Theme.c.surface0;
-                    border-radius: 4px;
-                    border-color: pkg-search-input.has-focus ? Theme.c.blue : Theme.c.surface1;
-                    border-width: 1px;
-                    clip: true;
+                // Search input + AUR button
+                HorizontalLayout {
+                    spacing: 8px;
 
-                    pkg-search-input := TextInput {
-                        width: max(parent.width - 16px, self.preferred-width);
-                        x: 8px;
-                        vertical-alignment: center;
-                        color: Theme.c.text;
-                        font-size: 14px;
+                    Rectangle {
+                        horizontal-stretch: 1;
+                        height: 36px;
+                        background: Theme.c.surface0;
+                        border-radius: 4px;
+                        border-color: pkg-search-input.has-focus ? Theme.c.blue : Theme.c.surface1;
+                        border-width: 1px;
+                        clip: true;
 
-                        private property <length> margin: 8px;
-                        cursor-position-changed(cursor-position) => {
-                            if cursor-position.x + self.x < margin {
-                                self.x = - cursor-position.x + margin;
-                            } else if cursor-position.x + self.x > parent.width - margin - self.text-cursor-width {
-                                self.x = parent.width - cursor-position.x - margin - self.text-cursor-width;
+                        pkg-search-input := TextInput {
+                            width: max(parent.width - 16px, self.preferred-width);
+                            x: 8px;
+                            vertical-alignment: center;
+                            color: Theme.c.text;
+                            font-size: 14px;
+
+                            private property <length> margin: 8px;
+                            cursor-position-changed(cursor-position) => {
+                                if cursor-position.x + self.x < margin {
+                                    self.x = - cursor-position.x + margin;
+                                } else if cursor-position.x + self.x > parent.width - margin - self.text-cursor-width {
+                                    self.x = parent.width - cursor-position.x - margin - self.text-cursor-width;
+                                }
+                            }
+
+                            edited => {
+                                search-changed(self.text);
                             }
                         }
 
-                        edited => {
-                            search-changed(self.text);
+                        // Placeholder
+                        if pkg-search-input.text == "": Text {
+                            x: 8px;
+                            text: "type to search packages...";
+                            color: Theme.c.overlay0;
+                            font-size: 14px;
+                            vertical-alignment: center;
+                        }
+
+                        init => { pkg-search-input.focus(); }
+                    }
+
+                    // AUR search button
+                    Rectangle {
+                        width: 60px;
+                        height: 36px;
+                        background: aur-btn-ta.has-hover ? Theme.c.mauve : Theme.c.surface0;
+                        border-radius: 4px;
+                        border-color: searching-aur ? Theme.c.mauve : Theme.c.surface1;
+                        border-width: 1px;
+
+                        aur-btn-ta := TouchArea {
+                            clicked => {
+                                search-aur(pkg-search-input.text);
+                            }
+                        }
+
+                        Text {
+                            text: "AUR";
+                            color: aur-btn-ta.has-hover ? Theme.c.base : (searching-aur ? Theme.c.mauve : Theme.c.subtext0);
+                            font-size: 13px;
+                            font-weight: FontWeight.semi-bold;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
                         }
                     }
-
-                    // Placeholder
-                    if pkg-search-input.text == "": Text {
-                        x: 8px;
-                        text: "type to search packages...";
-                        color: Theme.c.overlay0;
-                        font-size: 14px;
-                        vertical-alignment: center;
-                    }
-
-                    init => { pkg-search-input.focus(); }
                 }
 
                 // Status / hint

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -714,8 +714,7 @@ component StringListPopup inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: min(460px, parent.width - 40px);
-            // Adaptive: ~160px base + 40px per item, capped
-            height: min(160px + items.length * 40px, parent.height - 80px);
+            height: self.preferred-height;
             background: Theme.c.mantle;
             border-radius: 8px;
             border-color: Theme.c.surface1;

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -736,49 +736,47 @@ component StringListPopup inherits Rectangle {
                 }
 
                 // Existing items
-                ListView {
-                    vertical-stretch: 1;
+                ScrollView {
+                    max-height: 300px;
 
-                    for item[index] in items: Rectangle {
-                        height: 40px;
-                        background: transparent;
+                    VerticalLayout {
+                        spacing: 4px;
 
-                        Rectangle {
-                            y: 2px;
+                        for item[index] in items: Rectangle {
                             height: 36px;
                             background: Theme.c.surface0;
                             border-radius: 4px;
-                        }
 
-                        HorizontalLayout {
-                            padding-left: 12px;
-                            padding-right: 8px;
-                            alignment: space-between;
-
-                            Text {
-                                text: item.text;
-                                color: Theme.c.text;
-                                font-size: 14px;
-                                vertical-alignment: center;
-                                horizontal-stretch: 1;
-                            }
-
-                            Rectangle {
-                                width: 28px;
-                                height: 28px;
-                                background: sl-del-ta.has-hover ? Theme.c.red : transparent;
-                                border-radius: 4px;
-
-                                sl-del-ta := TouchArea {
-                                    clicked => { item-removed(index); }
-                                }
+                            HorizontalLayout {
+                                padding-left: 12px;
+                                padding-right: 8px;
+                                alignment: space-between;
 
                                 Text {
-                                    text: "\u{2715}";
-                                    color: sl-del-ta.has-hover ? Theme.c.base : Theme.c.overlay0;
+                                    text: item.text;
+                                    color: Theme.c.text;
                                     font-size: 14px;
-                                    horizontal-alignment: center;
                                     vertical-alignment: center;
+                                    horizontal-stretch: 1;
+                                }
+
+                                Rectangle {
+                                    width: 28px;
+                                    height: 28px;
+                                    background: sl-del-ta.has-hover ? Theme.c.red : transparent;
+                                    border-radius: 4px;
+
+                                    sl-del-ta := TouchArea {
+                                        clicked => { item-removed(index); }
+                                    }
+
+                                    Text {
+                                        text: "\u{2715}";
+                                        color: sl-del-ta.has-hover ? Theme.c.base : Theme.c.overlay0;
+                                        font-size: 14px;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
                                 }
                             }
                         }

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -713,9 +713,9 @@ component StringListPopup inherits Rectangle {
         Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
-            width: min(460px, parent.width - 40px);
-            // 130px base (title + input + buttons + padding) + 40px per item, max 400px
-            height: min(130px + items.length * 40px, min(400px, parent.height - 80px));
+            width: min(540px, parent.width - 40px);
+            // 140px base (title + input row + padding) + 40px per item
+            height: min(140px + items.length * 40px, parent.height - 80px);
             background: Theme.c.mantle;
             border-radius: 8px;
             border-color: Theme.c.surface1;
@@ -784,7 +784,7 @@ component StringListPopup inherits Rectangle {
                     }
                 }
 
-                // Add new item
+                // Add input + Add + Done in one row
                 HorizontalLayout {
                     spacing: 8px;
 
@@ -848,15 +848,10 @@ component StringListPopup inherits Rectangle {
                             vertical-alignment: center;
                         }
                     }
-                }
-
-                // Done button
-                HorizontalLayout {
-                    alignment: end;
 
                     Rectangle {
-                        width: 80px;
-                        height: 30px;
+                        width: 60px;
+                        height: 34px;
                         background: sl-done-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
                         border-radius: 4px;
 

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -714,7 +714,8 @@ component StringListPopup inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: min(460px, parent.width - 40px);
-            height: min(360px, parent.height - 80px);
+            // Adaptive: ~160px base + 40px per item, capped
+            height: min(160px + items.length * 40px, parent.height - 80px);
             background: Theme.c.mantle;
             border-radius: 8px;
             border-color: Theme.c.surface1;
@@ -740,9 +741,15 @@ component StringListPopup inherits Rectangle {
                     vertical-stretch: 1;
 
                     for item[index] in items: Rectangle {
-                        height: 36px;
-                        background: Theme.c.surface0;
-                        border-radius: 4px;
+                        height: 40px;
+                        background: transparent;
+
+                        Rectangle {
+                            y: 2px;
+                            height: 36px;
+                            background: Theme.c.surface0;
+                            border-radius: 4px;
+                        }
 
                         HorizontalLayout {
                             padding-left: 12px;

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -5,22 +5,22 @@ edition = "2024"
 
 [dependencies]
 archinstall-zfs-core = { path = "../core" }
-clap = { version = "4.6.0", features = ["derive"] }
-color-eyre = "0.6.5"
+clap.workspace = true
+color-eyre.workspace = true
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-futures = "0.3.32"
-nix = { version = "0.31.2", features = ["fs"] }
+futures.workspace = true
+nix.workspace = true
 ratatui = "0.30.0"
 ratatui-macros = "0.7.0"
 ratatui-themes = "0.2.0"
 ratatui-widgets = "0.3.0"
-sublime_fuzzy = "0.7.0"
-tokio = { version = "1.51.0", features = ["rt", "rt-multi-thread", "macros"] }
-tokio-util = { version = "0.7.18", features = ["rt"] }
-tracing = "0.1.44"
-tracing-appender = "0.2.4"
-tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+sublime_fuzzy.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-subscriber.workspace = true
 tui-scrollview = "0.6.3"
 tui-textarea-2 = "0.10.2"
 tui-widget-list = "0.15.2"
-zxcvbn = "3.1.0"
+zxcvbn.workspace = true

--- a/tui/src/tui/screens/mod.rs
+++ b/tui/src/tui/screens/mod.rs
@@ -1,5 +1,6 @@
 pub mod edit;
 pub mod install_progress;
+pub mod package_picker;
 pub mod pickers;
 pub mod select;
 pub mod steps;

--- a/tui/src/tui/screens/package_picker.rs
+++ b/tui/src/tui/screens/package_picker.rs
@@ -1,0 +1,372 @@
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{
+    Block, BorderType, Borders, Clear, HighlightSpacing, List, ListItem, ListState, Paragraph,
+};
+
+use crate::tui::theme;
+
+use archinstall_zfs_core::packages::PackageInfo;
+
+/// Result of the package picker: updated lists of repo and AUR packages.
+pub struct PackagePickerResult {
+    pub repo_packages: Vec<String>,
+    pub aur_packages: Vec<String>,
+}
+
+enum Focus {
+    Search,
+    Results,
+}
+
+/// Interactive package search and selection.
+/// Searches official repos first (via alpm), with option to search AUR.
+pub async fn run_package_picker(
+    terminal: &mut ratatui::DefaultTerminal,
+    initial_repo: &[String],
+    initial_aur: &[String],
+) -> color_eyre::eyre::Result<Option<PackagePickerResult>> {
+    let mut search_text = String::new();
+    let mut results: Vec<PackageInfo> = Vec::new();
+    let mut list_state = ListState::default();
+    let mut focus = Focus::Search;
+    let mut searching_aur = false;
+    let mut status_msg = String::new();
+
+    // Selected packages (repo and AUR tracked separately)
+    let mut selected_repo: Vec<String> = initial_repo.to_vec();
+    let mut selected_aur: Vec<String> = initial_aur.to_vec();
+
+    loop {
+        let all_selected: Vec<(&str, &str)> = selected_repo
+            .iter()
+            .map(|s| (s.as_str(), "repo"))
+            .chain(selected_aur.iter().map(|s| (s.as_str(), "aur")))
+            .collect();
+
+        terminal.draw(|frame| {
+            render_picker(
+                frame,
+                &search_text,
+                &results,
+                &mut list_state,
+                &all_selected,
+                &focus,
+                searching_aur,
+                &status_msg,
+            );
+        })?;
+
+        if crossterm::event::poll(std::time::Duration::from_millis(50))? {
+            let ev = crossterm::event::read()?;
+            if let Event::Key(key) = ev {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match (&focus, key.code, key.modifiers) {
+                    // Global: Esc to cancel, Ctrl+C to cancel
+                    (_, KeyCode::Esc, _) | (_, KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                        return Ok(None);
+                    }
+
+                    // Search mode
+                    (Focus::Search, KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                        search_text.push(c);
+                        status_msg.clear();
+                        // Search repo
+                        results = do_repo_search(&search_text).await;
+                        searching_aur = false;
+                        list_state.select(if results.is_empty() { None } else { Some(0) });
+                    }
+                    (Focus::Search, KeyCode::Backspace, _) => {
+                        search_text.pop();
+                        status_msg.clear();
+                        if search_text.is_empty() {
+                            results.clear();
+                            list_state.select(None);
+                        } else {
+                            results = do_repo_search(&search_text).await;
+                            searching_aur = false;
+                            list_state.select(if results.is_empty() { None } else { Some(0) });
+                        }
+                    }
+                    // Tab: search AUR instead
+                    (Focus::Search, KeyCode::Tab, _) => {
+                        if !search_text.is_empty() {
+                            status_msg = "Searching AUR...".to_string();
+                            // Render the status before blocking on HTTP
+                            terminal.draw(|frame| {
+                                render_picker(
+                                    frame,
+                                    &search_text,
+                                    &results,
+                                    &mut list_state,
+                                    &all_selected,
+                                    &focus,
+                                    true,
+                                    &status_msg,
+                                );
+                            })?;
+                            match archinstall_zfs_core::packages::search_aur(&search_text, 20).await
+                            {
+                                Ok(aur_results) => {
+                                    results = aur_results;
+                                    searching_aur = true;
+                                    status_msg.clear();
+                                }
+                                Err(e) => {
+                                    status_msg = format!("AUR error: {e}");
+                                    results.clear();
+                                }
+                            }
+                            list_state.select(if results.is_empty() { None } else { Some(0) });
+                        }
+                    }
+                    // Down arrow: move to results
+                    (Focus::Search, KeyCode::Down, _) if !results.is_empty() => {
+                        focus = Focus::Results;
+                        if list_state.selected().is_none() {
+                            list_state.select(Some(0));
+                        }
+                    }
+                    // Enter in search: add typed text directly as package
+                    (Focus::Search, KeyCode::Enter, _) => {
+                        if !search_text.is_empty() {
+                            // If there are results and top one matches, add it
+                            if let Some(0) = list_state.selected()
+                                && let Some(pkg) = results.first()
+                            {
+                                add_package(pkg, &mut selected_repo, &mut selected_aur);
+                                search_text.clear();
+                                results.clear();
+                                list_state.select(None);
+                                continue;
+                            }
+                        }
+                    }
+                    // Ctrl+D: done
+                    (_, KeyCode::Char('d'), KeyModifiers::CONTROL) => {
+                        return Ok(Some(PackagePickerResult {
+                            repo_packages: selected_repo,
+                            aur_packages: selected_aur,
+                        }));
+                    }
+
+                    // Results mode
+                    (Focus::Results, KeyCode::Up, _) => {
+                        let i = list_state.selected().unwrap_or(0);
+                        if i == 0 {
+                            focus = Focus::Search;
+                        } else {
+                            list_state.select(Some(i - 1));
+                        }
+                    }
+                    (Focus::Results, KeyCode::Down, _) => {
+                        let i = list_state.selected().unwrap_or(0);
+                        if i < results.len().saturating_sub(1) {
+                            list_state.select(Some(i + 1));
+                        }
+                    }
+                    (Focus::Results, KeyCode::Enter, _) => {
+                        if let Some(idx) = list_state.selected()
+                            && let Some(pkg) = results.get(idx)
+                        {
+                            add_package(pkg, &mut selected_repo, &mut selected_aur);
+                            search_text.clear();
+                            results.clear();
+                            list_state.select(None);
+                            focus = Focus::Search;
+                        }
+                    }
+
+                    // Delete selected packages with Ctrl+X
+                    (_, KeyCode::Char('x'), KeyModifiers::CONTROL) => {
+                        if !selected_repo.is_empty() || !selected_aur.is_empty() {
+                            // Remove last added
+                            if !selected_aur.is_empty() {
+                                selected_aur.pop();
+                            } else {
+                                selected_repo.pop();
+                            }
+                        }
+                    }
+
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn add_package(pkg: &PackageInfo, repo: &mut Vec<String>, aur: &mut Vec<String>) {
+    let name = &pkg.name;
+    // Don't add duplicates
+    if repo.iter().any(|s| s == name) || aur.iter().any(|s| s == name) {
+        return;
+    }
+    if pkg.repo == "aur" {
+        aur.push(name.clone());
+    } else {
+        repo.push(name.clone());
+    }
+}
+
+async fn do_repo_search(query: &str) -> Vec<PackageInfo> {
+    archinstall_zfs_core::packages::search_repo(query, 20)
+        .await
+        .unwrap_or_default()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_picker(
+    frame: &mut Frame,
+    search: &str,
+    results: &[PackageInfo],
+    state: &mut ListState,
+    selected: &[(&str, &str)],
+    focus: &Focus,
+    searching_aur: bool,
+    status: &str,
+) {
+    let area = frame.area();
+    let bg = Paragraph::new("").style(Style::default().add_modifier(Modifier::DIM));
+    frame.render_widget(bg, area);
+
+    // Full-width popup
+    let popup_width = area.width.saturating_sub(4).min(80);
+    let popup_height = area.height.saturating_sub(4);
+    let popup = super::centered_rect(popup_width, popup_height, area);
+
+    frame.render_widget(Clear, popup);
+
+    // Layout: title(1) + search(3) + results(flexible) + selected(variable) + footer(1)
+    let selected_height = if selected.is_empty() {
+        0
+    } else {
+        (selected.len() as u16 + 2).min(6)
+    };
+
+    let chunks = Layout::vertical([
+        Constraint::Length(3),               // search input
+        Constraint::Min(3),                  // results
+        Constraint::Length(selected_height), // selected packages
+    ])
+    .split(popup);
+
+    // Search input
+    let search_border_style = match focus {
+        Focus::Search => theme::ACCENT_STYLE,
+        Focus::Results => theme::BORDER_STYLE,
+    };
+    let source_label = if searching_aur { " AUR " } else { " Packages " };
+    let search_block = Block::default()
+        .title(source_label)
+        .title_style(theme::HEADER_STYLE)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(search_border_style)
+        .style(theme::BG_STYLE);
+
+    let search_display = if search.is_empty() {
+        Span::styled(" type to search...", theme::DIMMED_STYLE)
+    } else {
+        Span::styled(format!(" {search}\u{258f}"), theme::ACCENT_STYLE)
+    };
+    let search_widget = Paragraph::new(Line::from(vec![search_display])).block(search_block);
+    frame.render_widget(search_widget, chunks[0]);
+
+    // Results list
+    let results_block = Block::default()
+        .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+        .border_type(BorderType::Rounded)
+        .border_style(theme::BORDER_STYLE)
+        .style(theme::BG_STYLE);
+
+    if results.is_empty() && !search.is_empty() {
+        let msg = if !status.is_empty() {
+            status.to_string()
+        } else {
+            "No results. Press Tab to search AUR.".to_string()
+        };
+        let empty = Paragraph::new(Line::from(Span::styled(
+            format!("  {msg}"),
+            theme::DIMMED_STYLE,
+        )))
+        .block(results_block);
+        frame.render_widget(empty, chunks[1]);
+    } else {
+        let list_items: Vec<ListItem> = results
+            .iter()
+            .map(|pkg| {
+                let badge = format!("[{}]", pkg.repo);
+                let desc = if pkg.description.len() > 40 {
+                    format!("{}...", &pkg.description[..40])
+                } else {
+                    pkg.description.clone()
+                };
+                ListItem::new(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(&pkg.name, theme::NORMAL_STYLE),
+                    Span::styled(format!(" {badge} "), theme::DIMMED_STYLE),
+                    Span::styled(desc, theme::DIMMED_STYLE),
+                ]))
+            })
+            .collect();
+
+        let list = List::new(list_items)
+            .block(results_block)
+            .highlight_style(theme::SELECTED_STYLE)
+            .highlight_symbol(" \u{25b8} ")
+            .highlight_spacing(HighlightSpacing::Always);
+
+        frame.render_stateful_widget(list, chunks[1], state);
+    }
+
+    // Selected packages
+    if !selected.is_empty() {
+        let sel_block = Block::default()
+            .title(" Selected ")
+            .title_style(theme::HEADER_STYLE)
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(theme::BORDER_STYLE)
+            .style(theme::BG_STYLE);
+
+        let sel_text: Vec<Span> = selected
+            .iter()
+            .flat_map(|(name, source)| {
+                vec![
+                    Span::styled(*name, theme::VALUE_STYLE),
+                    Span::styled(format!("[{source}] "), theme::DIMMED_STYLE),
+                ]
+            })
+            .collect();
+
+        let sel_paragraph = Paragraph::new(Line::from(sel_text))
+            .block(sel_block)
+            .wrap(ratatui::widgets::Wrap { trim: false });
+        frame.render_widget(sel_paragraph, chunks[2]);
+    }
+
+    // Footer
+    let footer_area = Rect::new(popup.x, popup.y + popup.height, popup.width, 1);
+    if footer_area.y < area.height {
+        let footer = Paragraph::new(Line::from(vec![
+            Span::styled(" Enter", theme::ACCENT_STYLE),
+            Span::styled(" add  ", theme::DIMMED_STYLE),
+            Span::styled("Tab", theme::ACCENT_STYLE),
+            Span::styled(" AUR  ", theme::DIMMED_STYLE),
+            Span::styled("Ctrl+X", theme::ACCENT_STYLE),
+            Span::styled(" remove  ", theme::DIMMED_STYLE),
+            Span::styled("Ctrl+D", theme::ACCENT_STYLE),
+            Span::styled(" done  ", theme::DIMMED_STYLE),
+            Span::styled("Esc", theme::ACCENT_STYLE),
+            Span::styled(" cancel", theme::DIMMED_STYLE),
+        ]))
+        .alignment(Alignment::Center);
+        frame.render_widget(footer, footer_area);
+    }
+}

--- a/tui/src/tui/screens/steps/desktop.rs
+++ b/tui/src/tui/screens/steps/desktop.rs
@@ -75,24 +75,23 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             kind: MenuKind::Toggle,
         },
         MenuItem {
-            key: "additional_packages",
-            label: "Additional packages",
-            value: if config.additional_packages.is_empty() {
-                "None".into()
-            } else {
-                config.additional_packages.join(", ")
+            key: "packages",
+            label: "Extra packages",
+            value: {
+                let total = config.additional_packages.len() + config.aur_packages.len();
+                if total == 0 {
+                    "None".into()
+                } else {
+                    let mut parts: Vec<&str> = config
+                        .additional_packages
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect();
+                    parts.extend(config.aur_packages.iter().map(|s| s.as_str()));
+                    parts.join(", ")
+                }
             },
-            kind: MenuKind::Text,
-        },
-        MenuItem {
-            key: "aur_packages",
-            label: "AUR packages",
-            value: if config.aur_packages.is_empty() {
-                "None".into()
-            } else {
-                config.aur_packages.join(", ")
-            },
-            kind: MenuKind::Text,
+            kind: MenuKind::Custom,
         },
         MenuItem {
             key: "extra_services",

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -293,6 +293,18 @@ impl Wizard {
                 "users" => {
                     pickers::manage_users(&mut self.config, terminal)?;
                 }
+                "packages" => {
+                    if let Some(result) = super::package_picker::run_package_picker(
+                        terminal,
+                        &self.config.additional_packages,
+                        &self.config.aur_packages,
+                    )
+                    .await?
+                    {
+                        self.config.additional_packages = result.repo_packages;
+                        self.config.aur_packages = result.aur_packages;
+                    }
+                }
                 "pool_name" => {
                     pickers::pick_existing_pool(&mut self.config, terminal)?;
                 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap.workspace = true


### PR DESCRIPTION
Replace separate text inputs for additional_packages and aur_packages with a unified search picker in both TUI and Slint GUI.

- New `core/src/packages.rs` module with `search_repo()` (alpm) and `search_aur()` (raur) functions, ranked by sublime_fuzzy
- TUI: interactive package picker — type to search repos, Tab for AUR, Enter to add, Ctrl+X to remove, Ctrl+D to confirm
- Slint: package search popup with same flow — type to search, Tab for AUR, click to add/remove
- Remove .sig downloading from async downloader — libalpm always re-fetches signatures during trans_commit() regardless of cache (confirmed via log analysis of DownloadEvent::Init/Completed results)
- Rename PkgRetrieveStart/Done logs to "retrieving package signatures" for clarity
- Move 12 shared dependencies to workspace Cargo.toml