### PR TITLE
Slint refactor phase 2: tests, two-tier focus, states[] polish

### DIFF
--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -643,3 +643,332 @@ pub fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {
         _ => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> GlobalConfig {
+        GlobalConfig::default()
+    }
+
+    // ── apply_radio ─────────────────────────────────────
+
+    #[test]
+    fn radio_installation_mode_sets_and_clears_dependents() {
+        let mut c = cfg();
+        c.disk_by_id = Some("/dev/sda".into());
+        c.efi_partition_by_id = Some("/dev/sda1".into());
+
+        // Switching mode should clear all by-id selections
+        apply_radio(&mut c, "installation_mode", 1);
+        assert_eq!(c.installation_mode, Some(InstallationMode::NewPool));
+        assert!(c.disk_by_id.is_none());
+        assert!(c.efi_partition_by_id.is_none());
+        assert!(c.zfs_partition_by_id.is_none());
+        assert!(c.swap_partition_by_id.is_none());
+    }
+
+    #[test]
+    fn radio_installation_mode_no_clear_when_unchanged() {
+        let mut c = cfg();
+        c.installation_mode = Some(InstallationMode::FullDisk);
+        c.disk_by_id = Some("/dev/sda".into());
+
+        apply_radio(&mut c, "installation_mode", 0); // Same mode (FullDisk)
+        assert_eq!(c.installation_mode, Some(InstallationMode::FullDisk));
+        // Selections should be preserved when mode doesn't actually change
+        assert!(c.disk_by_id.is_some());
+    }
+
+    #[test]
+    fn radio_installation_mode_indices() {
+        let cases = [
+            (0, InstallationMode::FullDisk),
+            (1, InstallationMode::NewPool),
+            (2, InstallationMode::ExistingPool),
+        ];
+        for (idx, expected) in cases {
+            let mut c = cfg();
+            apply_radio(&mut c, "installation_mode", idx);
+            assert_eq!(c.installation_mode, Some(expected), "idx={idx}");
+        }
+    }
+
+    #[test]
+    fn radio_compression_indices() {
+        let cases = [
+            (0, CompressionAlgo::Lz4),
+            (1, CompressionAlgo::Zstd),
+            (2, CompressionAlgo::Zstd5),
+            (3, CompressionAlgo::Zstd10),
+            (4, CompressionAlgo::Off),
+        ];
+        for (idx, expected) in cases {
+            let mut c = cfg();
+            apply_radio(&mut c, "compression", idx);
+            assert_eq!(c.compression, expected, "idx={idx}");
+        }
+    }
+
+    #[test]
+    fn radio_encryption_clears_password_when_set_to_none() {
+        let mut c = cfg();
+        c.zfs_encryption_mode = ZfsEncryptionMode::Pool;
+        c.zfs_encryption_password = Some("hunter2".into());
+
+        apply_radio(&mut c, "encryption", 0); // None
+        assert_eq!(c.zfs_encryption_mode, ZfsEncryptionMode::None);
+        assert!(c.zfs_encryption_password.is_none());
+    }
+
+    #[test]
+    fn radio_encryption_keeps_password_when_set_to_pool() {
+        let mut c = cfg();
+        c.zfs_encryption_mode = ZfsEncryptionMode::Dataset;
+        c.zfs_encryption_password = Some("hunter2".into());
+
+        apply_radio(&mut c, "encryption", 1); // Pool
+        assert_eq!(c.zfs_encryption_mode, ZfsEncryptionMode::Pool);
+        assert_eq!(c.zfs_encryption_password.as_deref(), Some("hunter2"));
+    }
+
+    #[test]
+    fn radio_swap_mode_indices() {
+        let cases = [
+            (0, SwapMode::None),
+            (1, SwapMode::Zram),
+            (2, SwapMode::ZswapPartition),
+            (3, SwapMode::ZswapPartitionEncrypted),
+        ];
+        for (idx, expected) in cases {
+            let mut c = cfg();
+            apply_radio(&mut c, "swap_mode", idx);
+            assert_eq!(c.swap_mode, expected, "idx={idx}");
+        }
+    }
+
+    #[test]
+    fn radio_init_system_indices() {
+        let mut c = cfg();
+        apply_radio(&mut c, "init_system", 0);
+        assert_eq!(c.init_system, InitSystem::Dracut);
+        apply_radio(&mut c, "init_system", 1);
+        assert_eq!(c.init_system, InitSystem::Mkinitcpio);
+    }
+
+    #[test]
+    fn radio_audio_indices() {
+        let cases = [
+            (0, None),
+            (1, Some(AudioServer::Pipewire)),
+            (2, Some(AudioServer::Pulseaudio)),
+        ];
+        for (idx, expected) in cases {
+            let mut c = cfg();
+            apply_radio(&mut c, "audio", idx);
+            assert_eq!(c.audio, expected, "idx={idx}");
+        }
+    }
+
+    #[test]
+    fn radio_unknown_key_is_noop() {
+        let mut c = cfg();
+        let before_mode = c.installation_mode;
+        let before_compression = c.compression;
+        let before_swap = c.swap_mode;
+        apply_radio(&mut c, "totally_made_up", 5);
+        assert_eq!(c.installation_mode, before_mode);
+        assert_eq!(c.compression, before_compression);
+        assert_eq!(c.swap_mode, before_swap);
+    }
+
+    // ── apply_text ──────────────────────────────────────
+
+    #[test]
+    fn text_pool_name_sets_and_clears() {
+        let mut c = cfg();
+        apply_text(&mut c, "pool_name", "rpool");
+        assert_eq!(c.pool_name.as_deref(), Some("rpool"));
+
+        // Empty string clears the field
+        apply_text(&mut c, "pool_name", "");
+        assert!(c.pool_name.is_none());
+    }
+
+    #[test]
+    fn text_dataset_prefix_does_not_clear_on_empty() {
+        let mut c = cfg();
+        let original = c.dataset_prefix.clone();
+        apply_text(&mut c, "dataset_prefix", "myprefix");
+        assert_eq!(c.dataset_prefix, "myprefix");
+
+        // Empty string is a no-op (must not blank the prefix)
+        apply_text(&mut c, "dataset_prefix", "");
+        assert_eq!(c.dataset_prefix, "myprefix");
+
+        // Restoring the default works
+        apply_text(&mut c, "dataset_prefix", &original);
+        assert_eq!(c.dataset_prefix, original);
+    }
+
+    #[test]
+    fn text_hostname_sets_and_clears() {
+        let mut c = cfg();
+        apply_text(&mut c, "hostname", "archbox");
+        assert_eq!(c.hostname.as_deref(), Some("archbox"));
+        apply_text(&mut c, "hostname", "");
+        assert!(c.hostname.is_none());
+    }
+
+    #[test]
+    fn text_timezone_sets_and_clears() {
+        let mut c = cfg();
+        apply_text(&mut c, "timezone", "Europe/Berlin");
+        assert_eq!(c.timezone.as_deref(), Some("Europe/Berlin"));
+        apply_text(&mut c, "timezone", "");
+        assert!(c.timezone.is_none());
+    }
+
+    #[test]
+    fn text_root_password_sets_and_clears() {
+        let mut c = cfg();
+        apply_text(&mut c, "root_password", "hunter2");
+        assert_eq!(c.root_password.as_deref(), Some("hunter2"));
+        apply_text(&mut c, "root_password", "");
+        assert!(c.root_password.is_none());
+    }
+
+    #[test]
+    fn text_encryption_password_sets_and_clears() {
+        let mut c = cfg();
+        apply_text(&mut c, "encryption_password", "secret");
+        assert_eq!(c.zfs_encryption_password.as_deref(), Some("secret"));
+        apply_text(&mut c, "encryption_password", "");
+        assert!(c.zfs_encryption_password.is_none());
+    }
+
+    #[test]
+    fn text_parallel_downloads_clamps_and_rejects_garbage() {
+        let mut c = cfg();
+
+        apply_text(&mut c, "parallel_downloads", "8");
+        assert_eq!(c.parallel_downloads, 8);
+
+        // Above 20 → clamped to 20
+        apply_text(&mut c, "parallel_downloads", "100");
+        assert_eq!(c.parallel_downloads, 20);
+
+        // Zero → clamped to 1
+        apply_text(&mut c, "parallel_downloads", "0");
+        assert_eq!(c.parallel_downloads, 1);
+
+        // Garbage / non-numeric → previous value preserved
+        c.parallel_downloads = 5;
+        apply_text(&mut c, "parallel_downloads", "abc");
+        assert_eq!(c.parallel_downloads, 5);
+
+        // Negative parses fail (it's u32) → preserved
+        apply_text(&mut c, "parallel_downloads", "-3");
+        assert_eq!(c.parallel_downloads, 5);
+    }
+
+    #[test]
+    fn text_unknown_key_is_noop() {
+        let mut c = cfg();
+        let before_pool = c.pool_name.clone();
+        let before_hostname = c.hostname.clone();
+        let before_parallel = c.parallel_downloads;
+        apply_text(&mut c, "totally_made_up", "value");
+        assert_eq!(c.pool_name, before_pool);
+        assert_eq!(c.hostname, before_hostname);
+        assert_eq!(c.parallel_downloads, before_parallel);
+    }
+
+    // ── next_selectable_index ───────────────────────────
+
+    #[test]
+    fn next_selectable_skips_non_interactive_types() {
+        let items = vec![
+            ConfigItem {
+                key: "a".into(),
+                label: "A".into(),
+                value: "".into(),
+                item_type: ItemType::RadioHeader,
+            },
+            ConfigItem {
+                key: "b".into(),
+                label: "B".into(),
+                value: "".into(),
+                item_type: ItemType::RadioOption,
+            },
+            ConfigItem {
+                key: "c".into(),
+                label: "C".into(),
+                value: "".into(),
+                item_type: ItemType::Separator,
+            },
+            ConfigItem {
+                key: "d".into(),
+                label: "D".into(),
+                value: "".into(),
+                item_type: ItemType::Text,
+            },
+        ];
+
+        // From -1, going forward, the first selectable is index 1 (RadioOption)
+        assert_eq!(next_selectable_index(&items, -1, 1), 1);
+        // From 1, forward, skip Separator(2), land on Text(3)
+        assert_eq!(next_selectable_index(&items, 1, 1), 3);
+        // From 3, backward, skip Separator(2), land on RadioOption(1)
+        assert_eq!(next_selectable_index(&items, 3, -1), 1);
+    }
+
+    #[test]
+    fn next_selectable_wraps_around() {
+        let items = vec![
+            ConfigItem {
+                key: "a".into(),
+                label: "A".into(),
+                value: "".into(),
+                item_type: ItemType::Text,
+            },
+            ConfigItem {
+                key: "b".into(),
+                label: "B".into(),
+                value: "".into(),
+                item_type: ItemType::Toggle,
+            },
+        ];
+        // From last item, forward → wraps to first
+        assert_eq!(next_selectable_index(&items, 1, 1), 0);
+        // From first item, backward → wraps to last
+        assert_eq!(next_selectable_index(&items, 0, -1), 1);
+    }
+
+    #[test]
+    fn next_selectable_returns_minus_one_for_empty() {
+        let items: Vec<ConfigItem> = vec![];
+        assert_eq!(next_selectable_index(&items, -1, 1), -1);
+        assert_eq!(next_selectable_index(&items, 5, -1), -1);
+    }
+
+    #[test]
+    fn next_selectable_returns_current_when_no_interactive_items() {
+        let items = vec![
+            ConfigItem {
+                key: "".into(),
+                label: "".into(),
+                value: "".into(),
+                item_type: ItemType::Separator,
+            },
+            ConfigItem {
+                key: "".into(),
+                label: "".into(),
+                value: "".into(),
+                item_type: ItemType::Readonly,
+            },
+        ];
+        assert_eq!(next_selectable_index(&items, 0, 1), 0);
+    }
+}

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -66,22 +66,19 @@ export component App inherits Window {
     callback key-nav-up();
     callback key-nav-activate();
 
-    // ── Keyboard navigation ─────────────────────────
+    // ── Global keyboard shortcuts ──────────────────
+    // Wizard-local keys (j/k/arrows/Enter) live inside WizardView's own
+    // FocusScope; this scope only handles globally-meaningful shortcuts
+    // and is unconditionally active outside of popups and the install
+    // screen.
     main-focus-scope := FocusScope {
-        enabled: InstallState.state == 0 && !PopupState.select-visible && !PopupState.text-input-visible && !PopupState.users-visible && !PopupState.pkg-search-visible && !PopupState.strlist-visible;
+        enabled: InstallState.state == 0
+            && !PopupState.select-visible
+            && !PopupState.text-input-visible
+            && !PopupState.users-visible
+            && !PopupState.pkg-search-visible
+            && !PopupState.strlist-visible;
         key-pressed(e) => {
-            if e.text == Key.DownArrow || e.text == "j" {
-                key-nav-down();
-                return accept;
-            }
-            if e.text == Key.UpArrow || e.text == "k" {
-                key-nav-up();
-                return accept;
-            }
-            if e.text == Key.Return {
-                key-nav-activate();
-                return accept;
-            }
             if e.text == Key.Tab {
                 WizardState.next();
                 return accept;
@@ -114,6 +111,9 @@ export component App inherits Window {
         toggle-activated(key) => { toggle-activated(key); }
         install-requested() => { install-requested(); }
         quit-requested() => { quit-requested(); }
+        key-nav-down() => { key-nav-down(); }
+        key-nav-up() => { key-nav-up(); }
+        key-nav-activate() => { key-nav-activate(); }
     }
 
     // ── Install progress screen ──────────────────────

--- a/slint-ui/ui/views/welcome-view.slint
+++ b/slint-ui/ui/views/welcome-view.slint
@@ -136,8 +136,8 @@ export component WelcomeView inherits Rectangle {
                     }
 
                     // ZFS status
-                    Rectangle {
-                        height: WelcomeState.zfs-installing ? 72px : 48px;
+                    zfs-card := Rectangle {
+                        height: 48px;
                         background: Theme.c.surface0;
                         border-radius: 10px;
 
@@ -151,13 +151,9 @@ export component WelcomeView inherits Rectangle {
                                 padding-right: 16px;
                                 spacing: 12px;
 
-                                Text {
-                                    text: WelcomeState.zfs-ok ? "\u{2713}"
-                                        : WelcomeState.zfs-installing ? "\u{21bb}"
-                                        : "\u{2717}";
-                                    color: WelcomeState.zfs-ok ? Theme.c.green
-                                        : WelcomeState.zfs-installing ? Theme.c.blue
-                                        : Theme.c.overlay0;
+                                zfs-icon := Text {
+                                    text: "\u{2717}";
+                                    color: Theme.c.overlay0;
                                     font-size: 18px;
                                     vertical-alignment: center;
                                     width: 24px;
@@ -171,13 +167,9 @@ export component WelcomeView inherits Rectangle {
                                     horizontal-stretch: 1;
                                 }
 
-                                Text {
-                                    text: WelcomeState.zfs-ok ? "Ready"
-                                        : WelcomeState.zfs-installing ? WelcomeState.zfs-install-status
-                                        : "Waiting for network...";
-                                    color: WelcomeState.zfs-ok ? Theme.c.green
-                                        : WelcomeState.zfs-installing ? Theme.c.blue
-                                        : Theme.c.overlay0;
+                                zfs-status := Text {
+                                    text: "Waiting for network...";
+                                    color: Theme.c.overlay0;
                                     font-size: 13px;
                                     vertical-alignment: center;
                                 }
@@ -204,6 +196,25 @@ export component WelcomeView inherits Rectangle {
                                 height: 12px;
                             }
                         }
+
+                        // Three-way state: idle (base) → installing → ready.
+                        // Last match wins, so `ready` overrides `installing` if
+                        // both somehow match.
+                        states [
+                            installing when WelcomeState.zfs-installing: {
+                                zfs-card.height: 72px;
+                                zfs-icon.text: "\u{21bb}";
+                                zfs-icon.color: Theme.c.blue;
+                                zfs-status.text: WelcomeState.zfs-install-status;
+                                zfs-status.color: Theme.c.blue;
+                            }
+                            ready when WelcomeState.zfs-ok: {
+                                zfs-icon.text: "\u{2713}";
+                                zfs-icon.color: Theme.c.green;
+                                zfs-status.text: "Ready";
+                                zfs-status.color: Theme.c.green;
+                            }
+                        ]
                     }
                 }
 
@@ -211,12 +222,10 @@ export component WelcomeView inherits Rectangle {
                 HorizontalLayout {
                     alignment: center;
 
-                    Rectangle {
+                    start-button := Rectangle {
                         width: 160px;
                         height: 44px;
-                        background: WelcomeState.all-checks-ok
-                            ? (start-ta.has-hover ? Theme.c.sky : Theme.c.blue)
-                            : Theme.c.surface1;
+                        background: Theme.c.surface1;
                         border-radius: 10px;
 
                         start-ta := TouchArea {
@@ -225,14 +234,25 @@ export component WelcomeView inherits Rectangle {
                             clicked => { WizardState.go-to(1); }
                         }
 
-                        Text {
+                        start-text := Text {
                             text: "Get Started \u{2192}";
-                            color: WelcomeState.all-checks-ok ? Theme.c.base : Theme.c.overlay0;
+                            color: Theme.c.overlay0;
                             font-size: 15px;
                             font-weight: FontWeight.semi-bold;
                             horizontal-alignment: center;
                             vertical-alignment: center;
                         }
+
+                        states [
+                            ready when WelcomeState.all-checks-ok: {
+                                start-button.background: Theme.c.blue;
+                                start-text.color: Theme.c.base;
+                            }
+                            ready-hover when WelcomeState.all-checks-ok && start-ta.has-hover: {
+                                start-button.background: Theme.c.sky;
+                                start-text.color: Theme.c.base;
+                            }
+                        ]
                     }
                 }
 

--- a/slint-ui/ui/views/wizard-view.slint
+++ b/slint-ui/ui/views/wizard-view.slint
@@ -4,6 +4,7 @@
 import { ScrollView } from "std-widgets.slint";
 import { Theme } from "../styling.slint";
 import { WizardState } from "../state/wizard-state.slint";
+import { PopupState } from "../state/popup-state.slint";
 import { SidebarItem } from "../components/sidebar-item.slint";
 import { ConfigItemRow } from "../components/config-item.slint";
 
@@ -13,8 +14,46 @@ export component WizardView inherits VerticalLayout {
     callback install-requested();
     callback quit-requested();
 
+    // Wizard-local keyboard navigation. Emitted from `wizard-focus-scope`
+    // and bound to Rust's on_key_nav_* handlers in app.slint.
+    callback key-nav-down();
+    callback key-nav-up();
+    callback key-nav-activate();
+
     padding: 0px;
     spacing: 0px;
+
+    // Wizard-local FocusScope: handles arrow / j / k / Enter for the items
+    // list. Global shortcuts (Tab/Backtab/q/1–7) live in the App root scope
+    // and pick up events that this scope rejects.
+    wizard-focus-scope := FocusScope {
+        x: 0;
+        width: 0px;
+        height: 0px;
+        enabled: !PopupState.select-visible
+            && !PopupState.text-input-visible
+            && !PopupState.users-visible
+            && !PopupState.strlist-visible
+            && !PopupState.pkg-search-visible;
+
+        key-pressed(event) => {
+            if event.text == Key.DownArrow || event.text == "j" {
+                root.key-nav-down();
+                return accept;
+            }
+            if event.text == Key.UpArrow || event.text == "k" {
+                root.key-nav-up();
+                return accept;
+            }
+            if event.text == Key.Return {
+                root.key-nav-activate();
+                return accept;
+            }
+            return reject;
+        }
+    }
+
+    init => { wizard-focus-scope.focus(); }
 
     // Title bar
     Rectangle {


### PR DESCRIPTION
Three small follow-ups to #40, each landing a different bucket-3 polish item.

- 22 unit tests for `config_items::apply_radio` / `apply_text` / `next_selectable_index`. Locks in the surprising behaviors that are easy to break in a refactor: installation_mode clears the by-id selections only when the mode actually changes; encryption clears the password going to None but keeps it switching Pool↔Dataset; dataset_prefix treats empty as a no-op; parallel_downloads clamps to 1..=20 and ignores garbage; next_selectable_index skips Separator/Readonly/Warning/RadioHeader, wraps around, and handles empty slices.
- Two-tier keyboard focus. The arrow/j/k/Enter keys move out of the App-root FocusScope into a wizard-local zero-width FocusScope inside `WizardView`. The wizard scope grabs focus on init and bubbles unhandled events up to the root, which now only handles globally-meaningful shortcuts (Tab/Backtab/q/1–7). Side benefit: arrows and Enter no longer fire on the welcome screen, where they had no useful effect.
- `states[]` blocks for the ZFS status card and the Start button in `welcome-view`. The 3-way `zfs-ok ? ... : zfs-installing ? ... : ...` ternary chain on icon/text/color/card-height becomes a base + two ordered states (last match wins). The Start button gets `ready` and `ready-hover` states layered over the disabled base. Pure cleanup, no behavioral change.

No Rust API changes; no `app.slint` or controller signature changes. Both linuxkms (default) and desktop feature flags build clean and `cargo test -p archinstall-zfs-slint` is green.

## Testing

- [x] `cargo test -p archinstall-zfs-slint` — 22/22
- [x] `cargo build -p archinstall-zfs-slint` (linuxkms)
- [x] `cargo build -p archinstall-zfs-slint --no-default-features --features desktop`
- [ ] Manual VM smoke test of welcome → wizard → install