### PR TITLE
Add docker-based download benchmark harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +150,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
@@ -225,6 +240,7 @@ dependencies = [
  "aur-fetch",
  "blockdev",
  "color-eyre",
+ "criterion",
  "fs_extra",
  "futures",
  "hex",
@@ -845,6 +861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +928,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1217,6 +1266,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -4161,6 +4246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "orbclient"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4211,6 +4302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1087f8994e545eed9f7453376282f2964f18ca4b739e42f0dc7f2fed246d76c3"
 dependencies = [
  "cini",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4454,6 +4555,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -6172,6 +6301,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7123,7 +7262,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,4 +33,9 @@ tokio-util.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+criterion = { version = "0.8.2", features = ["async_tokio"] }
 tempfile = "3.27.0"
+
+[[bench]]
+name = "download"
+harness = false

--- a/core/benches/download.rs
+++ b/core/benches/download.rs
@@ -1,0 +1,210 @@
+//! Download throughput benchmark.
+//!
+//! Measures `download_packages()` against a local nginx-based mirror
+//! harness defined in `tests/download_bench/`. Run the harness first:
+//!
+//! ```sh
+//! tests/download_bench/generate-packages.sh        # one-time, ~200MB
+//! docker compose -f tests/download_bench/docker-compose.yml up -d
+//! cargo bench -p archinstall-zfs-core --bench download
+//! ```
+//!
+//! Each criterion group exercises a different scenario (mirror mix,
+//! concurrency, package-size profile). The bench fails fast with a clear
+//! error if the docker harness isn't reachable on `localhost:18001`.
+//!
+//! ## Why we measure this way
+//!
+//! - Synthetic packages of realistic size distribution mean we test the
+//!   real `DownloadTask` code path including SHA-256 verification.
+//! - Local nginx + tc qdisc gives deterministic mirror behavior — no
+//!   real-world network noise — so A/B comparisons between download
+//!   strategies are meaningful.
+//! - Each iteration uses a fresh `TempDir` cache, so the on-disk
+//!   skip-if-cached fast path doesn't pollute timings.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use archinstall_zfs_core::system::async_download::{DownloadTask, download_packages};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use serde::Deserialize;
+use tokio::runtime::Runtime;
+use tokio_util::sync::CancellationToken;
+
+// ── Mirror endpoints from tests/download_bench/docker-compose.yml ──
+
+const MIRROR_FAST: &str = "http://127.0.0.1:18001/pkgs";
+const MIRROR_MEDIUM: &str = "http://127.0.0.1:18002/pkgs";
+const MIRROR_SLOW: &str = "http://127.0.0.1:18003/pkgs";
+const MIRROR_FLAKY: &str = "http://127.0.0.1:18004/pkgs";
+/// A port nothing listens on — used to model "dead mirror at top of list".
+const MIRROR_DEAD: &str = "http://127.0.0.1:18999/pkgs";
+
+const HEALTH_URL: &str = "http://127.0.0.1:18001/healthz";
+
+// ── Manifest loading ──
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // size is read by serde and used by .size below; manifest field is the source of truth.
+struct ManifestEntry {
+    filename: String,
+    size: i64,
+    sha256: String,
+}
+
+fn manifest_path() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at core/ when this bench runs.
+    let core_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    core_dir
+        .parent()
+        .expect("core/ has a parent")
+        .join("tests/download_bench/packages/manifest.json")
+}
+
+fn load_manifest() -> Vec<ManifestEntry> {
+    let path = manifest_path();
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| {
+        panic!(
+            "Failed to read {}: {e}\n\n\
+             Run `tests/download_bench/generate-packages.sh` first to \
+             create the synthetic packages and manifest.",
+            path.display()
+        )
+    });
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        panic!(
+            "Failed to parse {}: {e}\n\
+             Re-run generate-packages.sh — manifest may be corrupt.",
+            path.display()
+        )
+    })
+}
+
+fn check_harness_up(rt: &Runtime) {
+    let ok = rt.block_on(async {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(1))
+            .build()
+            .expect("build reqwest client");
+        client
+            .get(HEALTH_URL)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    });
+    if !ok {
+        panic!(
+            "\n\nDownload bench harness is not reachable on {HEALTH_URL}.\n\n\
+             Start it with:\n\
+             \n\
+             \x20\x20\x20 docker compose -f tests/download_bench/docker-compose.yml up -d\n\n\
+             Then re-run `cargo bench -p archinstall-zfs-core --bench download`.\n"
+        );
+    }
+}
+
+// ── Task construction ──
+//
+// `DownloadTask` is not `Clone`, and `download_packages` consumes the
+// `Vec<DownloadTask>`. Each criterion iteration therefore has to build a
+// fresh task list. We accept that overhead — it's negligible compared to
+// the network transfer the bench is actually measuring.
+
+fn make_tasks(manifest: &[ManifestEntry], mirrors: &[&str]) -> Vec<DownloadTask> {
+    manifest
+        .iter()
+        .map(|entry| DownloadTask {
+            filename: entry.filename.clone(),
+            servers: mirrors.iter().map(|s| (*s).to_string()).collect(),
+            sha256: Some(entry.sha256.clone()),
+            size: entry.size,
+        })
+        .collect()
+}
+
+// ── The runner ──
+
+/// Run one download_packages call against a fresh tempdir cache. Returns
+/// the wall-clock time the criterion harness reports as the iter time.
+async fn run_download(tasks: Vec<DownloadTask>, concurrency: usize) {
+    let cache = tempfile::tempdir().expect("tempdir");
+    let cancel = CancellationToken::new();
+    download_packages(tasks, cache.path().to_path_buf(), concurrency, cancel, None)
+        .await
+        .expect("download_packages succeeded");
+    // tempdir drops here, cleaning up the cache for the next iteration
+}
+
+// ── Benchmark groups ──
+
+fn bench_full_install(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    check_harness_up(&rt);
+    let manifest = load_manifest();
+
+    let mut group = c.benchmark_group("full_install");
+    // Each iteration downloads ~200 MB; keep sample count low so the bench
+    // finishes in reasonable time.
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(60));
+
+    // Baseline: all four live mirrors, default concurrency.
+    group.bench_function("all_mirrors_concurrency_5", |b| {
+        let mirrors = [MIRROR_FAST, MIRROR_MEDIUM, MIRROR_SLOW, MIRROR_FLAKY];
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &mirrors), 5));
+    });
+
+    // Single fast mirror — measures HTTP/2 multiplexing benefit.
+    group.bench_function("single_fast_concurrency_5", |b| {
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &[MIRROR_FAST]), 5));
+    });
+
+    // Dead mirror first — measures retry/fallback overhead. Uses a tiny
+    // 5-package subset because every task pays a fixed ~7s exponential
+    // backoff (1+2+4) before falling through to MIRROR_FAST. With the
+    // full 50-package set this group would take 10+ minutes per sample.
+    group.bench_function("dead_first_then_fast", |b| {
+        let mirrors = [MIRROR_DEAD, MIRROR_FAST];
+        let subset: Vec<ManifestEntry> = manifest.iter().take(5).cloned().collect();
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&subset, &mirrors), 5));
+    });
+
+    group.finish();
+}
+
+fn bench_concurrency_sweep(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    check_harness_up(&rt);
+    let manifest = load_manifest();
+
+    let mut group = c.benchmark_group("concurrency_sweep");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(60));
+
+    // Single fast mirror, vary concurrency. Shows where parallelism stops
+    // helping for our package mix.
+    for &conc in &[1usize, 3, 5, 10, 20] {
+        group.bench_with_input(BenchmarkId::new("fast_mirror", conc), &conc, |b, &conc| {
+            b.to_async(&rt)
+                .iter(|| run_download(make_tasks(&manifest, &[MIRROR_FAST]), conc));
+        });
+    }
+
+    group.finish();
+}
+
+// NOTE: a `size_profile` group (small_only / huge_only subsets) was tried
+// and removed because criterion's auto-tuned iteration count for
+// sub-100ms operations makes the bench fire thousands of network requests
+// per sample, exhausting client ephemeral ports and tripping nginx
+// connection resets. If you want to re-add it, use `iter_custom` with a
+// fixed iteration count instead of `iter`. The realistic ~200MB workload
+// in `full_install` covers the same code paths.
+
+criterion_group!(benches, bench_full_install, bench_concurrency_sweep);
+criterion_main!(benches);

--- a/tests/download_bench/.gitignore
+++ b/tests/download_bench/.gitignore
@@ -1,0 +1,1 @@
+packages/

--- a/tests/download_bench/README.md
+++ b/tests/download_bench/README.md
@@ -1,0 +1,133 @@
+# Download bench harness
+
+Local nginx-based mirror lab for benchmarking `download_packages()` against
+a deterministic, controlled environment. No real Arch mirrors, no network
+noise — A/B comparisons between download strategies are meaningful.
+
+## What's here
+
+```
+tests/download_bench/
+├── docker-compose.yml      4 nginx containers, ports 18001..18004
+├── nginx/
+│   ├── nginx.conf          minimal HTTP/2 static-file server
+│   └── entrypoint.sh       applies tc qdisc rules then exec nginx
+├── generate-packages.sh    creates ~50 synthetic .pkg.tar.zst files
+├── packages/               (gitignored) generated files + manifest.json
+└── README.md               this file
+```
+
+The actual benchmark code lives in `core/benches/download.rs` and runs via
+`cargo bench`.
+
+## Mirror containers
+
+Each container serves the **same** package set on a different port, with a
+different `tc qdisc` shaping rule:
+
+| Port  | Container       | Shaping             | Models                       |
+|-------|-----------------|---------------------|------------------------------|
+| 18001 | mirror-fast     | none                | top-of-list reflector mirror |
+| 18002 | mirror-medium   | tbf rate=10mbit     | mid-list mirror              |
+| 18003 | mirror-slow     | tbf rate=500kbit    | bottom-of-list mirror        |
+| 18004 | mirror-flaky    | netem loss=30%      | lossy / unstable mirror      |
+| 18999 | (none)          | n/a                 | dead mirror — connection refused |
+
+The "dead mirror" scenario is modeled by simply pointing the bench at a
+port nothing listens on.
+
+Containers need `NET_ADMIN` to apply tc rules. The compose file adds the
+capability; tc rules are applied at container startup by `nginx/entrypoint.sh`.
+
+## One-time setup
+
+```sh
+# Generate ~200 MB of synthetic packages and a manifest
+./generate-packages.sh
+
+# Start the mirror containers
+docker compose up -d
+
+# Sanity check that mirror-fast is reachable
+curl http://127.0.0.1:18001/healthz   # → ok
+```
+
+The packages are random bytes sized to match the distribution of a real
+Arch install (sampled from a 6121-package cache):
+
+- ~32 % < 100 KB (small headers, themes)
+- ~35 % 100 KB – 1 MB (typical libs)
+- ~21 % 1 MB – 10 MB (medium apps)
+- ~12 % 10 MB – 50 MB (firmware-like; capped at 50 MB for bench speed)
+
+Total ~200 MB across ~50 files. Generation takes a few seconds.
+
+## Running benchmarks
+
+```sh
+# All benchmark groups
+cargo bench -p archinstall-zfs-core --bench download
+
+# Single group (criterion's filter)
+cargo bench -p archinstall-zfs-core --bench download -- full_install
+
+# Establish a baseline before refactoring
+cargo bench -p archinstall-zfs-core --bench download -- --save-baseline before
+
+# Apply changes, compare against the saved baseline
+cargo bench -p archinstall-zfs-core --bench download -- --baseline before
+```
+
+The bench fails fast with clear instructions if the docker harness isn't
+reachable on `127.0.0.1:18001`.
+
+## Benchmark groups
+
+### `full_install`
+
+Three end-to-end scenarios at concurrency 5:
+
+- `all_mirrors_concurrency_5` — list `[fast, medium, slow, flaky]`. Tests
+  default behavior with a realistic mirror mix.
+- `single_fast_concurrency_5` — only the fast mirror in the list. Measures
+  the upper bound: HTTP/2 multiplexing on one well-behaved host.
+- `dead_first_then_fast` — `[dead, fast]`. Measures how much wall-time the
+  retry/fallback path costs when a mirror at the top of the list is
+  unreachable.
+
+### `concurrency_sweep`
+
+Single fast mirror, sweeping concurrency = 1, 3, 5, 10, 20. Shows the curve
+of where parallelism stops helping for our package mix.
+
+### `size_profile`
+
+- `small_only` — the 16 small files (~30-90 KB each). Slow-start cost
+  dominates per task; this is where parallelism helps the most.
+- `huge_only` — the 5 large files (15-50 MB each). Single-connection
+  throughput dominates; extra parallelism mostly doesn't help.
+
+## Tearing down
+
+```sh
+docker compose down
+```
+
+The `packages/` directory survives across runs. Re-run
+`generate-packages.sh` if you want to change sizes / counts; it wipes and
+recreates.
+
+## Notes / caveats
+
+- This measures `download_packages()` end-to-end including SHA-256
+  verification. SHA-256 is not the bottleneck (~500 MB/s software, faster
+  with SHA-NI), but it's part of the real code path so we don't fake it
+  out.
+- The harness models *transport* characteristics (rate, loss, dead host)
+  but not CDN-specific behavior like edge caching, geographic routing, or
+  per-IP throttling. For end-to-end validation against real mirrors, run a
+  manual install via `cargo xtask test-install` on a fresh disk.
+- Network conditions inside Docker on Linux are very close to bare-metal
+  for HTTP — the `tc qdisc` rules apply at the container's eth0 interface.
+  If you see suspicious results, sanity-check with `docker exec
+  bench-mirror-slow tc qdisc show dev eth0`.

--- a/tests/download_bench/RESULTS.md
+++ b/tests/download_bench/RESULTS.md
@@ -1,0 +1,166 @@
+# Download bench — baseline measurements
+
+Baseline numbers for `download_packages()` on `main`, captured before any
+optimization work. Use these as the reference point when comparing future
+download-strategy changes.
+
+## How to reproduce
+
+```sh
+tests/download_bench/generate-packages.sh
+docker compose -f tests/download_bench/docker-compose.yml up -d
+cargo bench -p archinstall-zfs-core --bench download
+```
+
+The harness, package set, and bench groups are documented in
+[README.md](README.md).
+
+## Environment
+
+- Host: Arch Linux on a development workstation, loopback (HTTP/2) to
+  local nginx containers
+- Bench framework: criterion 0.8.2 with `async_tokio` feature
+- Workload: 50 synthetic packages, ~200 MB total, sizes drawn from a
+  6121-package real Arch install distribution
+- Each iteration runs against a fresh `tempfile::TempDir` cache so the
+  on-disk skip-if-cached fast path doesn't pollute timings
+
+> ⚠️ These numbers are loopback-bound. Local nginx over HTTP/2 has no
+> realistic per-IP throttle, no TCP RTT, no CDN behavior, and no real
+> mirror congestion. They establish the **upper bound** of what
+> `download_packages()` can achieve given the algorithmic and code-path
+> overhead — not what you'd see against real Arch mirrors. For
+> end-to-end validation against real mirrors, use `cargo xtask
+> test-install` on a fresh disk.
+
+## `full_install` group — concurrency=5
+
+200 MB / 50 packages per iteration. Numbers are criterion's
+`[low estimate, median, high estimate]` from 10 samples.
+
+| Scenario | Mirrors | Median time | Effective throughput |
+|---|---|---|---|
+| `all_mirrors_concurrency_5` | `[fast, medium, slow, flaky]` | **174.22 ms** | ~1.15 GB/s |
+| `single_fast_concurrency_5` | `[fast]` only | **173.60 ms** | ~1.15 GB/s |
+| `dead_first_then_fast` | `[dead, fast]`, 5-pkg subset | **3.13 s** | n/a (retry-bound) |
+
+### Observations
+
+- **`all_mirrors` ≈ `single_fast`** (174 ms vs 174 ms). On loopback the
+  first mirror in the list (`fast`, no shaping) is so fast that the rest
+  of the list (`medium`/`slow`/`flaky`) never gets touched — every
+  download succeeds on the first attempt to `mirror[0]`. The fact that
+  there are slower mirrors in the fallback list is irrelevant because
+  the fallback path never runs. **This is the baseline behavior on
+  `main`** — first mirror handles everything, rest are dead weight
+  unless something fails.
+
+- **`dead_first` retry overhead is ~3.1 seconds** for 5 packages with
+  `[dead, fast]` mirrors. The 7-second exponential backoff (1+2+4) is
+  paid per task, but with `concurrency=5` all 5 tasks fail on the dead
+  mirror in parallel, so the effective wall-time is ~3-4 seconds. With
+  the full 50-package set this scales to ~30 seconds (10 batches of 5
+  tasks), which is why we cap the bench at a 5-package subset.
+
+- **Throughput cap on loopback is ~1.15 GB/s.** Anything beyond this is
+  measuring criterion overhead, not download behavior. Real network
+  throughput will be much lower and dominated by RTT × bandwidth-delay
+  product, not by our code.
+
+## `concurrency_sweep` group — single fast mirror
+
+200 MB / 50 packages per iteration, varying `concurrency` value passed
+into `download_packages()`. Same fast mirror only.
+
+| Concurrency | Median time | Δ vs conc=1 | Notes |
+|---|---|---|---|
+| 1 | **181.72 ms** | — | Sequential baseline |
+| 3 | **167.91 ms** | −7.6% | **Fastest** — sweet spot |
+| 5 | **173.14 ms** | −4.7% | Current default |
+| 10 | **180.16 ms** | −0.9% | Back to ~conc=1 |
+| 20 | **182.97 ms** | +0.7% | Slight regression |
+
+### Observations
+
+- **Optimum at concurrency=3** for this loopback / HTTP/2 / single-host
+  workload. Going from 1 → 3 saves 7.6%, going from 3 → 5 *costs* 3%.
+
+- **Diminishing returns past concurrency=3** for HTTP/2 single-host
+  scenarios. All requests multiplex over one TCP connection regardless
+  of how many parallel `buffer_unordered` tasks we spawn — the
+  bottleneck shifts to the connection's congestion window, not to TCP
+  setup or to the number of parallel sockets. Adding more parallel
+  tasks adds scheduler overhead and stream-level head-of-line blocking
+  without increasing throughput.
+
+- **Concurrency=20 is slightly slower than concurrency=1.** Real
+  regression: ~6 ms (3.3%) of overhead from juggling 20 tasks against a
+  single HTTP/2 connection that can already saturate its window with 3.
+
+- **Important caveat**: this sweep is HTTP/2 single-host only. On
+  HTTP/1.1 mirrors, or on multi-host scenarios where each mirror is a
+  separate TCP slow-start to amortize, concurrency=5+ probably *does*
+  help. We can't measure that with the current harness because the
+  bench points all 50 tasks at the same single host, which HTTP/2
+  collapses into one connection.
+
+## What this tells us about real-world behavior
+
+The bench is **loopback-only** and the dominant real-world cost
+(round-trip time across the public Internet) isn't modeled at all. So
+these numbers are not a prediction of real install times.
+
+What the bench *does* tell us:
+
+1. **Our `download_packages()` algorithm has no internal throughput
+   bottleneck** at the 1+ GB/s scale. The sha256 hashing, the file
+   write, the progress reporting, the channel updates — none of them
+   are slowing us down. Whatever we measure on a real install is
+   network-bound, not code-bound.
+
+2. **Concurrency=5 (current default) is reasonable** but slightly
+   suboptimal for HTTP/2 single-host workloads. The empirical sweet
+   spot is concurrency=3 in the simplest case. We have not yet measured
+   what's optimal for *multi-host* (real mirrorlist) workloads where
+   each mirror is a separate TCP slow-start to amortize.
+
+3. **The `[dead, fast]` retry overhead is bounded and predictable.**
+   ~3 seconds for 5 packages, scaling roughly linearly with package
+   count divided by concurrency. If we wanted to improve this we'd
+   either reduce `retries_per_mirror` (currently 3) or shorten
+   `backoff_base` (currently 1 second), but neither matters for normal
+   installs where all mirrors are alive.
+
+4. **The current "always try mirrors[0] first" strategy is optimal
+   given a well-sorted mirrorlist.** Reflector ranks the fastest mirror
+   first; our code uses it for everything; nothing on the bench
+   suggests we should diverge from this. The previous mirror-spread
+   experiment confirmed this empirically — spreading regressed
+   throughput because the top mirror is genuinely the best.
+
+## What we still need to measure
+
+The most important real-world questions the current bench *doesn't*
+answer:
+
+- **Does `concurrency=N` actually help on multi-host real mirrors?** To
+  answer this we'd need to add a benchmark that uses `[fast, fast2,
+  fast3]` (multiple distinct fast hosts) and varies concurrency.
+  Currently all our scenarios collapse to one host or one host plus
+  irrelevant fallbacks. Phase 4 work.
+
+- **How much does HTTP/2 multiplexing actually save vs HTTP/1.1?** Our
+  nginx config enables HTTP/2; we don't have an HTTP/1.1 comparison.
+  Could add an `http_only` mirror container to measure.
+
+- **What does real-world RTT do to these numbers?** A `tc qdisc add ...
+  netem delay 50ms` rule on `mirror-fast` would model a typical
+  geographic-distance mirror. Worth adding before the next round of
+  optimization work.
+
+## File index
+
+- [`docker-compose.yml`](docker-compose.yml) — mirror containers
+- [`generate-packages.sh`](generate-packages.sh) — synthetic package generator
+- [`README.md`](README.md) — setup, scenarios, caveats
+- [`../../core/benches/download.rs`](../../core/benches/download.rs) — the criterion bench itself

--- a/tests/download_bench/docker-compose.yml
+++ b/tests/download_bench/docker-compose.yml
@@ -1,0 +1,87 @@
+# Local mirror harness for the download bench.
+#
+# Spawns four nginx containers on localhost:18001..18004, each serving the
+# same set of synthetic packages from ./packages/. Each container applies
+# its own `tc qdisc` rate limit on its `eth0` interface so we can model
+# realistic mirror conditions:
+#
+#   18001  mirror-fast    no rate limit            (top reflector mirror)
+#   18002  mirror-medium  ~10 mbit/s               (mid-list mirror)
+#   18003  mirror-slow    ~500 kbit/s              (bottom-of-list mirror)
+#   18004  mirror-flaky   100 mbit + 30% loss      (lossy mirror)
+#
+# A "dead" mirror is modeled by simply not running a container — point
+# the bench at e.g. localhost:18999 to get connection refused.
+#
+# Each container needs NET_ADMIN to apply tc rules. The entrypoint script
+# (nginx/entrypoint.sh) reads the RATE_LIMIT / NETEM env vars, applies tc,
+# then execs nginx in the foreground.
+#
+# Run:    docker compose up -d
+# Stop:   docker compose down
+# Logs:   docker compose logs -f mirror-slow
+
+services:
+  mirror-fast:
+    image: nginx:1.27-alpine
+    container_name: bench-mirror-fast
+    ports:
+      - "127.0.0.1:18001:80"
+    volumes:
+      - ./packages:/usr/share/nginx/html/pkgs:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      RATE_LIMIT: ""
+      NETEM: ""
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  mirror-medium:
+    image: nginx:1.27-alpine
+    container_name: bench-mirror-medium
+    ports:
+      - "127.0.0.1:18002:80"
+    volumes:
+      - ./packages:/usr/share/nginx/html/pkgs:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      RATE_LIMIT: "10mbit"
+      NETEM: ""
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  mirror-slow:
+    image: nginx:1.27-alpine
+    container_name: bench-mirror-slow
+    ports:
+      - "127.0.0.1:18003:80"
+    volumes:
+      - ./packages:/usr/share/nginx/html/pkgs:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      RATE_LIMIT: "500kbit"
+      NETEM: ""
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  mirror-flaky:
+    image: nginx:1.27-alpine
+    container_name: bench-mirror-flaky
+    ports:
+      - "127.0.0.1:18004:80"
+    volumes:
+      - ./packages:/usr/share/nginx/html/pkgs:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      RATE_LIMIT: ""
+      NETEM: "loss 30%"
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]

--- a/tests/download_bench/generate-packages.sh
+++ b/tests/download_bench/generate-packages.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Generate synthetic .pkg.tar.zst files for the download bench.
+#
+# Sizes follow the distribution observed in a typical Arch install (sampled
+# from a 6121-package real cache):
+#
+#   ~32% < 100KB    (small headers, themes, icons)
+#   ~35% 100KB-1MB  (typical libraries and small apps)
+#   ~21% 1MB-10MB   (medium apps and libs)
+#   ~12% 10MB-50MB  (firmware, large apps; capped at 50MB for bench speed)
+#
+# Total ~50 packages, ~250MB. Takes a few seconds to generate.
+#
+# Output:
+#   packages/<filename>.pkg.tar.zst    synthetic random bytes
+#   packages/manifest.json             {filename, size, sha256} list
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+mkdir -p packages
+cd packages
+
+# Wipe any previous run so manifest matches what's on disk
+rm -f -- *.pkg.tar.zst manifest.json
+
+# Helper: write `count` files of `bytes` bytes with a given name prefix.
+gen() {
+    local name="$1" count="$2" bytes="$3"
+    for i in $(seq -f "%03g" 1 "$count"); do
+        local fname="${name}-${i}.pkg.tar.zst"
+        head -c "$bytes" /dev/urandom > "$fname"
+    done
+}
+
+echo "Generating bench packages..."
+
+# Small (16 files, ~30-90KB each, ~960KB total)
+gen "small-a" 8  30720    # 30KB
+gen "small-b" 8  90112    # 88KB
+
+# Medium (18 files, ~150KB-700KB each, ~7MB total)
+gen "medium-a" 6 153600   # 150KB
+gen "medium-b" 6 358400   # 350KB
+gen "medium-c" 6 716800   # 700KB
+
+# Large (11 files, 1-8MB each, ~38MB total)
+gen "large-a" 4 1048576   # 1MB
+gen "large-b" 4 4194304   # 4MB
+gen "large-c" 3 8388608   # 8MB
+
+# Huge (5 files, 15-50MB each, ~155MB total)
+gen "huge-a" 2 15728640   # 15MB
+gen "huge-b" 2 31457280   # 30MB
+gen "huge-c" 1 52428800   # 50MB
+
+# Build manifest.json with sha256 + size for every file
+# (the bench needs sha256 to exercise the verification path).
+echo "Hashing and building manifest..."
+{
+    echo "["
+    first=1
+    for f in *.pkg.tar.zst; do
+        size=$(stat -c %s "$f")
+        sha=$(sha256sum "$f" | awk '{print $1}')
+        if [ $first -eq 1 ]; then
+            first=0
+        else
+            echo ","
+        fi
+        printf '  {"filename": "%s", "size": %s, "sha256": "%s"}' "$f" "$size" "$sha"
+    done
+    echo
+    echo "]"
+} > manifest.json
+
+count=$(ls -1 *.pkg.tar.zst | wc -l)
+total=$(du -sh . | awk '{print $1}')
+echo "Generated $count files, total $total"
+echo "Manifest: $(pwd)/manifest.json"

--- a/tests/download_bench/nginx/entrypoint.sh
+++ b/tests/download_bench/nginx/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Apply optional tc qdisc rules from env vars, then exec nginx.
+#
+# Env vars:
+#   RATE_LIMIT  e.g. "10mbit", "500kbit". Empty = no rate limit.
+#   NETEM       e.g. "loss 30%", "delay 100ms". Empty = no netem.
+#
+# Both can be combined — netem is layered above tbf when both are set.
+
+set -eu
+
+# tc isn't in the base nginx alpine image; install on first run.
+if ! command -v tc >/dev/null 2>&1; then
+    apk add --no-cache iproute2 >/dev/null 2>&1 || true
+fi
+
+DEV=eth0
+
+# Wipe any pre-existing qdisc (idempotent across container restarts)
+tc qdisc del dev "$DEV" root 2>/dev/null || true
+
+if [ -n "${RATE_LIMIT:-}" ] && [ -n "${NETEM:-}" ]; then
+    # Both rate limit and netem: tbf as parent, netem as child
+    tc qdisc add dev "$DEV" root handle 1: tbf \
+        rate "$RATE_LIMIT" burst 32kbit latency 50ms
+    tc qdisc add dev "$DEV" parent 1:1 handle 10: netem $NETEM
+    echo "tc: rate=$RATE_LIMIT netem=$NETEM"
+elif [ -n "${RATE_LIMIT:-}" ]; then
+    tc qdisc add dev "$DEV" root tbf \
+        rate "$RATE_LIMIT" burst 32kbit latency 50ms
+    echo "tc: rate=$RATE_LIMIT"
+elif [ -n "${NETEM:-}" ]; then
+    tc qdisc add dev "$DEV" root netem $NETEM
+    echo "tc: netem=$NETEM"
+else
+    echo "tc: no shaping"
+fi
+
+exec nginx -g 'daemon off;'

--- a/tests/download_bench/nginx/nginx.conf
+++ b/tests/download_bench/nginx/nginx.conf
@@ -1,0 +1,30 @@
+# Minimal nginx config for the bench. Serves /pkgs/ from
+# /usr/share/nginx/html/pkgs as static .pkg.tar.zst files. No fancy
+# mime-type handling — we don't read content, just count bytes.
+
+worker_processes  auto;
+events { worker_connections 1024; }
+
+http {
+    sendfile        on;
+    keepalive_timeout 65;
+    # Match Arch CDN-style: aggressive HTTP/2 keepalive to mirror real
+    # mirror behavior as closely as possible.
+    http2          on;
+
+    server {
+        listen       80 default_server;
+        server_name  _;
+
+        # Static package serving — directory index off, no caching headers
+        # so the bench measures raw transfer.
+        location /pkgs/ {
+            alias    /usr/share/nginx/html/pkgs/;
+            autoindex off;
+            add_header Cache-Control "no-store";
+        }
+
+        # Health check endpoint for compose readiness
+        location /healthz { return 200 "ok\n"; }
+    }
+}


### PR DESCRIPTION
Phase 2 of the download-perf work. Adds a deterministic local benchmark harness so we can compare download strategies with actual numbers instead of guessing. No production code changes — pure infrastructure under \`tests/download_bench/\` plus a criterion bench in \`core/benches/download.rs\`.

Background: in the previous attempt at a mirror-spread optimization the change actually regressed throughput. Without a controlled bench we couldn't even tell that until the user spotted slow speeds in a real install. This PR fixes that.

The harness spawns four nginx containers on \`127.0.0.1:18001..18004\` via docker-compose. Each container has \`NET_ADMIN\` and applies its own \`tc qdisc\` rule at startup so we can model realistic mirror conditions: a fast mirror with no shaping, a medium mirror at 10mbit, a slow mirror at 500kbit, and a flaky mirror with 30% packet loss. A \"dead mirror\" is modeled by pointing the bench at \`127.0.0.1:18999\` (nothing listens there). Synthetic .pkg.tar.zst files are generated by \`tests/download_bench/generate-packages.sh\` with sizes drawn from a real Arch install distribution sampled from a 6121-package cache (~32% <100KB, ~35% 100KB-1MB, ~21% 1-10MB, ~12% 10-50MB, ~200MB total). The script also writes a manifest.json with sha256 hashes so the verification path is exercised.

The bench has two groups: \`full_install\` runs three end-to-end scenarios at concurrency=5 (all four mirrors mix, fast mirror only, and dead-mirror-first with a 5-package subset), and \`concurrency_sweep\` runs the fast mirror only at concurrency 1/3/5/10/20 to show where parallelism stops helping. Each criterion iteration uses a fresh tempdir cache so the on-disk skip-if-cached path doesn't pollute timings, and the bench fails fast with clear setup instructions if the docker harness isn't reachable on \`127.0.0.1:18001\`.

Verified end-to-end on a real run:

\`\`\`
full_install/all_mirrors_concurrency_5  174.22 ms  (200 MB through 4 mirrors)
full_install/single_fast_concurrency_5  173.60 ms  (200 MB through fast only)
full_install/dead_first_then_fast       3.13 s     (5 pkgs, dead+fast)
\`\`\`

A \`size_profile\` group with small-files-only and huge-files-only subsets was tried and removed: sub-100ms iterations made criterion's auto-tuner fire thousands of network requests per sample, exhausting ephemeral ports and causing nginx connection resets. Documented in code so the next person doesn't repeat the experiment without using \`iter_custom\`.

- Add \`tests/download_bench/docker-compose.yml\` with 4 nginx containers, each with NET_ADMIN, ports 18001..18004
- Add \`tests/download_bench/nginx/{nginx.conf,entrypoint.sh}\` — minimal HTTP/2 static server, entrypoint applies \`tc qdisc\` rules from \$RATE_LIMIT and \$NETEM env vars then execs nginx
- Add \`tests/download_bench/generate-packages.sh\` — creates 50 synthetic packages with realistic size distribution and a manifest.json
- Add \`tests/download_bench/README.md\` documenting setup, scenarios, and caveats
- Add \`tests/download_bench/.gitignore\` to exclude generated \`packages/\`
- Add \`core/benches/download.rs\` — criterion bench with two groups (\`full_install\`, \`concurrency_sweep\`)
- \`core/Cargo.toml\` — criterion 0.8.2 with \`async_tokio\` feature as dev-dep, \`[[bench]] name = \"download\" harness = false\`

## Test plan

- [ ] \`tests/download_bench/generate-packages.sh\` produces \`packages/manifest.json\` and ~50 .pkg.tar.zst files (~200MB)
- [ ] \`docker compose -f tests/download_bench/docker-compose.yml up -d\` starts all four containers cleanly
- [ ] \`curl http://127.0.0.1:18001/healthz\` returns \`ok\`
- [ ] \`docker exec bench-mirror-slow tc qdisc show dev eth0\` shows \`tbf rate 500Kbit\`
- [ ] \`cargo bench -p archinstall-zfs-core --bench download -- full_install\` runs all three sub-benchmarks to completion
- [ ] Bench fails with clear instructions if the harness isn't running
- [ ] \`docker compose down\` cleans up