### PR TITLE
Profile redesign: ProfileKind/ProfileSelection + GUI sub-prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,43 @@ A custom ZED hook (`history_event-zfs-list-cacher.sh`) ensures only the current 
 - Builds using a temporary user (`aurinstall`) with temporary passwordless sudo
 - Cleans up temp user and build artifacts after installation
 
+### Profiles
+
+Profiles bundle a desktop environment, window manager, or server role with the
+packages, services, display manager, and post-install hooks needed to make it
+work end-to-end. Both the TUI and GUI ask follow-up questions only when they're
+actually relevant: a desktop profile prompts for optional packages, display
+manager override, and (for Wayland compositors) seat access; a server profile
+skips all of those.
+
+> **One profile per install.** Unlike upstream archinstall you can't compose
+> several profiles in one run (no `gnome + i3` or `sshd + docker + postgresql`
+> in a single pick). If you need a combination, choose the closest profile and
+> add the extras through the **Extra packages** picker, plus **Extra services**
+> for any units that need enabling. We trade composition for simpler
+> reproducibility — your config JSON always names exactly one profile.
+
+The profile-scoped settings live inside a `profile_selection` block in the
+config JSON, and switching profiles atomically replaces the whole block so
+stale fields can never leak between selections:
+
+```json
+{
+  "profile_selection": {
+    "profile": "hyprland",
+    "optional_packages": ["hyprpaper", "hyprlock", "wl-clipboard"],
+    "display_manager_override": null,
+    "seat_access": "seatd"
+  },
+  "gfx_driver": "nvidia_open"
+}
+```
+
+GPU driver, audio server, and Bluetooth stay top-level because they're useful
+on headless installs too. The GPU driver picker is hidden for non-graphical
+profiles, and selecting the proprietary NVIDIA driver with a Wayland-only
+compositor surfaces a warning (TUI shows a confirmation, GUI an inline notice).
+
 ### Snapshot management (optional)
 - zrepl support for automatic snapshot creation and retention
 - Schedules: 15-minute intervals with tiered retention (4x15m, 24x1h, 3x1d)

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -195,12 +195,9 @@ pub struct GlobalConfig {
     pub users: Option<Vec<UserConfig>>,
     pub kernels: Option<Vec<String>>,
     /// User's profile choice plus all profile-scoped sub-selections
-    /// (optional packages, DM override, seat access).
-    ///
-    /// Replaces the previous flat `profile` / `display_manager_override` /
-    /// `seat_access` fields. The whole struct is replaced atomically when
-    /// the user switches profiles, so stale settings cannot leak across.
-    #[serde(default, alias = "profile")]
+    /// (optional packages, DM override, seat access). Atomic replace on
+    /// profile switch, so stale settings cannot leak across.
+    #[serde(default)]
     pub profile_selection: Option<ProfileSelection>,
     /// GPU driver (independent of profile — useful for headless installs too).
     pub gfx_driver: Option<GfxDriver>,

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::profile::DisplayManager;
 use crate::system::gpu::GfxDriver;
 
 pub const ZFS_PASSPHRASE_MIN_LENGTH: usize = 8;
@@ -192,14 +194,16 @@ pub struct GlobalConfig {
     pub root_password: Option<String>,
     pub users: Option<Vec<UserConfig>>,
     pub kernels: Option<Vec<String>>,
-    pub profile: Option<String>,
+    /// User's profile choice plus all profile-scoped sub-selections
+    /// (optional packages, DM override, seat access).
+    ///
+    /// Replaces the previous flat `profile` / `display_manager_override` /
+    /// `seat_access` fields. The whole struct is replaced atomically when
+    /// the user switches profiles, so stale settings cannot leak across.
+    #[serde(default, alias = "profile")]
+    pub profile_selection: Option<ProfileSelection>,
+    /// GPU driver (independent of profile — useful for headless installs too).
     pub gfx_driver: Option<GfxDriver>,
-    /// Override the display manager provided by the selected profile.
-    #[serde(default)]
-    pub display_manager_override: Option<String>,
-    /// Seat access mechanism for Wayland compositors.
-    #[serde(default)]
-    pub seat_access: Option<SeatAccess>,
     pub mirror_regions: Option<Vec<String>>,
     #[serde(default)]
     pub additional_packages: Vec<String>,
@@ -228,6 +232,74 @@ pub struct UserConfig {
     pub ssh_authorized_keys: Vec<String>,
     #[serde(default)]
     pub autologin: bool,
+}
+
+/// User selection for a profile, plus all profile-scoped settings derived
+/// from it. Replacing this struct atomically guarantees stale fields can't
+/// leak between profile switches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileSelection {
+    /// Profile registry key (e.g. `"gnome"`).
+    pub profile: String,
+    /// Optional extras the user enabled. Subset of the profile's
+    /// `optional_packages`. Sorted for stable diffs.
+    #[serde(default)]
+    pub optional_packages: BTreeSet<String>,
+    /// User-chosen DM override. `None` means "use the profile's default DM".
+    #[serde(default)]
+    pub display_manager_override: Option<DisplayManager>,
+    /// Seat access for Wayland compositors. Only meaningful when the
+    /// underlying profile has `needs_seat_access = true`.
+    #[serde(default)]
+    pub seat_access: Option<SeatAccess>,
+}
+
+impl ProfileSelection {
+    /// Create a fresh selection for `profile_name` with sensible defaults
+    /// pulled from the registry. Returns `None` if the profile is unknown.
+    pub fn new(profile_name: &str) -> Option<Self> {
+        let p = crate::profile::get_profile(profile_name)?;
+        Some(Self {
+            profile: profile_name.to_string(),
+            optional_packages: BTreeSet::new(),
+            display_manager_override: None,
+            // Pre-fill seatd as a sensible default for Wayland compositors
+            // that need explicit seat access; user can override.
+            seat_access: if p.needs_seat_access() {
+                Some(SeatAccess::Seatd)
+            } else {
+                None
+            },
+        })
+    }
+
+    /// Resolve this selection's profile in the registry. Returns `None`
+    /// when the profile name no longer exists (e.g. after a downgrade).
+    pub fn profile_def(&self) -> Option<crate::profile::Profile> {
+        crate::profile::get_profile(&self.profile)
+    }
+
+    /// Effective DM = explicit override, falling back to the profile default.
+    pub fn effective_display_manager(&self) -> Option<DisplayManager> {
+        self.display_manager_override
+            .or_else(|| self.profile_def().and_then(|p| p.default_display_manager()))
+    }
+
+    /// Profile packages ∪ chosen optionals. Does *not* include the DM
+    /// package — the installer enables/installs the DM separately so it can
+    /// also handle overrides.
+    pub fn resolved_packages(&self) -> Vec<String> {
+        let Some(p) = self.profile_def() else {
+            return Vec::new();
+        };
+        let mut out: Vec<String> = p.packages.iter().map(|s| s.to_string()).collect();
+        for opt in &self.optional_packages {
+            if !out.contains(opt) {
+                out.push(opt.clone());
+            }
+        }
+        out
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -299,10 +371,8 @@ impl Default for GlobalConfig {
             root_password: None,
             users: None,
             kernels: None,
-            profile: None,
+            profile_selection: None,
             gfx_driver: None,
-            display_manager_override: None,
-            seat_access: None,
             mirror_regions: None,
             additional_packages: Vec::new(),
             network_copy_iso: false,

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -244,12 +244,13 @@ impl Installer {
     }
 
     fn install_profile(&mut self) -> Result<()> {
-        if let Some(profile_name) = self.config.profile.clone() {
-            let profile = crate::profile::get_profile(&profile_name);
-            if let Some(p) = profile {
-                // 1. Install packages
-                if !p.packages.is_empty() {
-                    let pkg_refs: Vec<&str> = p.packages.to_vec();
+        if let Some(selection) = self.config.profile_selection.clone() {
+            let profile_name = selection.profile.clone();
+            if let Some(p) = selection.profile_def() {
+                // 1. Install packages (profile base + chosen optionals)
+                let pkgs = selection.resolved_packages();
+                if !pkgs.is_empty() {
+                    let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
                     self.install_target_packages(&pkg_refs)?;
                 }
 
@@ -263,31 +264,39 @@ impl Installer {
                     services::enable_user_service(&*self.runner, &self.target, service)?;
                 }
 
-                // 4. Autologin — use effective DM (override or profile default)
-                let eff_dm = self.effective_display_manager(&p);
-                if let Some(dm) = eff_dm
-                    && let Some(ref user_list) = self.config.users
-                    && let Some(user) = user_list.iter().find(|u| u.autologin)
-                {
-                    let session = sddm_session_for_profile(&profile_name);
-                    autologin::configure(&*self.runner, &self.target, dm, &user.username, session)?;
-                }
-
-                // 5. Display manager override
-                if let Some(ref new_dm) = self.config.display_manager_override.clone() {
-                    let profile_dm = p.display_manager();
-                    if Some(new_dm.as_str()) != profile_dm {
-                        self.install_target_packages(&[new_dm.as_str()])?;
-                        if let Some(old_dm) = profile_dm {
-                            services::disable_service(&*self.runner, &self.target, old_dm)?;
+                // 4. Display manager — install + enable the effective DM.
+                //    If the user picked a different DM than the profile default,
+                //    install the override package and disable the original.
+                let profile_dm = p.default_display_manager();
+                let effective_dm = selection.effective_display_manager();
+                if let Some(dm) = effective_dm {
+                    let is_override = profile_dm != Some(dm);
+                    if is_override {
+                        self.install_target_packages(&[dm.package()])?;
+                        if let Some(old) = profile_dm {
+                            services::disable_service(&*self.runner, &self.target, old.service())?;
                         }
-                        services::enable_service(&*self.runner, &self.target, new_dm)?;
+                    }
+                    services::enable_service(&*self.runner, &self.target, dm.service())?;
+
+                    // 5. Autologin
+                    if let Some(ref user_list) = self.config.users
+                        && let Some(user) = user_list.iter().find(|u| u.autologin)
+                    {
+                        let session = p.sddm_session();
+                        autologin::configure(
+                            &*self.runner,
+                            &self.target,
+                            dm.service(),
+                            &user.username,
+                            session,
+                        )?;
                     }
                 }
 
                 // 6. Seat access for Wayland compositors
-                if p.needs_seat_access {
-                    self.configure_seat_access()?;
+                if p.needs_seat_access() {
+                    self.configure_seat_access(selection.seat_access)?;
                 }
 
                 // 7. Post-install steps (db init, group membership, etc.)
@@ -335,24 +344,16 @@ impl Installer {
         Ok(())
     }
 
-    /// Return the display manager to use: `display_manager_override` takes
-    /// priority over the profile's built-in DM.
-    fn effective_display_manager<'a>(
-        &'a self,
-        profile: &'a crate::profile::Profile,
-    ) -> Option<&'a str> {
-        self.config
-            .display_manager_override
-            .as_deref()
-            .or_else(|| profile.display_manager())
-    }
-
-    /// Configure seat access for Wayland compositors based on `config.seat_access`.
-    fn configure_seat_access(&mut self) -> Result<()> {
+    /// Configure seat access for Wayland compositors. The mode is taken
+    /// from the active profile selection (`ProfileSelection::seat_access`).
+    fn configure_seat_access(
+        &mut self,
+        seat: Option<crate::config::types::SeatAccess>,
+    ) -> Result<()> {
         use crate::config::types::SeatAccess;
         use crate::system::cmd::{check_exit, chroot_cmd};
 
-        match self.config.seat_access {
+        match seat {
             Some(SeatAccess::Seatd) => {
                 self.install_target_packages(&["seatd"])?;
                 services::enable_service(&*self.runner, &self.target, "seatd")?;
@@ -622,22 +623,6 @@ impl Installer {
         }
 
         Ok(())
-    }
-}
-
-/// Map an installer profile name to the SDDM session name (.desktop file stem).
-/// Returns `None` when the mapping is unknown — SDDM will use its default.
-fn sddm_session_for_profile(profile: &str) -> Option<&'static str> {
-    match profile {
-        "kde" => Some("plasma"),
-        "hyprland" => Some("hyprland"),
-        "sway" => Some("sway"),
-        "i3" => Some("i3"),
-        "lxqt" => Some("lxqt"),
-        "labwc" => Some("labwc"),
-        "niri" => Some("niri"),
-        "river" => Some("river"),
-        _ => None,
     }
 }
 

--- a/core/src/profile/desktop.rs
+++ b/core/src/profile/desktop.rs
@@ -1,19 +1,60 @@
-use super::Profile;
+use super::{DesktopProfile, DisplayManager, DisplayServer, OptionalPackage, Profile, ProfileKind};
+
+/// Helper to keep desktop profile literals concise.
+#[allow(clippy::too_many_arguments)]
+fn desktop(
+    name: &'static str,
+    display_name: &'static str,
+    packages: Vec<&'static str>,
+    display_server: DisplayServer,
+    default_display_manager: Option<DisplayManager>,
+    needs_seat_access: bool,
+    sddm_session: Option<&'static str>,
+    optional_packages: Vec<OptionalPackage>,
+) -> Profile {
+    Profile {
+        name,
+        display_name,
+        description: "",
+        packages,
+        services: Vec::new(),
+        user_services: Vec::new(),
+        post_install_steps: Vec::new(),
+        kind: ProfileKind::Desktop(DesktopProfile {
+            display_server,
+            default_display_manager,
+            needs_seat_access,
+            sddm_session,
+            optional_packages,
+        }),
+    }
+}
+
+/// Convenience: build a `Vec<OptionalPackage>` from a list of bare package
+/// names. Descriptions can be filled in later.
+fn opts(pkgs: &[&'static str]) -> Vec<OptionalPackage> {
+    pkgs.iter().copied().map(OptionalPackage::new).collect()
+}
 
 pub fn desktop_profiles() -> Vec<Profile> {
+    use DisplayManager::*;
+    use DisplayServer::*;
+
     vec![
-        Profile {
-            name: "gnome",
-            display_name: "GNOME",
-            packages: vec!["gnome", "gnome-tweaks"],
-            services: vec!["gdm"],
-            optional_packages: vec!["gnome-extra", "gnome-software", "flatpak"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "kde",
-            display_name: "KDE Plasma",
-            packages: vec![
+        desktop(
+            "gnome",
+            "GNOME",
+            vec!["gnome", "gnome-tweaks"],
+            Both,
+            Some(Gdm),
+            false,
+            None,
+            opts(&["gnome-extra", "gnome-software", "flatpak"]),
+        ),
+        desktop(
+            "kde",
+            "KDE Plasma",
+            vec![
                 "plasma-desktop",
                 "konsole",
                 "kate",
@@ -21,22 +62,26 @@ pub fn desktop_profiles() -> Vec<Profile> {
                 "ark",
                 "plasma-workspace",
             ],
-            services: vec!["sddm"],
-            optional_packages: vec!["kde-applications", "flatpak", "discover"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "xfce",
-            display_name: "Xfce",
-            packages: vec!["xfce4", "xfce4-goodies", "pavucontrol", "gvfs", "xarchiver"],
-            services: vec!["lightdm"],
-            optional_packages: vec!["thunar", "mousepad", "ristretto"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "cinnamon",
-            display_name: "Cinnamon",
-            packages: vec![
+            Both,
+            Some(Sddm),
+            false,
+            Some("plasma"),
+            opts(&["kde-applications", "flatpak", "discover"]),
+        ),
+        desktop(
+            "xfce",
+            "Xfce",
+            vec!["xfce4", "xfce4-goodies", "pavucontrol", "gvfs", "xarchiver"],
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            opts(&["thunar", "mousepad", "ristretto"]),
+        ),
+        desktop(
+            "cinnamon",
+            "Cinnamon",
+            vec![
                 "cinnamon",
                 "system-config-printer",
                 "gnome-keyring",
@@ -47,40 +92,52 @@ pub fn desktop_profiles() -> Vec<Profile> {
                 "xed",
                 "xdg-user-dirs-gtk",
             ],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "budgie",
-            display_name: "Budgie",
-            packages: vec![
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "budgie",
+            "Budgie",
+            vec![
                 "materia-gtk-theme",
                 "budgie",
                 "mate-terminal",
                 "nemo",
                 "papirus-icon-theme",
             ],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "mate",
-            display_name: "MATE",
-            packages: vec!["mate", "mate-extra"],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "deepin",
-            display_name: "Deepin",
-            packages: vec!["deepin", "deepin-terminal", "deepin-editor"],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "lxqt",
-            display_name: "LXQt",
-            packages: vec![
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "mate",
+            "MATE",
+            vec!["mate", "mate-extra"],
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "deepin",
+            "Deepin",
+            vec!["deepin", "deepin-terminal", "deepin-editor"],
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "lxqt",
+            "LXQt",
+            vec![
                 "lxqt",
                 "breeze-icons",
                 "oxygen-icons",
@@ -89,13 +146,16 @@ pub fn desktop_profiles() -> Vec<Profile> {
                 "l3afpad",
                 "slock",
             ],
-            services: vec!["sddm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "hyprland",
-            display_name: "Hyprland",
-            packages: vec![
+            Xorg,
+            Some(Sddm),
+            false,
+            Some("lxqt"),
+            Vec::new(),
+        ),
+        desktop(
+            "hyprland",
+            "Hyprland",
+            vec![
                 "hyprland",
                 "dunst",
                 "kitty",
@@ -109,22 +169,23 @@ pub fn desktop_profiles() -> Vec<Profile> {
                 "grim",
                 "slurp",
             ],
-            services: vec!["sddm"],
-            needs_seat_access: true,
-            optional_packages: vec![
+            Wayland,
+            Some(Sddm),
+            true,
+            Some("hyprland"),
+            opts(&[
                 "hyprpaper",
                 "hypridle",
                 "hyprlock",
                 "swww",
                 "mako",
                 "wl-clipboard",
-            ],
-            ..Profile::default()
-        },
-        Profile {
-            name: "sway",
-            display_name: "Sway",
-            packages: vec![
+            ]),
+        ),
+        desktop(
+            "sway",
+            "Sway",
+            vec![
                 "sway",
                 "swaybg",
                 "swaylock",
@@ -138,15 +199,16 @@ pub fn desktop_profiles() -> Vec<Profile> {
                 "foot",
                 "xorg-xwayland",
             ],
-            services: vec!["lightdm"],
-            needs_seat_access: true,
-            optional_packages: vec!["swaylock-effects", "wl-clipboard", "mako"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "i3",
-            display_name: "i3",
-            packages: vec![
+            Wayland,
+            Some(Lightdm),
+            true,
+            Some("sway"),
+            opts(&["swaylock-effects", "wl-clipboard", "mako"]),
+        ),
+        desktop(
+            "i3",
+            "i3",
+            vec![
                 "i3-wm",
                 "i3lock",
                 "i3status",
@@ -154,84 +216,95 @@ pub fn desktop_profiles() -> Vec<Profile> {
                 "xss-lock",
                 "xterm",
                 "lightdm-gtk-greeter",
-                "lightdm",
                 "dmenu",
             ],
-            services: vec!["lightdm"],
-            optional_packages: vec!["polybar", "rofi", "feh", "nitrogen"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "cosmic",
-            display_name: "COSMIC",
-            packages: vec!["cosmic", "xdg-user-dirs"],
-            services: vec!["cosmic-greeter"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "enlightenment",
-            display_name: "Enlightenment",
-            packages: vec![
+            Xorg,
+            Some(Lightdm),
+            false,
+            Some("i3"),
+            opts(&["polybar", "rofi", "feh", "nitrogen"]),
+        ),
+        desktop(
+            "cosmic",
+            "COSMIC",
+            vec!["cosmic", "xdg-user-dirs"],
+            Wayland,
+            Some(CosmicGreeter),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "enlightenment",
+            "Enlightenment",
+            vec![
                 "enlightenment",
                 "terminology",
-                "lightdm",
                 "lightdm-gtk-greeter",
                 "xdg-user-dirs",
             ],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "awesome",
-            display_name: "Awesome",
-            packages: vec![
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "awesome",
+            "Awesome",
+            vec![
                 "awesome",
                 "xterm",
-                "lightdm",
                 "lightdm-gtk-greeter",
                 "dmenu",
                 "picom",
                 "xdg-user-dirs",
             ],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "bspwm",
-            display_name: "Bspwm",
-            packages: vec![
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "bspwm",
+            "Bspwm",
+            vec![
                 "bspwm",
                 "sxhkd",
                 "xterm",
-                "lightdm",
                 "lightdm-gtk-greeter",
                 "dmenu",
                 "picom",
                 "xdg-user-dirs",
             ],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "labwc",
-            display_name: "LabWC",
-            packages: vec![
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "labwc",
+            "LabWC",
+            vec![
                 "labwc",
                 "waybar",
                 "foot",
                 "fuzzel",
                 "xdg-desktop-portal-wlr",
                 "xdg-user-dirs",
-                "sddm",
             ],
-            services: vec!["sddm"],
-            needs_seat_access: true,
-            ..Profile::default()
-        },
-        Profile {
-            name: "niri",
-            display_name: "Niri",
-            packages: vec![
+            Wayland,
+            Some(Sddm),
+            true,
+            Some("labwc"),
+            Vec::new(),
+        ),
+        desktop(
+            "niri",
+            "Niri",
+            vec![
                 "niri",
                 "foot",
                 "fuzzel",
@@ -239,56 +312,62 @@ pub fn desktop_profiles() -> Vec<Profile> {
                 "xdg-desktop-portal-gnome",
                 "xwayland-satellite",
                 "xdg-user-dirs",
-                "sddm",
             ],
-            services: vec!["sddm"],
-            needs_seat_access: true,
-            ..Profile::default()
-        },
-        Profile {
-            name: "qtile",
-            display_name: "Qtile",
-            packages: vec![
+            Wayland,
+            Some(Sddm),
+            true,
+            Some("niri"),
+            Vec::new(),
+        ),
+        desktop(
+            "qtile",
+            "Qtile",
+            vec![
                 "qtile",
                 "xterm",
-                "lightdm",
                 "lightdm-gtk-greeter",
                 "dmenu",
                 "xdg-user-dirs",
             ],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "river",
-            display_name: "River",
-            packages: vec![
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
+        desktop(
+            "river",
+            "River",
+            vec![
                 "river",
                 "foot",
                 "fuzzel",
                 "waybar",
                 "xdg-desktop-portal-wlr",
                 "xdg-user-dirs",
-                "sddm",
             ],
-            services: vec!["sddm"],
-            needs_seat_access: true,
-            ..Profile::default()
-        },
-        Profile {
-            name: "xmonad",
-            display_name: "XMonad",
-            packages: vec![
+            Wayland,
+            Some(Sddm),
+            true,
+            Some("river"),
+            Vec::new(),
+        ),
+        desktop(
+            "xmonad",
+            "XMonad",
+            vec![
                 "xmonad",
                 "xmonad-contrib",
                 "xterm",
-                "lightdm",
                 "lightdm-gtk-greeter",
                 "dmenu",
                 "xdg-user-dirs",
             ],
-            services: vec!["lightdm"],
-            ..Profile::default()
-        },
+            Xorg,
+            Some(Lightdm),
+            false,
+            None,
+            Vec::new(),
+        ),
     ]
 }

--- a/core/src/profile/desktop.rs
+++ b/core/src/profile/desktop.rs
@@ -30,10 +30,12 @@ fn desktop(
     }
 }
 
-/// Convenience: build a `Vec<OptionalPackage>` from a list of bare package
-/// names. Descriptions can be filled in later.
-fn opts(pkgs: &[&'static str]) -> Vec<OptionalPackage> {
-    pkgs.iter().copied().map(OptionalPackage::new).collect()
+/// Convenience: build a `Vec<OptionalPackage>` from `(package, description)`
+/// pairs. Pass an empty description to leave it blank.
+fn opts(pkgs: &[(&'static str, &'static str)]) -> Vec<OptionalPackage> {
+    pkgs.iter()
+        .map(|(p, d)| OptionalPackage::with_desc(p, d))
+        .collect()
 }
 
 pub fn desktop_profiles() -> Vec<Profile> {
@@ -41,6 +43,19 @@ pub fn desktop_profiles() -> Vec<Profile> {
     use DisplayServer::*;
 
     vec![
+        // Bare X server with no DE/WM/DM. Use this when you want to install
+        // X yourself or pair it with a window manager that isn't packaged
+        // here. Mirrors upstream archinstall's `Xorg` top-level profile.
+        desktop(
+            "xorg",
+            "Xorg (bare)",
+            vec!["xorg-server", "xorg-xinit"],
+            Xorg,
+            None,
+            false,
+            None,
+            Vec::new(),
+        ),
         desktop(
             "gnome",
             "GNOME",
@@ -49,7 +64,14 @@ pub fn desktop_profiles() -> Vec<Profile> {
             Some(Gdm),
             false,
             None,
-            opts(&["gnome-extra", "gnome-software", "flatpak"]),
+            opts(&[
+                (
+                    "gnome-extra",
+                    "Extra GNOME apps (Maps, Weather, Calendar, …)",
+                ),
+                ("gnome-software", "Software centre with Flatpak support"),
+                ("flatpak", "Sandboxed application runtime"),
+            ]),
         ),
         desktop(
             "kde",
@@ -66,7 +88,14 @@ pub fn desktop_profiles() -> Vec<Profile> {
             Some(Sddm),
             false,
             Some("plasma"),
-            opts(&["kde-applications", "flatpak", "discover"]),
+            opts(&[
+                (
+                    "kde-applications",
+                    "Full KDE application suite (Okular, Gwenview, …)",
+                ),
+                ("flatpak", "Sandboxed application runtime"),
+                ("discover", "KDE software centre"),
+            ]),
         ),
         desktop(
             "xfce",
@@ -76,7 +105,11 @@ pub fn desktop_profiles() -> Vec<Profile> {
             Some(Lightdm),
             false,
             None,
-            opts(&["thunar", "mousepad", "ristretto"]),
+            opts(&[
+                ("thunar", "File manager"),
+                ("mousepad", "Lightweight text editor"),
+                ("ristretto", "Image viewer"),
+            ]),
         ),
         desktop(
             "cinnamon",
@@ -174,12 +207,12 @@ pub fn desktop_profiles() -> Vec<Profile> {
             true,
             Some("hyprland"),
             opts(&[
-                "hyprpaper",
-                "hypridle",
-                "hyprlock",
-                "swww",
-                "mako",
-                "wl-clipboard",
+                ("hyprpaper", "Wallpaper utility from the Hyprland project"),
+                ("hypridle", "Idle daemon (auto-lock, dim, sleep)"),
+                ("hyprlock", "Screen locker"),
+                ("swww", "Animated wallpaper daemon"),
+                ("mako", "Wayland notification daemon"),
+                ("wl-clipboard", "Clipboard helper (wl-copy / wl-paste)"),
             ]),
         ),
         desktop(
@@ -203,7 +236,14 @@ pub fn desktop_profiles() -> Vec<Profile> {
             Some(Lightdm),
             true,
             Some("sway"),
-            opts(&["swaylock-effects", "wl-clipboard", "mako"]),
+            opts(&[
+                (
+                    "swaylock-effects",
+                    "swaylock fork with blur/screenshot effects",
+                ),
+                ("wl-clipboard", "Clipboard helper (wl-copy / wl-paste)"),
+                ("mako", "Wayland notification daemon"),
+            ]),
         ),
         desktop(
             "i3",
@@ -222,7 +262,12 @@ pub fn desktop_profiles() -> Vec<Profile> {
             Some(Lightdm),
             false,
             Some("i3"),
-            opts(&["polybar", "rofi", "feh", "nitrogen"]),
+            opts(&[
+                ("polybar", "Modular status bar"),
+                ("rofi", "Application launcher and dmenu replacement"),
+                ("feh", "Image viewer often used to set wallpaper"),
+                ("nitrogen", "Graphical wallpaper setter"),
+            ]),
         ),
         desktop(
             "cosmic",

--- a/core/src/profile/mod.rs
+++ b/core/src/profile/mod.rs
@@ -1,5 +1,28 @@
+//! Profile registry.
+//!
+//! A `Profile` is a named bundle of packages, services, and post-install
+//! steps. Behavior that is specific to a *kind* of profile (desktop vs server
+//! vs minimal) lives inside `ProfileKind` so that fields are only present
+//! where they actually apply.
+//!
+//! ## Design notes
+//!
+//! - Common fields (name, display_name, packages, services, …) live on
+//!   `Profile`.
+//! - Kind-specific fields (display manager, seat access, optional packages,
+//!   sddm session) live inside `ProfileKind::Desktop(DesktopProfile)`. Server
+//!   and minimal profiles carry no extra data.
+//! - Display managers are typed via the `DisplayManager` enum rather than
+//!   stringly-typed inside `services`. The DM is *not* duplicated in
+//!   `services` — `install_profile` enables it explicitly via
+//!   `DisplayManager::service()`.
+//! - User-visible selection state lives in
+//!   `crate::config::types::ProfileSelection`, not on `Profile`.
+
 pub mod desktop;
 pub mod server;
+
+use serde::{Deserialize, Serialize};
 
 /// A post-installation step to run after packages and services are configured.
 #[derive(Debug, Clone)]
@@ -21,40 +44,181 @@ pub enum PostInstallStep {
     AddUsersToGroup { group: &'static str },
 }
 
-#[derive(Default)]
+/// Top-level profile definition. Common fields apply to every kind; the
+/// `kind` discriminant carries kind-specific data.
+#[derive(Debug, Clone)]
 pub struct Profile {
     pub name: &'static str,
     pub display_name: &'static str,
+    /// Short user-facing description. May be empty.
+    pub description: &'static str,
     pub packages: Vec<&'static str>,
-    /// Optional extras shown in a multi-select checklist after profile selection.
-    /// User choices are merged into `GlobalConfig::additional_packages`.
-    pub optional_packages: Vec<&'static str>,
     pub services: Vec<&'static str>,
     /// User-level systemd units enabled globally via `systemctl --global enable`.
-    /// Primarily used for PipeWire (handled separately by the audio block) and
-    /// any compositor-specific user services.
     pub user_services: Vec<&'static str>,
-    /// Whether this profile requires seat access configuration (Wayland compositors).
-    pub needs_seat_access: bool,
     /// Steps run after packages and services are set up.
     pub post_install_steps: Vec<PostInstallStep>,
+    pub kind: ProfileKind,
 }
 
-const DISPLAY_MANAGERS: &[&str] = &["gdm", "sddm", "lightdm", "ly", "cosmic-greeter"];
+#[derive(Debug, Clone)]
+pub enum ProfileKind {
+    /// Bare minimal install — no extras beyond the base system.
+    Minimal,
+    /// Headless / server profile.
+    Server,
+    /// Graphical desktop profile.
+    Desktop(DesktopProfile),
+}
+
+#[derive(Debug, Clone)]
+pub struct DesktopProfile {
+    /// Which display server protocol the profile expects to run under.
+    pub display_server: DisplayServer,
+    /// Display manager shipped with the profile, if any.
+    /// Some Wayland compositors are launched directly without a DM.
+    pub default_display_manager: Option<DisplayManager>,
+    /// True for compositors that need explicit seat access (typically
+    /// Wayland compositors that don't go through logind/polkit).
+    pub needs_seat_access: bool,
+    /// Session name written into SDDM's autologin config (.desktop stem).
+    /// Only consulted when SDDM is the active DM and a user has autologin.
+    pub sddm_session: Option<&'static str>,
+    /// Optional extras shown in a multi-select checklist after the user
+    /// picks this profile.
+    pub optional_packages: Vec<OptionalPackage>,
+}
+
+/// Display server protocol(s) supported by a desktop profile.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisplayServer {
+    Xorg,
+    Wayland,
+    /// Profile supports both (e.g. KDE Plasma, GNOME).
+    Both,
+}
+
+/// Display manager enum.
+///
+/// Replaces the previous string-based representation. The `service()` and
+/// `package()` helpers map each variant to its arch package / systemd unit.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DisplayManager {
+    Gdm,
+    Sddm,
+    Lightdm,
+    Ly,
+    CosmicGreeter,
+}
+
+impl DisplayManager {
+    /// Systemd unit name (without `.service` suffix).
+    pub const fn service(self) -> &'static str {
+        match self {
+            Self::Gdm => "gdm",
+            Self::Sddm => "sddm",
+            Self::Lightdm => "lightdm",
+            Self::Ly => "ly",
+            Self::CosmicGreeter => "cosmic-greeter",
+        }
+    }
+
+    /// Arch package name. Currently identical to `service()` for every
+    /// known DM, but kept distinct so future divergences are localised here.
+    pub const fn package(self) -> &'static str {
+        self.service()
+    }
+
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::Gdm => "GDM",
+            Self::Sddm => "SDDM",
+            Self::Lightdm => "LightDM",
+            Self::Ly => "Ly",
+            Self::CosmicGreeter => "COSMIC Greeter",
+        }
+    }
+
+    pub const ALL: &'static [DisplayManager] = &[
+        Self::Gdm,
+        Self::Sddm,
+        Self::Lightdm,
+        Self::Ly,
+        Self::CosmicGreeter,
+    ];
+}
+
+impl std::fmt::Display for DisplayManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.service())
+    }
+}
+
+/// Optional package with a user-facing description.
+///
+/// Description may be empty for entries we haven't documented yet.
+#[derive(Debug, Clone)]
+pub struct OptionalPackage {
+    pub package: &'static str,
+    pub description: &'static str,
+}
+
+impl OptionalPackage {
+    pub const fn new(package: &'static str) -> Self {
+        Self {
+            package,
+            description: "",
+        }
+    }
+
+    pub const fn with_desc(package: &'static str, description: &'static str) -> Self {
+        Self {
+            package,
+            description,
+        }
+    }
+}
+
+// ── Profile accessors ──────────────────────────────────────────────────────
 
 impl Profile {
-    /// Return the display manager service this profile uses, if any.
-    pub fn display_manager(&self) -> Option<&str> {
-        self.services
-            .iter()
-            .find(|s| DISPLAY_MANAGERS.contains(s))
-            .copied()
+    /// Returns the desktop-specific data, if this profile is a desktop.
+    pub fn desktop(&self) -> Option<&DesktopProfile> {
+        match &self.kind {
+            ProfileKind::Desktop(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    pub fn is_desktop(&self) -> bool {
+        matches!(self.kind, ProfileKind::Desktop(_))
+    }
+
+    /// DM shipped with the profile, if any. None for non-desktop profiles or
+    /// compositors launched without a DM.
+    pub fn default_display_manager(&self) -> Option<DisplayManager> {
+        self.desktop().and_then(|d| d.default_display_manager)
+    }
+
+    pub fn needs_seat_access(&self) -> bool {
+        self.desktop().is_some_and(|d| d.needs_seat_access)
+    }
+
+    pub fn optional_packages(&self) -> &[OptionalPackage] {
+        self.desktop()
+            .map(|d| d.optional_packages.as_slice())
+            .unwrap_or(&[])
+    }
+
+    pub fn sddm_session(&self) -> Option<&'static str> {
+        self.desktop().and_then(|d| d.sddm_session)
     }
 }
 
 pub fn get_profile(name: &str) -> Option<Profile> {
-    let all = all_profiles();
-    all.into_iter().find(|p| p.name == name)
+    all_profiles().into_iter().find(|p| p.name == name)
 }
 
 pub fn all_profiles() -> Vec<Profile> {
@@ -73,6 +237,8 @@ mod tests {
         let p = get_profile("gnome").unwrap();
         assert_eq!(p.display_name, "GNOME");
         assert!(p.packages.contains(&"gnome"));
+        assert_eq!(p.default_display_manager(), Some(DisplayManager::Gdm));
+        assert!(p.is_desktop());
     }
 
     #[test]
@@ -82,8 +248,7 @@ mod tests {
 
     #[test]
     fn test_all_profiles_nonempty() {
-        let profiles = all_profiles();
-        assert!(profiles.len() > 5);
+        assert!(all_profiles().len() > 5);
     }
 
     #[test]
@@ -91,30 +256,52 @@ mod tests {
         for name in &["hyprland", "sway", "labwc", "niri", "river"] {
             let p = get_profile(name).unwrap();
             assert!(
-                p.needs_seat_access,
+                p.needs_seat_access(),
                 "{name} should have needs_seat_access=true"
             );
         }
     }
 
     #[test]
+    fn test_minimal_is_not_desktop() {
+        let m = get_profile("minimal").unwrap();
+        assert!(!m.is_desktop());
+        assert!(!m.needs_seat_access());
+        assert_eq!(m.default_display_manager(), None);
+        assert!(m.optional_packages().is_empty());
+    }
+
+    #[test]
     fn test_server_profiles_have_post_install() {
-        let pg = get_profile("postgresql").unwrap();
-        assert!(
-            !pg.post_install_steps.is_empty(),
-            "postgresql needs post_install_steps"
-        );
+        for name in &["postgresql", "mariadb", "docker"] {
+            let p = get_profile(name).unwrap();
+            assert!(
+                !p.post_install_steps.is_empty(),
+                "{name} needs post_install_steps"
+            );
+            assert!(matches!(p.kind, ProfileKind::Server));
+        }
+    }
 
-        let maria = get_profile("mariadb").unwrap();
-        assert!(
-            !maria.post_install_steps.is_empty(),
-            "mariadb needs post_install_steps"
-        );
+    #[test]
+    fn test_display_manager_service_mapping() {
+        assert_eq!(DisplayManager::Gdm.service(), "gdm");
+        assert_eq!(DisplayManager::CosmicGreeter.service(), "cosmic-greeter");
+    }
 
-        let docker = get_profile("docker").unwrap();
-        assert!(
-            !docker.post_install_steps.is_empty(),
-            "docker needs post_install_steps"
+    #[test]
+    fn test_cosmic_uses_cosmic_greeter() {
+        let p = get_profile("cosmic").unwrap();
+        assert_eq!(
+            p.default_display_manager(),
+            Some(DisplayManager::CosmicGreeter)
         );
+    }
+
+    #[test]
+    fn test_kde_sddm_session() {
+        let p = get_profile("kde").unwrap();
+        assert_eq!(p.default_display_manager(), Some(DisplayManager::Sddm));
+        assert_eq!(p.sddm_session(), Some("plasma"));
     }
 }

--- a/core/src/profile/mod.rs
+++ b/core/src/profile/mod.rs
@@ -196,6 +196,21 @@ impl Profile {
         matches!(self.kind, ProfileKind::Desktop(_))
     }
 
+    /// Whether asking the user to pick a GPU driver makes sense for this
+    /// profile. Currently true for desktops only — server/minimal installs
+    /// don't need a GPU stack and the picker is hidden.
+    pub fn supports_gfx_driver(&self) -> bool {
+        self.is_desktop()
+    }
+
+    /// True for profiles that target Wayland exclusively (no Xorg fallback).
+    /// Used to flag the Nvidia-proprietary-on-Wayland conflict.
+    pub fn is_wayland_only(&self) -> bool {
+        self.desktop()
+            .map(|d| matches!(d.display_server, DisplayServer::Wayland))
+            .unwrap_or(false)
+    }
+
     /// DM shipped with the profile, if any. None for non-desktop profiles or
     /// compositors launched without a DM.
     pub fn default_display_manager(&self) -> Option<DisplayManager> {

--- a/core/src/profile/server.rs
+++ b/core/src/profile/server.rs
@@ -1,91 +1,101 @@
-use super::{PostInstallStep, Profile};
+use super::{PostInstallStep, Profile, ProfileKind};
+
+/// Helper to keep server profile literals concise.
+fn server(
+    name: &'static str,
+    display_name: &'static str,
+    packages: Vec<&'static str>,
+    services: Vec<&'static str>,
+    post_install_steps: Vec<PostInstallStep>,
+) -> Profile {
+    Profile {
+        name,
+        display_name,
+        description: "",
+        packages,
+        services,
+        user_services: Vec::new(),
+        post_install_steps,
+        kind: ProfileKind::Server,
+    }
+}
 
 pub fn server_profiles() -> Vec<Profile> {
     vec![
         Profile {
             name: "minimal",
             display_name: "Minimal",
-            ..Profile::default()
+            description: "Bare base system, nothing extra.",
+            packages: Vec::new(),
+            services: Vec::new(),
+            user_services: Vec::new(),
+            post_install_steps: Vec::new(),
+            kind: ProfileKind::Minimal,
         },
-        Profile {
-            name: "sshd",
-            display_name: "SSH Server",
-            packages: vec!["openssh"],
-            services: vec!["sshd"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "docker",
-            display_name: "Docker",
-            packages: vec!["docker"],
-            services: vec!["docker"],
-            // Add every installer-created user to the docker group so they can
-            // use Docker without sudo.
-            post_install_steps: vec![PostInstallStep::AddUsersToGroup { group: "docker" }],
-            ..Profile::default()
-        },
-        Profile {
-            name: "httpd",
-            display_name: "Apache",
-            packages: vec!["apache"],
-            services: vec!["httpd"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "nginx",
-            display_name: "Nginx",
-            packages: vec!["nginx"],
-            services: vec!["nginx"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "cockpit",
-            display_name: "Cockpit",
-            packages: vec!["cockpit", "udisks2", "packagekit"],
-            services: vec!["cockpit.socket"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "postgresql",
-            display_name: "PostgreSQL",
-            packages: vec!["postgresql"],
-            services: vec!["postgresql"],
-            // The postgresql package creates the `postgres` system user via its
-            // install scripts (run by pacman during libalpm install). initdb
-            // must run after that as the postgres user to initialise the data
-            // directory. Failure is warn-only so idempotent reinstalls don't
-            // abort if the directory already exists.
-            post_install_steps: vec![PostInstallStep::RunAsUser {
+        server(
+            "sshd",
+            "SSH Server",
+            vec!["openssh"],
+            vec!["sshd"],
+            Vec::new(),
+        ),
+        server(
+            "docker",
+            "Docker",
+            vec!["docker"],
+            vec!["docker"],
+            // Add every installer-created user to the docker group so they
+            // can use Docker without sudo.
+            vec![PostInstallStep::AddUsersToGroup { group: "docker" }],
+        ),
+        server("httpd", "Apache", vec!["apache"], vec!["httpd"], Vec::new()),
+        server("nginx", "Nginx", vec!["nginx"], vec!["nginx"], Vec::new()),
+        server(
+            "cockpit",
+            "Cockpit",
+            vec!["cockpit", "udisks2", "packagekit"],
+            vec!["cockpit.socket"],
+            Vec::new(),
+        ),
+        server(
+            "postgresql",
+            "PostgreSQL",
+            vec!["postgresql"],
+            vec!["postgresql"],
+            // The postgresql package creates the `postgres` system user via
+            // its install scripts. initdb runs after that as the postgres
+            // user to initialise the data directory. Failure is warn-only so
+            // idempotent reinstalls don't abort if the directory already
+            // exists.
+            vec![PostInstallStep::RunAsUser {
                 user: "postgres",
                 cmd: "initdb",
                 args: &["-D", "/var/lib/postgres/data"],
             }],
-            ..Profile::default()
-        },
-        Profile {
-            name: "mariadb",
-            display_name: "MariaDB",
-            packages: vec!["mariadb"],
-            services: vec!["mariadb"],
-            post_install_steps: vec![PostInstallStep::RunAsRoot {
+        ),
+        server(
+            "mariadb",
+            "MariaDB",
+            vec!["mariadb"],
+            vec!["mariadb"],
+            vec![PostInstallStep::RunAsRoot {
                 cmd: "mariadb-install-db",
                 args: &["--user=mysql", "--basedir=/usr", "--datadir=/var/lib/mysql"],
             }],
-            ..Profile::default()
-        },
-        Profile {
-            name: "lighttpd",
-            display_name: "Lighttpd",
-            packages: vec!["lighttpd"],
-            services: vec!["lighttpd"],
-            ..Profile::default()
-        },
-        Profile {
-            name: "tomcat",
-            display_name: "Tomcat",
-            packages: vec!["tomcat10", "java-runtime"],
-            services: vec!["tomcat10"],
-            ..Profile::default()
-        },
+        ),
+        server(
+            "lighttpd",
+            "Lighttpd",
+            vec!["lighttpd"],
+            vec!["lighttpd"],
+            Vec::new(),
+        ),
+        server(
+            "tomcat",
+            "Tomcat",
+            vec!["tomcat10", "java-runtime"],
+            vec!["tomcat10"],
+            Vec::new(),
+        ),
     ]
 }

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -201,7 +201,12 @@ impl AlpmContext {
 
         tracing::info!("installing packages");
 
-        // Set up install progress callback
+        // Set up install progress callback. We hold a clone of the sender
+        // so we can emit a `Done` event after the transaction completes —
+        // without it the GUI's progress bar stays stuck on the last
+        // "Installing N/N: pkg 100%" until the install thread exits and
+        // the channel sender is dropped.
+        let progress_tx_clone = progress_tx.clone();
         if let Some(tx) = progress_tx {
             self.handle
                 .set_progress_cb(tx, |_kind, pkgname, percent, howmany, current, tx| {
@@ -214,11 +219,19 @@ impl AlpmContext {
                 });
         }
 
-        // Commit — libalpm finds packages in cache, skips download phase
-        self.handle.trans_commit().map_err(|e| {
+        // Commit — libalpm finds packages in cache, skips download phase.
+        // Always emit `Done` afterwards (success or failure) so the GUI
+        // bar gets dismissed before subsequent phases run.
+        let commit_result = self.handle.trans_commit().map_err(|e| {
             let msg = format!("transaction commit failed: {e}");
             eyre!(msg)
-        })?;
+        });
+
+        if let Some(tx) = &progress_tx_clone {
+            tx.send_replace(super::async_download::PackageProgress::Done);
+        }
+
+        commit_result?;
 
         self.handle
             .trans_release()

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -4,8 +4,8 @@
 use slint::SharedString;
 
 use archinstall_zfs_core::config::types::{
-    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, SwapMode,
-    ZfsEncryptionMode,
+    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
+    SwapMode, ZfsEncryptionMode,
 };
 
 use crate::ui::{ConfigItem, ItemType};
@@ -324,7 +324,11 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         ci(
             "profile",
             "Profile",
-            c.profile.as_deref().unwrap_or("None"),
+            &c.profile_selection
+                .as_ref()
+                .and_then(|s| s.profile_def())
+                .map(|p| p.display_name.to_string())
+                .unwrap_or_else(|| "None".into()),
             ItemType::Select,
         ),
     ];
@@ -643,10 +647,12 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
         }
         "profile" => {
             let profiles = archinstall_zfs_core::profile::all_profiles();
-            config.profile = if idx == 0 {
+            config.profile_selection = if idx == 0 {
                 None
             } else {
-                profiles.get((idx - 1) as usize).map(|p| p.name.to_string())
+                profiles
+                    .get((idx - 1) as usize)
+                    .and_then(|p| ProfileSelection::new(p.name))
             };
         }
         "audio" => {

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -396,6 +396,38 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     ));
 
     items.push(section_header("Hardware"));
+    // GPU driver — only shown for graphical profiles (mirrors upstream
+    // archinstall's `is_graphic_driver_supported` gate). Headless installs
+    // skip the row entirely.
+    if profile_def
+        .as_ref()
+        .is_some_and(|p| p.supports_gfx_driver())
+    {
+        items.push(ci(
+            "gpu_driver",
+            "GPU driver",
+            &c.gfx_driver
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "None".into()),
+            ItemType::Select,
+        ));
+
+        // Inline warning when the proprietary NVIDIA driver is paired with
+        // a Wayland-only compositor. The TUI shows a confirmation dialog;
+        // the GUI surfaces it as a Warning row inside the same section so
+        // the user sees it without opening a popup.
+        if profile_def.as_ref().is_some_and(|p| p.is_wayland_only())
+            && c.gfx_driver == Some(archinstall_zfs_core::system::gpu::GfxDriver::NvidiaOpen)
+        {
+            items.push(ConfigItem {
+                value: "Proprietary NVIDIA driver is known-problematic on \
+                        Wayland-only compositors."
+                    .into(),
+                item_type: ItemType::Warning,
+                ..Default::default()
+            });
+        }
+    }
     items.push(ci(
         "bluetooth",
         "Bluetooth",

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -5,7 +5,7 @@ use slint::SharedString;
 
 use archinstall_zfs_core::config::types::{
     AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
-    SwapMode, ZfsEncryptionMode,
+    SeatAccess, SwapMode, ZfsEncryptionMode,
 };
 
 use crate::ui::{ConfigItem, ItemType};
@@ -319,19 +319,70 @@ fn build_users_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 }
 
 fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
+    let sel = c.profile_selection.as_ref();
+    let profile_def = sel.and_then(|s| s.profile_def());
+
     let mut items = vec![
         section_header("Desktop"),
         ci(
             "profile",
             "Profile",
-            &c.profile_selection
+            &profile_def
                 .as_ref()
-                .and_then(|s| s.profile_def())
                 .map(|p| p.display_name.to_string())
                 .unwrap_or_else(|| "None".into()),
             ItemType::Select,
         ),
     ];
+
+    // ── Profile configuration: only when a desktop profile is active ──
+    if let (Some(sel), Some(p)) = (sel, profile_def.as_ref())
+        && p.is_desktop()
+    {
+        items.push(section_header("Profile configuration"));
+
+        // Optional packages: "N of M"
+        let total = p.optional_packages().len();
+        if total > 0 {
+            let chosen = sel.optional_packages.len();
+            items.push(ci(
+                "optional_packages",
+                "Optional packages",
+                &format!("{chosen} of {total}"),
+                ItemType::Select,
+            ));
+        }
+
+        // Display manager: shows the effective DM with (default) or
+        // (override) suffix so the user can tell at a glance whether they
+        // diverged from the profile.
+        let value = match (sel.display_manager_override, p.default_display_manager()) {
+            (Some(over), _) => format!("{} (override)", over.display_name()),
+            (None, Some(def)) => format!("{} (default)", def.display_name()),
+            (None, None) => "None".to_string(),
+        };
+        items.push(ci(
+            "display_manager",
+            "Display manager",
+            &value,
+            ItemType::Select,
+        ));
+
+        // Seat access (Wayland compositors). Its own section card via
+        // radio_group, like Audio.
+        if p.needs_seat_access() {
+            items.extend(radio_group(
+                "seat_access",
+                "Seat access",
+                &["None", "seatd", "polkit"],
+                match sel.seat_access {
+                    None => 0,
+                    Some(SeatAccess::Seatd) => 1,
+                    Some(SeatAccess::Polkit) => 2,
+                },
+            ));
+        }
+    }
 
     items.extend(radio_group(
         "audio",
@@ -660,6 +711,15 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
                 0 => None,
                 1 => Some(AudioServer::Pipewire),
                 _ => Some(AudioServer::Pulseaudio),
+            }
+        }
+        "seat_access" => {
+            if let Some(sel) = config.profile_selection.as_mut() {
+                sel.seat_access = match idx {
+                    0 => None,
+                    1 => Some(SeatAccess::Seatd),
+                    _ => Some(SeatAccess::Polkit),
+                };
             }
         }
         _ => {}

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -489,33 +489,43 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         let mut i = 0;
         while i < step_items.len() {
             let item = &step_items[i];
-            if item.item_type == ItemType::SectionHeader {
-                // Collapse `header + N radio options` into a single readonly
-                // row showing "Group: Selected option".
-                let header_label = item.label.clone();
-                let mut selected_label: SharedString = "Not set".into();
-                i += 1;
-                while i < step_items.len() && step_items[i].item_type == ItemType::RadioOption {
-                    if step_items[i].value == "selected" {
-                        selected_label = step_items[i].label.clone();
+            match item.item_type {
+                ItemType::RadioHeader => {
+                    // Collapse `radio-header + N radio-options` into a single
+                    // readonly row showing "Group: Selected option".
+                    let header_label = item.label.clone();
+                    let mut selected_label: SharedString = "Not set".into();
+                    i += 1;
+                    while i < step_items.len() && step_items[i].item_type == ItemType::RadioOption {
+                        if step_items[i].value == "selected" {
+                            selected_label = step_items[i].label.clone();
+                        }
+                        i += 1;
                     }
+                    items.push(ConfigItem {
+                        label: header_label,
+                        value: selected_label,
+                        item_type: ItemType::Readonly,
+                        ..Default::default()
+                    });
+                }
+                ItemType::SectionHeader => {
+                    // Visual section divider — the step-level header above
+                    // already groups things on the review screen, so the
+                    // inner divider would just produce an empty Readonly
+                    // row ("Not set"). Drop it.
                     i += 1;
                 }
-                items.push(ConfigItem {
-                    label: header_label,
-                    value: selected_label,
-                    item_type: ItemType::Readonly,
-                    ..Default::default()
-                });
-            } else {
-                items.push(ConfigItem {
-                    key: item.key.clone(),
-                    label: item.label.clone(),
-                    value: item.value.clone(),
-                    item_type: ItemType::Readonly,
-                    ..Default::default()
-                });
-                i += 1;
+                _ => {
+                    items.push(ConfigItem {
+                        key: item.key.clone(),
+                        label: item.label.clone(),
+                        value: item.value.clone(),
+                        item_type: ItemType::Readonly,
+                        ..Default::default()
+                    });
+                    i += 1;
+                }
             }
         }
     }
@@ -574,9 +584,17 @@ fn section_header(label: &str) -> ConfigItem {
     }
 }
 
-/// Emit a radio group: a section header followed by clickable options.
+/// Emit a radio group: a `RadioHeader` followed by clickable `RadioOption`
+/// rows. The header is a distinct `ItemType` from a plain `SectionHeader`
+/// so the review screen knows to collapse the header + options into one
+/// summary row, while bare section headers (used as visual dividers) get
+/// dropped in review entirely.
 fn radio_group(key: &str, label: &str, options: &[&str], selected: i32) -> Vec<ConfigItem> {
-    let mut items = vec![section_header(label)];
+    let mut items = vec![ConfigItem {
+        label: label.into(),
+        item_type: ItemType::RadioHeader,
+        ..Default::default()
+    }];
     for (i, opt) in options.iter().enumerate() {
         items.push(ConfigItem {
             key: format!("radio:{key}:{i}").into(),
@@ -612,6 +630,10 @@ fn mark_section_boundaries(items: &mut [ConfigItem]) {
                 | ItemType::Readonly
         )
     }
+    // SectionHeader and RadioHeader both break sections; everything that
+    // isn't a field naturally is a "non-field" and breaks the section, so
+    // no extra check needed beyond is_field above (RadioHeader != any
+    // field variant).
 
     let n = items.len();
     for i in 0..n {
@@ -641,6 +663,7 @@ pub fn next_selectable_index(items: &[ConfigItem], current: i32, dir: i32) -> i3
             && t != ItemType::Readonly
             && t != ItemType::Warning
             && t != ItemType::SectionHeader
+            && t != ItemType::RadioHeader
         {
             return idx;
         }

--- a/slint-ui/src/controllers/lists.rs
+++ b/slint-ui/src/controllers/lists.rs
@@ -18,6 +18,47 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &EditingMode
     setup_users(app, config, models);
     setup_extra_services(app, config, models);
     setup_packages(app, config, models);
+    setup_multi_select(app, config, models);
+}
+
+/// Multi-select popup handler. Currently only `optional_packages` uses it,
+/// but the dispatch is keyed so future multi-selects can plug in here.
+fn setup_multi_select(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &EditingModels) {
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    let model = models.multi_select.clone();
+    app.on_multi_select_toggled(move |key, idx| {
+        let Some(app) = weak.upgrade() else { return };
+        let i = idx as usize;
+        let Some(mut row) = model.row_data(i) else {
+            return;
+        };
+        row.checked = !row.checked;
+        let pkg_name = row.text.to_string();
+        model.set_row_data(i, row.clone());
+
+        if key == "optional_packages" {
+            let mut c = cfg.borrow_mut();
+            if let Some(sel) = c.profile_selection.as_mut() {
+                if row.checked {
+                    sel.optional_packages.insert(pkg_name);
+                } else {
+                    sel.optional_packages.remove(&pkg_name);
+                }
+            }
+            // Don't rebuild the wizard list — the popup is open and the
+            // background list isn't visible anyway. Refresh on close instead.
+            let _ = &app;
+        }
+    });
+
+    // On close, refresh the wizard items so the "N of M" summary updates.
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    app.on_multi_select_closed(move |_key| {
+        let Some(app) = weak.upgrade() else { return };
+        refresh_items(&app, &cfg.borrow());
+    });
 }
 
 fn setup_users(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &EditingModels) {

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -150,13 +150,23 @@ fn setup_select_confirmed(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_
         }
 
         if key == "dm_select" {
-            // 0 = "use profile default", 1..N = DisplayManager::ALL[idx-1].
+            // Indices map 1:1 to DisplayManager::ALL. Canonicalize: picking
+            // the profile's own default DM clears the override entirely so
+            // the stored state stays in canonical form (override == None ⇔
+            // "use profile default").
             let mut c = cfg.borrow_mut();
-            if let Some(sel) = c.profile_selection.as_mut() {
-                sel.display_manager_override = if idx == 0 {
+            let profile_default = c
+                .profile_selection
+                .as_ref()
+                .and_then(|s| s.profile_def())
+                .and_then(|p| p.default_display_manager());
+            if let Some(sel) = c.profile_selection.as_mut()
+                && let Some(&picked) = DisplayManager::ALL.get(idx as usize)
+            {
+                sel.display_manager_override = if Some(picked) == profile_default {
                     None
                 } else {
-                    DisplayManager::ALL.get((idx - 1) as usize).copied()
+                    Some(picked)
                 };
             }
             refresh_items(&app, &c);
@@ -375,6 +385,23 @@ fn build_kernel_options(
         .collect()
 }
 
+/// Build the DM picker label list. `DisplayManager::ALL` is the canonical
+/// option order (indices map 1:1); we just decorate the profile's own
+/// default with `  ✦ default`, mirroring the GPU driver picker's
+/// `  ✦ suggested` annotation.
+fn dm_picker_labels(profile_default: Option<DisplayManager>) -> Vec<String> {
+    DisplayManager::ALL
+        .iter()
+        .map(|d| {
+            if Some(*d) == profile_default {
+                format!("{}  ✦ default", d.display_name())
+            } else {
+                d.display_name().to_string()
+            }
+        })
+        .collect()
+}
+
 // ── Item activation (open the right popup for the clicked row) ──────
 
 fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_scan: &KernelScan) {
@@ -476,31 +503,26 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             show_select(app, "gfx_driver_select", "GPU driver", &refs, current);
         }
         "display_manager" => {
-            // Open SelectPopup with [ "Use profile default (X)", Gdm, Sddm,
-            // Lightdm, Ly, CosmicGreeter ]. Result handled in
-            // setup_select_confirmed under the "dm_select" key.
+            // Open SelectPopup with the full DisplayManager list, annotating
+            // the profile's own default with `  ✦ default` (same idiom as the
+            // GPU driver picker uses for its suggestion). Picking the
+            // annotated row clears the override (canonical "use default")
+            // — handled in setup_select_confirmed under "dm_select".
             let sel = config.profile_selection.as_ref();
             let profile_default = sel
                 .and_then(|s| s.profile_def())
                 .and_then(|p| p.default_display_manager());
-            let default_label = format!(
-                "Use profile default ({})",
-                profile_default.map(|d| d.display_name()).unwrap_or("none")
-            );
-            let mut labels: Vec<String> = vec![default_label];
-            labels.extend(
-                DisplayManager::ALL
-                    .iter()
-                    .map(|d| d.display_name().to_string()),
-            );
+            let labels = dm_picker_labels(profile_default);
             let refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
 
-            // Pre-select current override if set, else "use default" (0).
-            let current = sel
-                .and_then(|s| s.display_manager_override)
+            // Pre-select the effective DM: explicit override if set, else
+            // the profile default. -1 (no highlight) only if the profile
+            // has no default DM and the user hasn't picked one.
+            let effective = sel.and_then(|s| s.display_manager_override.or(profile_default));
+            let current = effective
                 .and_then(|d| DisplayManager::ALL.iter().position(|x| *x == d))
-                .map(|i| (i + 1) as i32)
-                .unwrap_or(0);
+                .map(|i| i as i32)
+                .unwrap_or(-1);
             show_select(app, "dm_select", "Display manager", &refs, current);
         }
         "timezone" => {

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -368,9 +368,9 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             names.extend(profiles.iter().map(|p| p.name.to_string()));
             let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
             let current = config
-                .profile
+                .profile_selection
                 .as_ref()
-                .and_then(|sel| profiles.iter().position(|p| p.name == *sel))
+                .and_then(|sel| profiles.iter().position(|p| p.name == sel.profile))
                 .map(|i| (i + 1) as i32)
                 .unwrap_or(0);
             show_select(app, "profile", "Profile", &refs, current);

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -10,6 +10,7 @@ use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use archinstall_zfs_core::config::types::GlobalConfig;
 use archinstall_zfs_core::profile::DisplayManager;
+use archinstall_zfs_core::system::gpu::{GfxDriver, detect_gpus, suggested_driver};
 
 use crate::config_items::{apply_radio, apply_text, build_step_items, next_selectable_index};
 use crate::controllers::welcome::KernelScan;
@@ -158,6 +159,29 @@ fn setup_select_confirmed(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_
                     DisplayManager::ALL.get((idx - 1) as usize).copied()
                 };
             }
+            refresh_items(&app, &c);
+            return;
+        }
+
+        if key == "gfx_driver_select" {
+            // Index 0 = None (skip GPU packages), 1..N = drivers in the
+            // same order as the popup builder.
+            let drivers: &[Option<GfxDriver>] = &[
+                None,
+                Some(GfxDriver::AllOpenSource),
+                Some(GfxDriver::Amd),
+                Some(GfxDriver::Intel),
+                Some(GfxDriver::NvidiaOpen),
+                Some(GfxDriver::NvidiaNouveau),
+                Some(GfxDriver::Vm),
+            ];
+            let mut c = cfg.borrow_mut();
+            if let Some(d) = drivers.get(idx as usize) {
+                c.gfx_driver = *d;
+            }
+            // The Nvidia/Wayland warning is rendered as a Warning row by
+            // build_desktop_items the next time the items are refreshed —
+            // no extra confirmation popup needed in the GUI.
             refresh_items(&app, &c);
             return;
         }
@@ -414,6 +438,41 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             popup.set_multi_select_key("optional_packages".into());
             popup.set_multi_select_title(format!("Optional packages — {}", p.display_name).into());
             popup.set_multi_select_visible(true);
+        }
+        "gpu_driver" => {
+            // Build the GPU driver options list. Order matches the TUI
+            // picker (None first, then drivers in display order). The
+            // suggested driver based on detected hardware is annotated.
+            let suggestion = suggested_driver(&detect_gpus());
+            let drivers: &[Option<GfxDriver>] = &[
+                None,
+                Some(GfxDriver::AllOpenSource),
+                Some(GfxDriver::Amd),
+                Some(GfxDriver::Intel),
+                Some(GfxDriver::NvidiaOpen),
+                Some(GfxDriver::NvidiaNouveau),
+                Some(GfxDriver::Vm),
+            ];
+            let labels: Vec<String> = drivers
+                .iter()
+                .map(|d| {
+                    let base = match d {
+                        None => "None — skip GPU driver installation".to_string(),
+                        Some(drv) => drv.to_string(),
+                    };
+                    if *d == suggestion {
+                        format!("{base}  ✦ suggested")
+                    } else {
+                        base
+                    }
+                })
+                .collect();
+            let refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+            let current = drivers
+                .iter()
+                .position(|d| *d == config.gfx_driver)
+                .unwrap_or(0) as i32;
+            show_select(app, "gfx_driver_select", "GPU driver", &refs, current);
         }
         "display_manager" => {
             // Open SelectPopup with [ "Use profile default (X)", Gdm, Sddm,

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -257,6 +257,7 @@ fn setup_keyboard_nav(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
             && item_type != ItemType::Readonly
             && item_type != ItemType::Warning
             && item_type != ItemType::SectionHeader
+            && item_type != ItemType::RadioHeader
         {
             app.invoke_item_activated(key);
         }

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -9,11 +9,15 @@ use std::rc::Rc;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use archinstall_zfs_core::config::types::GlobalConfig;
+use archinstall_zfs_core::profile::DisplayManager;
 
 use crate::config_items::{apply_radio, apply_text, build_step_items, next_selectable_index};
 use crate::controllers::welcome::KernelScan;
+use crate::editing_models::set_multi_select_options;
 use crate::refresh::refresh_items;
-use crate::ui::{App, EditingState, ItemType, PopupState, SelectOption, Theme, WizardState};
+use crate::ui::{
+    App, EditingState, ItemType, MultiSelectOption, PopupState, SelectOption, Theme, WizardState,
+};
 
 pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &KernelScan) {
     setup_step_changed(app, config);
@@ -141,6 +145,20 @@ fn setup_select_confirmed(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_
                 cfg.borrow_mut().keyboard_layout = opt.text.to_string();
                 refresh_items(&app, &cfg.borrow());
             }
+            return;
+        }
+
+        if key == "dm_select" {
+            // 0 = "use profile default", 1..N = DisplayManager::ALL[idx-1].
+            let mut c = cfg.borrow_mut();
+            if let Some(sel) = c.profile_selection.as_mut() {
+                sel.display_manager_override = if idx == 0 {
+                    None
+                } else {
+                    DisplayManager::ALL.get((idx - 1) as usize).copied()
+                };
+            }
+            refresh_items(&app, &c);
             return;
         }
 
@@ -365,7 +383,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
         "profile" => {
             let profiles = archinstall_zfs_core::profile::all_profiles();
             let mut names: Vec<String> = vec!["None".to_string()];
-            names.extend(profiles.iter().map(|p| p.name.to_string()));
+            names.extend(profiles.iter().map(|p| p.display_name.to_string()));
             let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
             let current = config
                 .profile_selection
@@ -374,6 +392,56 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
                 .map(|i| (i + 1) as i32)
                 .unwrap_or(0);
             show_select(app, "profile", "Profile", &refs, current);
+        }
+        "optional_packages" => {
+            // Build a fresh MultiSelectOption list from the profile's
+            // optional packages and the user's current checked subset.
+            let Some(sel) = config.profile_selection.as_ref() else {
+                return;
+            };
+            let Some(p) = sel.profile_def() else { return };
+            let opts: Vec<MultiSelectOption> = p
+                .optional_packages()
+                .iter()
+                .map(|op| MultiSelectOption {
+                    text: SharedString::from(op.package),
+                    description: SharedString::from(op.description),
+                    checked: sel.optional_packages.contains(op.package),
+                })
+                .collect();
+            set_multi_select_options(app, opts);
+            let popup = app.global::<PopupState>();
+            popup.set_multi_select_key("optional_packages".into());
+            popup.set_multi_select_title(format!("Optional packages — {}", p.display_name).into());
+            popup.set_multi_select_visible(true);
+        }
+        "display_manager" => {
+            // Open SelectPopup with [ "Use profile default (X)", Gdm, Sddm,
+            // Lightdm, Ly, CosmicGreeter ]. Result handled in
+            // setup_select_confirmed under the "dm_select" key.
+            let sel = config.profile_selection.as_ref();
+            let profile_default = sel
+                .and_then(|s| s.profile_def())
+                .and_then(|p| p.default_display_manager());
+            let default_label = format!(
+                "Use profile default ({})",
+                profile_default.map(|d| d.display_name()).unwrap_or("none")
+            );
+            let mut labels: Vec<String> = vec![default_label];
+            labels.extend(
+                DisplayManager::ALL
+                    .iter()
+                    .map(|d| d.display_name().to_string()),
+            );
+            let refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+
+            // Pre-select current override if set, else "use default" (0).
+            let current = sel
+                .and_then(|s| s.display_manager_override)
+                .and_then(|d| DisplayManager::ALL.iter().position(|x| *x == d))
+                .map(|i| (i + 1) as i32)
+                .unwrap_or(0);
+            show_select(app, "dm_select", "Display manager", &refs, current);
         }
         "timezone" => {
             let regions = archinstall_zfs_core::installer::locale::list_timezone_regions();

--- a/slint-ui/src/editing_models.rs
+++ b/slint-ui/src/editing_models.rs
@@ -7,7 +7,10 @@ use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use archinstall_zfs_core::config::types::GlobalConfig;
 
-use crate::ui::{App, EditingState, PackageEntry, PackageSearchResult, SelectOption, UserEntry};
+use crate::ui::{
+    App, EditingState, MultiSelectOption, PackageEntry, PackageSearchResult, SelectOption,
+    UserEntry,
+};
 
 #[derive(Clone)]
 pub struct EditingModels {
@@ -15,6 +18,9 @@ pub struct EditingModels {
     pub extra_services: Rc<VecModel<SelectOption>>,
     pub packages_selected: Rc<VecModel<PackageEntry>>,
     pub package_search: Rc<VecModel<PackageSearchResult>>,
+    /// Backing model for `MultiSelectPopup`. Reseeded each time the popup
+    /// opens; rows are mutated in place when the user toggles them.
+    pub multi_select: Rc<VecModel<MultiSelectOption>>,
 }
 
 impl EditingModels {
@@ -24,16 +30,18 @@ impl EditingModels {
             extra_services: Rc::new(VecModel::default()),
             packages_selected: Rc::new(VecModel::default()),
             package_search: Rc::new(VecModel::default()),
+            multi_select: Rc::new(VecModel::default()),
         }
     }
 
-    /// Wire the four `VecModel`s into the EditingState global once at startup.
+    /// Wire the editing `VecModel`s into the EditingState global once at startup.
     pub fn attach(&self, app: &App) {
         let editing = app.global::<EditingState>();
         editing.set_users(self.users.clone().into());
         editing.set_extra_services(self.extra_services.clone().into());
         editing.set_packages_selected(self.packages_selected.clone().into());
         editing.set_package_search_results(self.package_search.clone().into());
+        editing.set_multi_select_options(self.multi_select.clone().into());
     }
 
     /// Mirror the canonical config lists into the live VecModels.
@@ -85,5 +93,17 @@ pub fn set_search_results(app: &App, items: Vec<PackageSearchResult>) {
         .as_any()
         .downcast_ref::<VecModel<PackageSearchResult>>()
         .expect("package_search_results is always a VecModel");
+    vec_model.set_vec(items);
+}
+
+/// Replace the contents of the multi-select VecModel. Used when opening the
+/// MultiSelectPopup with a fresh set of options.
+pub fn set_multi_select_options(app: &App, items: Vec<crate::ui::MultiSelectOption>) {
+    let model: ModelRc<crate::ui::MultiSelectOption> =
+        app.global::<EditingState>().get_multi_select_options();
+    let vec_model = model
+        .as_any()
+        .downcast_ref::<VecModel<crate::ui::MultiSelectOption>>()
+        .expect("multi_select_options is always a VecModel");
     vec_model.set_vec(items);
 }

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -26,6 +26,7 @@ import { SelectPopup } from "popups/select-popup.slint";
 import { UserManagePopup } from "popups/user-manage-popup.slint";
 import { StringListPopup } from "popups/string-list-popup.slint";
 import { PackageSearchPopup } from "popups/package-search-popup.slint";
+import { MultiSelectPopup } from "popups/multi-select-popup.slint";
 
 import { WelcomeView } from "views/welcome-view.slint";
 import { WizardView } from "views/wizard-view.slint";
@@ -49,6 +50,10 @@ export component App inherits Window {
     callback pkg-search-aur(string);
     callback pkg-added(int);
     callback pkg-removed(int);
+
+    // Multi-select popup callbacks (profile optional packages, etc.)
+    callback multi-select-toggled(string, int); // (key, index)
+    callback multi-select-closed(string);       // key (so Rust can refresh)
 
     // Callbacks to Rust
     callback item-activated(string);
@@ -77,7 +82,8 @@ export component App inherits Window {
             && !PopupState.text-input-visible
             && !PopupState.users-visible
             && !PopupState.pkg-search-visible
-            && !PopupState.strlist-visible;
+            && !PopupState.strlist-visible
+            && !PopupState.multi-select-visible;
         key-pressed(e) => {
             if e.text == Key.Tab {
                 WizardState.next();
@@ -189,6 +195,18 @@ export component App inherits Window {
         item-added(val) => { strlist-added(val); }
         item-removed(index) => { strlist-removed(index); }
         closed() => { PopupState.strlist-visible = false; }
+    }
+
+    MultiSelectPopup {
+        title: PopupState.multi-select-title;
+        options: EditingState.multi-select-options;
+        popup-visible: PopupState.multi-select-visible;
+
+        toggled(idx) => { multi-select-toggled(PopupState.multi-select-key, idx); }
+        closed() => {
+            PopupState.multi-select-visible = false;
+            multi-select-closed(PopupState.multi-select-key);
+        }
     }
 
     PackageSearchPopup {

--- a/slint-ui/ui/components/config-item.slint
+++ b/slint-ui/ui/components/config-item.slint
@@ -33,7 +33,12 @@ export component ConfigItemRow inherits Rectangle {
     callback focus-requested(int);       // pointer hover/click → set focus
 
     // Pre-computed predicates so the rest of the component reads cleanly.
-    property <bool> is-section-header: item.item-type == ItemType.section-header;
+    // Section header and radio header render identically — the distinction
+    // only matters in Rust (build_review_items collapses radio-header + the
+    // following radio-options into one row, plain section-headers are dropped
+    // in review).
+    property <bool> is-section-header: item.item-type == ItemType.section-header
+        || item.item-type == ItemType.radio-header;
     property <bool> is-separator: item.item-type == ItemType.separator;
     property <bool> is-warning: item.item-type == ItemType.warning;
     property <bool> is-action: item.item-type == ItemType.action;

--- a/slint-ui/ui/popups/multi-select-popup.slint
+++ b/slint-ui/ui/popups/multi-select-popup.slint
@@ -1,0 +1,139 @@
+// Multi-select checklist popup. Used for profile optional packages.
+//
+// Sizing strategy mirrors StringListPopup: the card grows with content up
+// to a window-bounds clamp, the ScrollView absorbs the deficit beyond the
+// cap. See string-list-popup.slint header for the full rationale.
+//
+// Each row is a CheckBox; toggling emits `toggled(index)` immediately so
+// Rust can mutate the underlying VecModel in place. The popup never holds
+// any local edit state — the checked field on each MultiSelectOption is
+// the single source of truth.
+
+import { ScrollView } from "std-widgets.slint";
+import { Theme } from "../styling.slint";
+import { MultiSelectOption } from "../types.slint";
+import { StyledButton } from "../components/styled-button.slint";
+
+export component MultiSelectPopup inherits Rectangle {
+    in property <string> title;
+    in property <[MultiSelectOption]> options;
+    in property <bool> popup-visible;
+
+    callback toggled(int);
+    callback closed();
+
+    if popup-visible: Rectangle {
+        background: #00000080;
+        width: 100%; height: 100%;
+
+        TouchArea { clicked => { closed(); } }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: min(540px, parent.width - 40px);
+            height: min(self.preferred-height, parent.height - 80px);
+            background: Theme.c.mantle;
+            border-radius: Theme.radius-md;
+            border-color: Theme.c.surface1;
+            border-width: 1px;
+            clip: true;
+            accessible-role: groupbox;
+            accessible-label: root.title;
+
+            VerticalLayout {
+                padding: Theme.spacing-lg;
+                spacing: Theme.spacing-sm;
+
+                Text {
+                    text: root.title;
+                    color: Theme.c.blue;
+                    font-size: Theme.font-lg;
+                    font-weight: FontWeight.semi-bold;
+                    height: Theme.spacing-xl;
+                }
+
+                // ScrollView pattern: preferred-height override exposes
+                // content height to the parent layout, vertical-stretch
+                // (std default) absorbs the deficit when capped.
+                ScrollView {
+                    preferred-height: items-vbox.preferred-height;
+                    vertical-stretch: 1;
+
+                    items-vbox := VerticalLayout {
+                        spacing: Theme.spacing-xs;
+
+                        for option[index] in root.options: Rectangle {
+                            height: Theme.control-height;
+                            background: row-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
+                            border-radius: Theme.radius-sm;
+
+                            row-ta := TouchArea {
+                                clicked => { root.toggled(index); }
+                            }
+
+                            HorizontalLayout {
+                                padding-left: Theme.spacing-md;
+                                padding-right: Theme.spacing-md;
+                                spacing: Theme.spacing-sm;
+
+                                // Inline checkbox visual. Click is owned
+                                // by the row's TouchArea above so we don't
+                                // need an interactive CheckBox here.
+                                VerticalLayout {
+                                    alignment: center;
+                                    horizontal-stretch: 0;
+
+                                    Rectangle {
+                                        width: 16px;
+                                        height: 16px;
+                                        background: option.checked ? Theme.c.blue : transparent;
+                                        border-color: option.checked ? Theme.c.blue : Theme.c.overlay0;
+                                        border-width: 1.5px;
+                                        border-radius: 3px;
+
+                                        if option.checked: Text {
+                                            text: "\u{2713}";
+                                            color: Theme.c.base;
+                                            font-size: 12px;
+                                            font-weight: FontWeight.bold;
+                                            horizontal-alignment: center;
+                                            vertical-alignment: center;
+                                        }
+                                    }
+                                }
+
+                                Text {
+                                    text: option.text;
+                                    color: Theme.c.text;
+                                    font-size: Theme.font-base;
+                                    vertical-alignment: center;
+                                }
+
+                                if option.description != "": Text {
+                                    text: option.description;
+                                    color: Theme.c.overlay0;
+                                    font-size: Theme.font-sm;
+                                    vertical-alignment: center;
+                                    overflow: elide;
+                                    horizontal-stretch: 1;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                HorizontalLayout {
+                    alignment: end;
+
+                    StyledButton {
+                        label: "Done";
+                        min-width: 80px;
+                        style: Theme.button-primary;
+                        clicked => { root.closed(); }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/slint-ui/ui/popups/select-popup.slint
+++ b/slint-ui/ui/popups/select-popup.slint
@@ -6,19 +6,14 @@ import { StyledTextInput } from "../components/styled-text-input.slint";
 export component SelectPopup inherits Rectangle {
     in property <string> title;
     in property <[SelectOption]> options;
+    // Index of the row to highlight on open. The popup never tracks a
+    // separate "current" highlight — clicking a row immediately fires
+    // `accepted(idx)` and closes, so the only highlight that matters is
+    // the initial one driven directly by `selected-index`. Earlier
+    // versions had an `out property result-index: selected-index;` that
+    // got broken by the first click and then leaked across re-opens.
     in property <int> selected-index;
-    out property <int> result-index: selected-index;
     in property <bool> popup-visible;
-
-    // Reset the highlight every time the popup is (re)opened. Without this,
-    // the first click breaks the `result-index: selected-index` binding and
-    // subsequent opens stay stuck on the previously-clicked row instead of
-    // tracking the new `selected-index` that Rust pushes in.
-    changed popup-visible => {
-        if root.popup-visible {
-            root.result-index = root.selected-index;
-        }
-    }
     in property <bool> show-filter: false;
 
     callback accepted(int);
@@ -75,20 +70,17 @@ export component SelectPopup inherits Rectangle {
                     for option[index] in root.options: Rectangle {
                         height: Theme.control-height-sm;
                         background: item-ta.has-hover ? Theme.c.surface1
-                                  : index == root.result-index ? Theme.c.surface0
+                                  : index == root.selected-index ? Theme.c.surface0
                                   : transparent;
                         border-radius: Theme.radius-sm;
                         accessible-role: list-item;
                         accessible-label: option.text;
-                        accessible-item-selected: index == root.result-index;
+                        accessible-item-selected: index == root.selected-index;
                         accessible-item-index: index;
                         accessible-item-count: root.options.length;
 
                         item-ta := TouchArea {
-                            clicked => {
-                                root.result-index = index;
-                                root.accepted(index);
-                            }
+                            clicked => { root.accepted(index); }
                         }
 
                         HorizontalLayout {
@@ -96,8 +88,8 @@ export component SelectPopup inherits Rectangle {
                             alignment: start;
 
                             Text {
-                                text: index == root.result-index ? "> " + option.text : "  " + option.text;
-                                color: index == root.result-index ? Theme.c.green : Theme.c.text;
+                                text: index == root.selected-index ? "> " + option.text : "  " + option.text;
+                                color: index == root.selected-index ? Theme.c.green : Theme.c.text;
                                 font-size: Theme.font-base;
                                 vertical-alignment: center;
                             }

--- a/slint-ui/ui/popups/select-popup.slint
+++ b/slint-ui/ui/popups/select-popup.slint
@@ -9,6 +9,16 @@ export component SelectPopup inherits Rectangle {
     in property <int> selected-index;
     out property <int> result-index: selected-index;
     in property <bool> popup-visible;
+
+    // Reset the highlight every time the popup is (re)opened. Without this,
+    // the first click breaks the `result-index: selected-index` binding and
+    // subsequent opens stay stuck on the previously-clicked row instead of
+    // tracking the new `selected-index` that Rust pushes in.
+    changed popup-visible => {
+        if root.popup-visible {
+            root.result-index = root.selected-index;
+        }
+    }
     in property <bool> show-filter: false;
 
     callback accepted(int);

--- a/slint-ui/ui/popups/text-input-popup.slint
+++ b/slint-ui/ui/popups/text-input-popup.slint
@@ -5,7 +5,7 @@ import { ProgressBar } from "../components/progress-bar.slint";
 
 export component TextInputPopup inherits Rectangle {
     in property <string> title;
-    in-out property <string> input-text;
+    in property <string> input-text;
     in property <bool> is-password: false;
     in property <bool> popup-visible;
     in property <int> strength-score: -1;

--- a/slint-ui/ui/state/editing-state.slint
+++ b/slint-ui/ui/state/editing-state.slint
@@ -6,7 +6,7 @@
 // but the Rust handlers update the underlying VecModels in place — no full
 // model rebuild on every edit.
 
-import { UserEntry, PackageEntry, PackageSearchResult, SelectOption } from "../types.slint";
+import { UserEntry, PackageEntry, PackageSearchResult, SelectOption, MultiSelectOption } from "../types.slint";
 
 export global EditingState {
     in property <[UserEntry]> users;
@@ -15,4 +15,8 @@ export global EditingState {
     in property <[PackageSearchResult]> package-search-results;
     in property <bool> package-searching-aur: false;
     in property <string> package-status-text;
+
+    // Backing list for MultiSelectPopup. Rust seeds it on open and mutates
+    // the `checked` field in place when the user toggles a row.
+    in property <[MultiSelectOption]> multi-select-options;
 }

--- a/slint-ui/ui/state/popup-state.slint
+++ b/slint-ui/ui/state/popup-state.slint
@@ -38,4 +38,9 @@ export global PopupState {
 
     // ── Package search popup ──
     in-out property <bool> pkg-search-visible: false;
+
+    // ── Multi-select popup (profile optional packages, etc.) ──
+    in-out property <bool> multi-select-visible: false;
+    in-out property <string> multi-select-title;
+    in-out property <string> multi-select-key;
 }

--- a/slint-ui/ui/types.slint
+++ b/slint-ui/ui/types.slint
@@ -9,7 +9,14 @@ export enum ItemType {
     action,
     readonly,
     warning,
+    // Visual section divider — small uppercase label, no card. Skipped in
+    // the review screen because the step-level header already groups things.
     section-header,
+    // Header of an inline radio group: same visual as section-header but
+    // semantically *bound* to the RadioOption rows that immediately follow.
+    // The review screen collapses (radio-header + N radio-options) into a
+    // single readonly summary row.
+    radio-header,
     radio-option,
 }
 

--- a/slint-ui/ui/types.slint
+++ b/slint-ui/ui/types.slint
@@ -32,6 +32,16 @@ export struct SelectOption {
     text: string,
 }
 
+// One row in MultiSelectPopup. `text` is the package name (or whatever is
+// being multi-selected); `description` is an optional human-readable hint
+// shown to the right of the label. `checked` is the user's current toggle
+// state.
+export struct MultiSelectOption {
+    text: string,
+    description: string,
+    checked: bool,
+}
+
 export struct UserEntry {
     username: string,
     has-sudo: bool,

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -3,9 +3,10 @@ use std::path::PathBuf;
 use color_eyre::eyre::Result;
 
 use archinstall_zfs_core::config::types::{
-    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, SeatAccess, SwapMode,
-    UserConfig, ZfsEncryptionMode, ZfsModuleMode,
+    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
+    SeatAccess, SwapMode, UserConfig, ZfsEncryptionMode, ZfsModuleMode,
 };
+use archinstall_zfs_core::profile::{DisplayManager, OptionalPackage};
 use archinstall_zfs_core::system::gpu::{GfxDriver, detect_gpus, suggested_driver};
 
 use super::edit::run_edit;
@@ -325,9 +326,9 @@ pub fn pick_profile(
 
     // Pre-select the current profile
     let initial = config
-        .profile
-        .as_deref()
-        .and_then(|name| profiles.iter().position(|p| p.name == name))
+        .profile_selection
+        .as_ref()
+        .and_then(|sel| profiles.iter().position(|p| p.name == sel.profile))
         .map(|i| i + 1)
         .unwrap_or(0);
 
@@ -337,50 +338,36 @@ pub fn pick_profile(
     };
 
     if idx == 0 {
-        // "None" selected — clear profile-related config
-        config.profile = None;
-        config.seat_access = None;
-        config.display_manager_override = None;
+        // "None" selected — clear the whole selection
+        config.profile_selection = None;
         return Ok(());
     }
 
     let chosen = &profiles[idx - 1];
 
-    // Remove optional packages from the previous profile before switching
-    if let Some(ref old_name) = config.profile.clone()
-        && let Some(old_profile) = archinstall_zfs_core::profile::get_profile(old_name)
-    {
-        config
-            .additional_packages
-            .retain(|pkg| !old_profile.optional_packages.contains(&pkg.as_str()));
-    }
-
-    config.profile = Some(chosen.name.to_string());
+    // Fresh selection with profile defaults — atomic replace, no stale fields.
+    let mut sel = ProfileSelection::new(chosen.name).expect("profile from registry");
 
     // Optional packages checklist
-    if !chosen.optional_packages.is_empty() {
-        let extras = pick_optional_packages(terminal, &chosen.optional_packages)?;
-        for pkg in extras {
-            if !config.additional_packages.contains(&pkg) {
-                config.additional_packages.push(pkg);
-            }
-        }
+    let opts = chosen.optional_packages();
+    if !opts.is_empty() {
+        let chosen_opts = pick_optional_packages(terminal, opts)?;
+        sel.optional_packages = chosen_opts.into_iter().collect();
     }
 
     // Display manager override
-    if let Some(dm_result) = pick_display_manager(terminal, chosen.display_manager())? {
-        config.display_manager_override = dm_result;
+    if let Some(dm_result) = pick_display_manager(terminal, chosen.default_display_manager())? {
+        sel.display_manager_override = dm_result;
     }
 
     // Seat access (Wayland compositors only)
-    if chosen.needs_seat_access {
-        if let Some(seat) = pick_seat_access(terminal)? {
-            config.seat_access = Some(seat);
-        }
-    } else {
-        config.seat_access = None;
+    if chosen.needs_seat_access()
+        && let Some(seat) = pick_seat_access(terminal)?
+    {
+        sel.seat_access = Some(seat);
     }
 
+    config.profile_selection = Some(sel);
     Ok(())
 }
 
@@ -388,19 +375,33 @@ pub fn pick_profile(
 /// Cancelling returns an empty Vec (treated as "skip optional packages").
 pub fn pick_optional_packages(
     terminal: &mut ratatui::DefaultTerminal,
-    optional: &[&str],
+    optional: &[OptionalPackage],
 ) -> Result<Vec<String>> {
     if optional.is_empty() {
         return Ok(Vec::new());
     }
+    let labels: Vec<String> = optional
+        .iter()
+        .map(|p| {
+            if p.description.is_empty() {
+                p.package.to_string()
+            } else {
+                format!("{}  — {}", p.package, p.description)
+            }
+        })
+        .collect();
+    let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
     let result = run_multiselect(
         terminal,
         "Optional packages (Space to toggle)",
-        optional,
+        &label_refs,
         &[],
     )?;
     match result.selected {
-        Some(indices) => Ok(indices.iter().map(|&i| optional[i].to_string()).collect()),
+        Some(indices) => Ok(indices
+            .iter()
+            .map(|&i| optional[i].package.to_string())
+            .collect()),
         None => Ok(Vec::new()),
     }
 }
@@ -410,26 +411,28 @@ pub fn pick_optional_packages(
 /// Returns:
 /// - `None`         — user cancelled (no change)
 /// - `Some(None)`   — user chose "Use profile default" (clear override)
-/// - `Some(Some(s))`— user selected a specific DM
+/// - `Some(Some(d))`— user selected a specific DM
 pub fn pick_display_manager(
     terminal: &mut ratatui::DefaultTerminal,
-    profile_default: Option<&str>,
-) -> Result<Option<Option<String>>> {
-    const DMS: &[&str] = &["gdm", "sddm", "lightdm", "ly"];
-
+    profile_default: Option<DisplayManager>,
+) -> Result<Option<Option<DisplayManager>>> {
     let default_label = format!(
         "Use profile default ({})",
-        profile_default.unwrap_or("none")
+        profile_default.map(|d| d.service()).unwrap_or("none")
     );
     let mut labels: Vec<String> = vec![default_label];
-    labels.extend(DMS.iter().map(|s| s.to_string()));
+    labels.extend(
+        DisplayManager::ALL
+            .iter()
+            .map(|d| d.display_name().to_string()),
+    );
     let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
 
     let result = run_select(terminal, "Display manager", &label_refs, 0)?;
     match result.selected {
         None => Ok(None),
         Some(0) => Ok(Some(None)),
-        Some(idx) => Ok(Some(Some(DMS[idx - 1].to_string()))),
+        Some(idx) => Ok(Some(Some(DisplayManager::ALL[idx - 1]))),
     }
 }
 
@@ -618,12 +621,14 @@ pub fn apply_select(
             config.network_copy_iso = idx == 0;
         }
         "seat_access" => {
-            config.seat_access = match idx {
-                0 => None,
-                1 => Some(SeatAccess::Seatd),
-                2 => Some(SeatAccess::Polkit),
-                _ => return Ok(()),
-            };
+            if let Some(sel) = config.profile_selection.as_mut() {
+                sel.seat_access = match idx {
+                    0 => None,
+                    1 => Some(SeatAccess::Seatd),
+                    2 => Some(SeatAccess::Polkit),
+                    _ => return Ok(()),
+                };
+            }
         }
         _ => {}
     }

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -254,12 +254,18 @@ pub async fn pick_kernel(
 /// Pick a GPU driver.
 ///
 /// Detects installed GPUs via `lspci` and highlights the auto-suggested
-/// driver. Returns:
+/// driver. When `wayland_only_profile` is true and the user picks the
+/// proprietary Nvidia open-kernel-module driver, prompts a confirmation
+/// because that combination is known-broken for Wayland-only compositors
+/// (mirrors upstream archinstall's profile_menu.py:97-110 logic).
+///
+/// Returns:
 /// - `None`         — user cancelled (no config change)
 /// - `Some(None)`   — user explicitly chose "None" (clear `gfx_driver`)
 /// - `Some(Some(d))`— user selected a specific driver
 pub fn pick_gpu_driver(
     terminal: &mut ratatui::DefaultTerminal,
+    wayland_only_profile: bool,
 ) -> Result<Option<Option<GfxDriver>>> {
     let gpus = detect_gpus();
     let suggestion = suggested_driver(&gpus);
@@ -306,10 +312,28 @@ pub fn pick_gpu_driver(
         .unwrap_or(0);
 
     let result = run_select(terminal, &title, &opt_refs, current)?;
-    match result.selected {
-        None => Ok(None),                    // cancelled
-        Some(idx) => Ok(Some(drivers[idx])), // Some(None) or Some(Some(driver))
+    let Some(idx) = result.selected else {
+        return Ok(None); // cancelled
+    };
+    let chosen = drivers[idx];
+
+    // Nvidia-on-Wayland-only conflict warning. Only the proprietary open
+    // kernel module is at issue — nouveau works fine on Wayland.
+    if wayland_only_profile && chosen == Some(GfxDriver::NvidiaOpen) {
+        let confirm = run_select(
+            terminal,
+            "The proprietary NVIDIA driver is known-problematic on \
+             Wayland-only compositors. Install it anyway?",
+            &["No — pick a different driver", "Yes — install anyway"],
+            0,
+        )?;
+        if confirm.selected != Some(1) {
+            // User backed out — leave the existing config alone.
+            return Ok(None);
+        }
     }
+
+    Ok(Some(chosen))
 }
 
 /// Full profile selection flow: profile → optional packages → DM → seat access.

--- a/tui/src/tui/screens/steps/desktop.rs
+++ b/tui/src/tui/screens/steps/desktop.rs
@@ -38,15 +38,22 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         },
     ));
 
-    items.push(MenuItem {
-        key: "gpu_driver",
-        label: "GPU driver",
-        value: config
-            .gfx_driver
-            .map(|d| d.to_string())
-            .unwrap_or("None".into()),
-        kind: MenuKind::Custom,
-    });
+    // GPU driver is only meaningful for graphical profiles. Hide the row
+    // for Server / Minimal selections to keep the step focused.
+    if profile_def
+        .as_ref()
+        .is_some_and(|p| p.supports_gfx_driver())
+    {
+        items.push(MenuItem {
+            key: "gpu_driver",
+            label: "GPU driver",
+            value: config
+                .gfx_driver
+                .map(|d| d.to_string())
+                .unwrap_or("None".into()),
+            kind: MenuKind::Custom,
+        });
+    }
 
     items.extend(radio_group(
         "audio",

--- a/tui/src/tui/screens/steps/desktop.rs
+++ b/tui/src/tui/screens/steps/desktop.rs
@@ -3,29 +3,26 @@ use archinstall_zfs_core::config::types::{AudioServer, GlobalConfig, SeatAccess}
 use super::{MenuItem, MenuKind, radio_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
+    let sel = config.profile_selection.as_ref();
+    let profile_def = sel.and_then(|s| s.profile_def());
+
     let mut items = vec![
         MenuItem {
             key: "profile",
             label: "Profile",
-            value: config
-                .profile
-                .as_deref()
-                .and_then(archinstall_zfs_core::profile::get_profile)
+            value: profile_def
+                .as_ref()
                 .map(|p| p.display_name.to_string())
-                .unwrap_or("Not set".into()),
+                .unwrap_or_else(|| "Not set".into()),
             kind: MenuKind::Custom,
         },
         MenuItem {
             key: "display_manager",
             label: "Display manager",
-            value: config.display_manager_override.clone().unwrap_or_else(|| {
-                config
-                    .profile
-                    .as_deref()
-                    .and_then(archinstall_zfs_core::profile::get_profile)
-                    .and_then(|p| p.display_manager().map(str::to_string))
-                    .unwrap_or("Profile default".into())
-            }),
+            value: sel
+                .and_then(|s| s.effective_display_manager())
+                .map(|d| d.display_name().to_string())
+                .unwrap_or_else(|| "Profile default".into()),
             kind: MenuKind::Custom,
         },
     ];
@@ -34,7 +31,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         "seat_access",
         "Seat access",
         &["None", "seatd", "polkit"],
-        match config.seat_access {
+        match sel.and_then(|s| s.seat_access) {
             None => 0,
             Some(SeatAccess::Seatd) => 1,
             Some(SeatAccess::Polkit) => 2,

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -272,17 +272,16 @@ impl Wizard {
                     pickers::pick_profile(&mut self.config, terminal)?;
                 }
                 "display_manager" => {
-                    let eff_dm = self.config.display_manager_override.clone().or_else(|| {
-                        self.config
-                            .profile
-                            .as_deref()
-                            .and_then(archinstall_zfs_core::profile::get_profile)
-                            .and_then(|p| p.display_manager().map(str::to_string))
-                    });
-                    if let Some(result) =
-                        pickers::pick_display_manager(terminal, eff_dm.as_deref())?
+                    let profile_default = self
+                        .config
+                        .profile_selection
+                        .as_ref()
+                        .and_then(|s| s.profile_def())
+                        .and_then(|p| p.default_display_manager());
+                    if let Some(result) = pickers::pick_display_manager(terminal, profile_default)?
+                        && let Some(sel) = self.config.profile_selection.as_mut()
                     {
-                        self.config.display_manager_override = result;
+                        sel.display_manager_override = result;
                     }
                 }
                 "gpu_driver" => {

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -285,7 +285,14 @@ impl Wizard {
                     }
                 }
                 "gpu_driver" => {
-                    if let Some(driver) = pickers::pick_gpu_driver(terminal)? {
+                    let wayland_only = self
+                        .config
+                        .profile_selection
+                        .as_ref()
+                        .and_then(|s| s.profile_def())
+                        .map(|p| p.is_wayland_only())
+                        .unwrap_or(false);
+                    if let Some(driver) = pickers::pick_gpu_driver(terminal, wayland_only)? {
                         self.config.gfx_driver = driver;
                     }
                 }


### PR DESCRIPTION
Restructures the profile system around a tagged `ProfileKind` enum and a single atomic `ProfileSelection` so that desktop-only fields live exclusively where they apply, switching profiles cannot leak stale settings, and the GUI can finally surface the sub-prompts (optional packages, DM override, seat access) that until now only existed in the TUI. Closes the visible-correctness gap that left Wayland users with no way to configure seat access from the GUI.

Three commits, layered:

1. **Core data model** — `Profile { common, kind: ProfileKind { Minimal, Server, Desktop(DesktopProfile) } }`. Display managers become a typed `DisplayManager` enum (`Gdm/Sddm/Lightdm/Ly/CosmicGreeter`) with `service()`/`package()` const methods, replacing the previous string-matching against `services`. SDDM session moves out of the installer match into profile data. `ProfileSelection { profile, optional_packages: BTreeSet<String>, display_manager_override, seat_access }` replaces the flat `profile`/`display_manager_override`/`seat_access` fields on `GlobalConfig` and is replaced atomically when the user switches profiles. `gfx_driver`/`audio`/`bluetooth` stay top-level since they apply to headless installs too. Installer pipeline simplified — typed DM end-to-end, dropped the `DISPLAY_MANAGERS` string set and `sddm_session_for_profile` helper.

2. **GUI Profile configuration section** — new `MultiSelectPopup` component (ScrollView + `preferred-height` content-aware sizing per the slint patterns skill, inline checkbox visuals so the row TouchArea owns clicks). Conditional 'Profile configuration' section card appears in the Desktop step only when a `ProfileKind::Desktop` is active, containing optional-packages and display-manager rows; seat access shows as a dedicated radio group when `needs_seat_access()`. Whole block disappears for Server/Minimal via existing `mark_section_boundaries` adjacency logic.

3. **Follow-ups cribbed from upstream archinstall** — `Xorg (bare)` profile (xorg-server + xorg-xinit, no DE), `supports_gfx_driver()`/`is_wayland_only()` helpers, GPU driver row hidden for Server/Minimal in both UIs, Nvidia/Wayland conflict warning (TUI confirmation dialog, GUI inline `Warning` row), GUI GPU driver picker wired into the Hardware section, optional-package descriptions filled in for GNOME/KDE/Xfce/Hyprland/Sway/i3, README \"Profiles\" section documenting the one-profile-per-install constraint and the JSON shape.

Changes:

- `core/src/profile/mod.rs` — `Profile` + `ProfileKind` + `DesktopProfile` + `DisplayManager`/`DisplayServer` enums + `OptionalPackage` with descriptions; helpers `desktop()`, `is_desktop()`, `default_display_manager()`, `needs_seat_access()`, `supports_gfx_driver()`, `is_wayland_only()`, `optional_packages()`, `sddm_session()`
- `core/src/profile/{desktop,server}.rs` — all 31 profile literals rewritten via `desktop()`/`server()` helpers; new `xorg` profile; SDDM session lifted from installer into profile data
- `core/src/config/types.rs` — `ProfileSelection` with `new()`, `profile_def()`, `effective_display_manager()`, `resolved_packages()`; serde `alias = \"profile\"` for legacy configs
- `core/src/installer/mod.rs` — `install_profile` reads from `profile_selection`, uses typed `DisplayManager` end-to-end
- `tui/src/tui/screens/pickers.rs` — `pick_optional_packages` takes `&[OptionalPackage]` and renders descriptions; `pick_display_manager` returns `Option<Option<DisplayManager>>`; `pick_gpu_driver` takes a `wayland_only_profile: bool` and prompts confirmation on `NvidiaOpen + Wayland`; `pick_profile` does atomic replace via `ProfileSelection::new`
- `tui/src/tui/screens/{wizard,steps/desktop}.rs` — read selection via the new accessors; GPU driver row hidden when `!supports_gfx_driver()`
- `slint-ui/ui/popups/multi-select-popup.slint` — new (139 LOC) following the StringListPopup ScrollView+`preferred-height` pattern; inline checkbox visuals
- `slint-ui/ui/types.slint` — new `MultiSelectOption { text, description, checked }`
- `slint-ui/ui/state/{popup,editing}-state.slint` — backing model + visibility/title/key, mirroring the package-search-popup pattern
- `slint-ui/ui/app.slint` — import + overlay + `multi-select-toggled` / `multi-select-closed` callbacks
- `slint-ui/src/editing_models.rs` — `multi_select` VecModel + `set_multi_select_options` helper
- `slint-ui/src/config_items.rs` — `build_desktop_items` emits the new Profile-configuration section + Seat access radio group + GPU driver row + Nvidia/Wayland Warning row when applicable; `apply_radio` gains a `seat_access` case
- `slint-ui/src/controllers/{wizard,lists}.rs` — handlers for `optional_packages`, `display_manager`, `gpu_driver`; `setup_select_confirmed` branches for `dm_select` / `gfx_driver_select`; `setup_multi_select` toggles rows in place and refreshes on close
- `README.md` — new Profiles section

Tests: 188 core + 27 GUI passing across all three commits. cargo fmt + clippy clean.

## Test plan

- [ ] Boot the GUI, pick GNOME → confirm \"Profile configuration\" section appears with Optional packages + Display manager rows, no Seat access radio
- [ ] Switch to Hyprland → confirm Seat access radio appears with seatd preselected
- [ ] Switch to sshd → confirm Profile configuration / Seat access / GPU driver rows all disappear
- [ ] Open optional packages popup, toggle a few → confirm the count on the row updates after closing
- [ ] Open Display manager popup, pick SDDM with GNOME → confirm row shows \"SDDM (override)\"
- [ ] Pick a Wayland-only compositor + NVIDIA Open driver → confirm GUI shows the inline warning, TUI shows the confirmation dialog
- [ ] Round-trip a config JSON containing the legacy flat \`profile\` field → confirm it loads via the serde alias