### PR TITLE
Extend bench harness: multi-host, HTTP/1.1, latency

### DIFF
--- a/core/benches/download.rs
+++ b/core/benches/download.rs
@@ -38,6 +38,10 @@ const MIRROR_FAST: &str = "http://127.0.0.1:18001/pkgs";
 const MIRROR_MEDIUM: &str = "http://127.0.0.1:18002/pkgs";
 const MIRROR_SLOW: &str = "http://127.0.0.1:18003/pkgs";
 const MIRROR_FLAKY: &str = "http://127.0.0.1:18004/pkgs";
+const MIRROR_FAST2: &str = "http://127.0.0.1:18005/pkgs";
+const MIRROR_FAST3: &str = "http://127.0.0.1:18006/pkgs";
+const MIRROR_HTTP1: &str = "http://127.0.0.1:18007/pkgs";
+const MIRROR_LAGGY: &str = "http://127.0.0.1:18008/pkgs";
 /// A port nothing listens on — used to model "dead mirror at top of list".
 const MIRROR_DEAD: &str = "http://127.0.0.1:18999/pkgs";
 
@@ -198,6 +202,109 @@ fn bench_concurrency_sweep(c: &mut Criterion) {
     group.finish();
 }
 
+/// `multi_host` — exercises multiple distinct origins (separate TCP
+/// connections to fast2/fast3 in addition to fast). On `main` the current
+/// "always try mirrors[0] first" code only ever hits the first mirror,
+/// so these scenarios serve as the **baseline against which any future
+/// multi-host strategy** (round-robin, spread, slowness-failover) must
+/// be compared.
+fn bench_multi_host(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    check_harness_up(&rt);
+    let manifest = load_manifest();
+
+    let mut group = c.benchmark_group("multi_host");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(60));
+
+    // Three distinct fast hosts in the mirror list. Different ports →
+    // different origins → reqwest opens separate TCP connections to
+    // each, instead of multiplexing everything over one HTTP/2 session.
+    // Current code always picks mirror[0] (fast), so this measures the
+    // *upper bound* a single-host strategy can achieve when the list
+    // would have allowed parallelism. Any future spread / round-robin
+    // implementation must beat this baseline to be worth shipping.
+    let three_fast = [MIRROR_FAST, MIRROR_FAST2, MIRROR_FAST3];
+
+    group.bench_function("three_fast_concurrency_5", |b| {
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &three_fast), 5));
+    });
+
+    group.bench_function("three_fast_concurrency_10", |b| {
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &three_fast), 10));
+    });
+
+    group.finish();
+}
+
+/// `protocol` — HTTP/2 multiplexing vs HTTP/1.1 keep-alive on the same
+/// single host. Both servers are otherwise identical (same nginx, same
+/// loopback, no shaping). Difference is purely the protocol negotiated.
+fn bench_protocol(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    check_harness_up(&rt);
+    let manifest = load_manifest();
+
+    let mut group = c.benchmark_group("protocol");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(60));
+
+    group.bench_function("http2_single_host", |b| {
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &[MIRROR_FAST]), 5));
+    });
+
+    group.bench_function("http1_single_host", |b| {
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &[MIRROR_HTTP1]), 5));
+    });
+
+    group.finish();
+}
+
+/// `latency` — RTT-bound scenarios. The `mirror-laggy` container has
+/// `tc qdisc netem delay 50ms` on its eth0, so every request pays a
+/// 50ms RTT for the TCP handshake plus per-stream HTTP/2 setup. Models
+/// a geographically distant mirror.
+///
+/// The interesting question this group answers: does parallelism still
+/// help when the bottleneck is RTT instead of bandwidth?
+fn bench_latency(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    check_harness_up(&rt);
+    let manifest = load_manifest();
+
+    let mut group = c.benchmark_group("latency");
+    group.sample_size(10);
+    // Latency-bound iters take longer; budget more time per sample.
+    group.measurement_time(Duration::from_secs(120));
+
+    // Reference point: same workload on the no-shaping mirror so we can
+    // read off the pure RTT cost as the delta.
+    group.bench_function("low_latency", |b| {
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &[MIRROR_FAST]), 5));
+    });
+
+    group.bench_function("geo_50ms_concurrency_5", |b| {
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &[MIRROR_LAGGY]), 5));
+    });
+
+    // Higher concurrency to test whether parallelism amortizes RTT.
+    // With HTTP/2 multiplexing all streams share one connection, so
+    // they share the RTT cost — concurrency should help less here than
+    // you'd naively expect.
+    group.bench_function("geo_50ms_concurrency_10", |b| {
+        b.to_async(&rt)
+            .iter(|| run_download(make_tasks(&manifest, &[MIRROR_LAGGY]), 10));
+    });
+
+    group.finish();
+}
+
 // NOTE: a `size_profile` group (small_only / huge_only subsets) was tried
 // and removed because criterion's auto-tuned iteration count for
 // sub-100ms operations makes the bench fire thousands of network requests
@@ -206,5 +313,12 @@ fn bench_concurrency_sweep(c: &mut Criterion) {
 // fixed iteration count instead of `iter`. The realistic ~200MB workload
 // in `full_install` covers the same code paths.
 
-criterion_group!(benches, bench_full_install, bench_concurrency_sweep);
+criterion_group!(
+    benches,
+    bench_full_install,
+    bench_concurrency_sweep,
+    bench_multi_host,
+    bench_protocol,
+    bench_latency
+);
 criterion_main!(benches);

--- a/tests/download_bench/README.md
+++ b/tests/download_bench/README.md
@@ -25,16 +25,30 @@ The actual benchmark code lives in `core/benches/download.rs` and runs via
 Each container serves the **same** package set on a different port, with a
 different `tc qdisc` shaping rule:
 
-| Port  | Container       | Shaping             | Models                       |
-|-------|-----------------|---------------------|------------------------------|
-| 18001 | mirror-fast     | none                | top-of-list reflector mirror |
-| 18002 | mirror-medium   | tbf rate=10mbit     | mid-list mirror              |
-| 18003 | mirror-slow     | tbf rate=500kbit    | bottom-of-list mirror        |
-| 18004 | mirror-flaky    | netem loss=30%      | lossy / unstable mirror      |
-| 18999 | (none)          | n/a                 | dead mirror — connection refused |
+| Port  | Container       | Shaping              | Protocol  | Models                           |
+|-------|-----------------|----------------------|-----------|----------------------------------|
+| 18001 | mirror-fast     | none                 | HTTP/2    | top-of-list reflector mirror     |
+| 18002 | mirror-medium   | tbf rate=10mbit      | HTTP/2    | mid-list mirror                  |
+| 18003 | mirror-slow     | tbf rate=500kbit     | HTTP/2    | bottom-of-list mirror            |
+| 18004 | mirror-flaky    | netem loss=30%       | HTTP/2    | lossy / unstable mirror          |
+| 18005 | mirror-fast2    | none                 | HTTP/2    | second fast host (multi-host)    |
+| 18006 | mirror-fast3    | none                 | HTTP/2    | third fast host (multi-host)     |
+| 18007 | mirror-http1    | none                 | HTTP/1.1  | HTTP/1.1 baseline                |
+| 18008 | mirror-laggy    | netem delay=50ms     | HTTP/2    | geographically distant mirror    |
+| 18999 | (none)          | n/a                  | n/a       | dead mirror — connection refused |
 
 The "dead mirror" scenario is modeled by simply pointing the bench at a
 port nothing listens on.
+
+`mirror-http1` uses a separate nginx config (`nginx/nginx-http1.conf`)
+with `http2 on;` removed so the bench can compare HTTP/2 multiplexing
+vs HTTP/1.1 keep-alive on a single host.
+
+`mirror-fast2` and `mirror-fast3` are deliberately on different ports so
+reqwest sees them as distinct origins (scheme + host + port) and opens
+**separate TCP connections** to each. Without the port difference HTTP/2
+would multiplex everything over one connection and the multi-host bench
+group would degenerate to single-host.
 
 Containers need `NET_ADMIN` to apply tc rules. The compose file adds the
 capability; tc rules are applied at container startup by `nginx/entrypoint.sh`.
@@ -93,12 +107,47 @@ Three end-to-end scenarios at concurrency 5:
   the upper bound: HTTP/2 multiplexing on one well-behaved host.
 - `dead_first_then_fast` — `[dead, fast]`. Measures how much wall-time the
   retry/fallback path costs when a mirror at the top of the list is
-  unreachable.
+  unreachable. Uses a 5-package subset to bound the exponential-backoff
+  cost (otherwise this group would take 10+ minutes per sample).
 
 ### `concurrency_sweep`
 
 Single fast mirror, sweeping concurrency = 1, 3, 5, 10, 20. Shows the curve
 of where parallelism stops helping for our package mix.
+
+### `multi_host`
+
+Three distinct fast hosts (`fast`, `fast2`, `fast3`) in the mirror list,
+each on a separate port = separate origin = separate TCP connection. On
+`main` the current "always try mirrors[0] first" code only ever uses the
+first host, so this group establishes the **baseline** any future
+multi-host strategy (round-robin / spread / slowness-failover) must
+beat.
+
+- `three_fast_concurrency_5` — three fast hosts, conc=5
+- `three_fast_concurrency_10` — three fast hosts, conc=10
+
+### `protocol`
+
+HTTP/2 multiplexing vs HTTP/1.1 keep-alive on the same single host
+otherwise. Both servers identical except for the protocol negotiated.
+
+- `http2_single_host` — `[fast]` (HTTP/2)
+- `http1_single_host` — `[http1]` (HTTP/1.1)
+
+### `latency`
+
+Geographic-distance mirror modeled with `tc qdisc netem delay 50ms`.
+Every request pays a 50 ms RTT for the TCP handshake plus per-stream
+HTTP/2 setup. Tests whether parallelism still helps when the bottleneck
+is RTT instead of bandwidth.
+
+- `low_latency` — reference point on `[fast]` (no delay), conc=5
+- `geo_50ms_concurrency_5` — `[laggy]` at 50 ms RTT, conc=5
+- `geo_50ms_concurrency_10` — `[laggy]` at 50 ms RTT, conc=10
+
+The latency group has `measurement_time = 120s` (vs 60s for the others)
+because each iter is RTT-dominated and slower.
 
 ### `size_profile`
 

--- a/tests/download_bench/RESULTS.md
+++ b/tests/download_bench/RESULTS.md
@@ -25,13 +25,16 @@ The harness, package set, and bench groups are documented in
 - Each iteration runs against a fresh `tempfile::TempDir` cache so the
   on-disk skip-if-cached fast path doesn't pollute timings
 
-> ⚠️ These numbers are loopback-bound. Local nginx over HTTP/2 has no
-> realistic per-IP throttle, no TCP RTT, no CDN behavior, and no real
-> mirror congestion. They establish the **upper bound** of what
+> ⚠️ Most numbers are loopback-bound. Local nginx over HTTP/2 has no
+> realistic per-IP throttle and (except in the `latency` group) no
+> RTT, no CDN behavior, and no real mirror congestion. The
+> non-`latency` numbers establish the **upper bound** of what
 > `download_packages()` can achieve given the algorithmic and code-path
-> overhead — not what you'd see against real Arch mirrors. For
-> end-to-end validation against real mirrors, use `cargo xtask
-> test-install` on a fresh disk.
+> overhead — not what you'd see against real Arch mirrors. The
+> `latency` group with `tc qdisc netem delay 50ms` is the closest the
+> harness gets to real conditions, and it shows that **RTT dominates
+> wall-time on realistic mirrors** by 6-8×. For end-to-end validation
+> against real mirrors, use `cargo xtask test-install` on a fresh disk.
 
 ## `full_install` group — concurrency=5
 
@@ -138,25 +141,125 @@ What the bench *does* tell us:
    experiment confirmed this empirically — spreading regressed
    throughput because the top mirror is genuinely the best.
 
+## `multi_host` group — multiple distinct fast hosts
+
+Three separate fast nginx containers (`fast`, `fast2`, `fast3`) on
+different ports = different origins = separate TCP connections from
+reqwest's pool. Tests whether having multiple hosts in the mirror list
+changes anything for the current code.
+
+| Scenario | Concurrency | Median time | vs `single_fast` |
+|---|---|---|---|
+| `three_fast_concurrency_5` | 5 | **171.62 ms** | −1% (within noise) |
+| `three_fast_concurrency_10` | 10 | **180.80 ms** | +4% |
+
+### Observations
+
+- **`multi_host` ≈ `single_fast`** (172 ms vs 174 ms). Confirms what we
+  suspected from `full_install`: the current code only ever uses
+  `mirrors[0]`. Adding more hosts to the list doesn't help because the
+  fallback path never runs.
+
+- **Concurrency=10 still slightly worse than concurrency=5** even with
+  multiple hosts available. With the current single-host strategy this
+  is expected (only mirror[0] is used, so HTTP/2 multiplexing limits
+  apply same as `concurrency_sweep`). A multi-host strategy that
+  actually distributed tasks across hosts should beat this — but we
+  haven't built one yet. **This number is the baseline that any future
+  spread / round-robin attempt has to beat.**
+
+## `protocol` group — HTTP/2 vs HTTP/1.1 on a single host
+
+| Scenario | Protocol | Median time |
+|---|---|---|
+| `http2_single_host` | HTTP/2 (h2c) | **172.80 ms** |
+| `http1_single_host` | HTTP/1.1 keep-alive | **173.13 ms** |
+
+### Observations
+
+- **HTTP/2 buys us nothing on loopback** (172.80 vs 173.13 ms — same
+  within noise). On a high-bandwidth low-latency link reqwest's
+  HTTP/1.1 keep-alive serializes 50 small requests over a few pooled
+  connections fast enough that multiplexing latency wins are zero.
+
+- **This is loopback-specific.** On real mirrors with TCP slow-start
+  and per-connection bandwidth caps, HTTP/2 multiplexing usually wins
+  by a substantial margin because all requests share one already-warm
+  congestion window. We'd need a `tc qdisc tbf` rate limit on the
+  http1 mirror to see the protocol difference manifest. Future work.
+
+- **Useful as a sanity check**: confirms our reqwest client handles
+  HTTP/1.1 fallback transparently and doesn't accidentally cripple
+  itself when HTTP/2 isn't available.
+
+## `latency` group — RTT-bound scenarios
+
+`mirror-laggy` adds `tc qdisc netem delay 50ms` to model a
+geographically distant mirror. Every request pays a 50 ms RTT for the
+TCP handshake plus per-stream HTTP/2 setup.
+
+| Scenario | Latency | Concurrency | Median time | vs `low_latency` |
+|---|---|---|---|---|
+| `low_latency` | ~0 ms (loopback) | 5 | **173.87 ms** | — |
+| `geo_50ms_concurrency_5` | 50 ms | 5 | **1.4277 s** | **8.2× slower** |
+| `geo_50ms_concurrency_10` | 50 ms | 10 | **1.1565 s** | **6.6× slower** |
+
+### Observations
+
+This is the **most important finding** in the entire bench suite.
+
+- **50 ms RTT costs ~1.25 seconds wall-time per install** on top of the
+  baseline. Real mirrors with realistic RTTs (20-200 ms) will be the
+  dominant cost in `download_packages()`, dwarfing everything our
+  algorithmic choices can do.
+
+- **At 50 ms RTT, concurrency=10 beats concurrency=5 by 19 %.**
+  (1.43 s → 1.16 s.) This is the **opposite** of what we saw on
+  loopback in `concurrency_sweep`, where conc=10 was a regression.
+
+- **The reason**: when RTT dominates, parallelism amortizes the
+  per-stream setup latency. With concurrency=5, only 5 streams have
+  their RTT in flight at any moment. With concurrency=10, 10 streams
+  share the RTT cost — they all wait for the same network round trip
+  in parallel instead of serially. HTTP/2 multiplexes them over one
+  TCP connection so the connection-setup RTT is paid once, but each
+  stream's first response still needs a round trip.
+
+- **The optimal concurrency depends on RTT, not on bandwidth.** Our
+  current default of 5 was chosen for low-RTT loopback-style
+  conditions. On real mirrors with 50-200 ms RTT, the optimum is
+  probably 10-20.
+
+### Implication for `DownloadConfig::default()`
+
+If we picked the default concurrency value based purely on the
+loopback `concurrency_sweep` numbers we'd lower it to 3. **Don't do
+that.** The latency group shows that on realistic-RTT mirrors a
+default of 5 is already conservative — the right answer is probably
+**8-10**, but we'd want to confirm with a real-mirror smoke test
+before changing the default.
+
 ## What we still need to measure
 
 The most important real-world questions the current bench *doesn't*
 answer:
 
-- **Does `concurrency=N` actually help on multi-host real mirrors?** To
-  answer this we'd need to add a benchmark that uses `[fast, fast2,
-  fast3]` (multiple distinct fast hosts) and varies concurrency.
-  Currently all our scenarios collapse to one host or one host plus
-  irrelevant fallbacks. Phase 4 work.
+- **Multi-host benefit at high RTT.** All our `multi_host` scenarios
+  use loopback (0 ms RTT). The interesting question is whether having
+  3 hosts at 50 ms RTT, with conc=10 distributed across them (3-4
+  streams per host), beats 1 host at 50 ms RTT with all 10 streams
+  multiplexed over one connection. Needs `mirror-fast2-laggy` and
+  `mirror-fast3-laggy` containers, plus a multi-host strategy in code
+  (round-robin / spread) before it's worth measuring.
 
-- **How much does HTTP/2 multiplexing actually save vs HTTP/1.1?** Our
-  nginx config enables HTTP/2; we don't have an HTTP/1.1 comparison.
-  Could add an `http_only` mirror container to measure.
+- **HTTP/2 advantage at high RTT.** HTTP/2 multiplexing's real benefit
+  shows up when RTT × number-of-requests dominates. Adding `tc qdisc
+  netem delay 50ms` to `mirror-http1` would let us compare HTTP/2 vs
+  HTTP/1.1 under realistic RTT conditions.
 
-- **What does real-world RTT do to these numbers?** A `tc qdisc add ...
-  netem delay 50ms` rule on `mirror-fast` would model a typical
-  geographic-distance mirror. Worth adding before the next round of
-  optimization work.
+- **Real mirror smoke test.** Phase 4 work — a one-shot bench against
+  3-5 real Arch mirrors via reflector to validate that everything we
+  learned in the lab holds up on the real internet.
 
 ## File index
 

--- a/tests/download_bench/docker-compose.yml
+++ b/tests/download_bench/docker-compose.yml
@@ -1,17 +1,30 @@
 # Local mirror harness for the download bench.
 #
-# Spawns four nginx containers on localhost:18001..18004, each serving the
+# Spawns nginx containers on 127.0.0.1:18001..18008, each serving the
 # same set of synthetic packages from ./packages/. Each container applies
-# its own `tc qdisc` rate limit on its `eth0` interface so we can model
-# realistic mirror conditions:
+# its own `tc qdisc` rate / netem rule on its `eth0` interface so we can
+# model realistic mirror conditions:
 #
-#   18001  mirror-fast    no rate limit            (top reflector mirror)
-#   18002  mirror-medium  ~10 mbit/s               (mid-list mirror)
-#   18003  mirror-slow    ~500 kbit/s              (bottom-of-list mirror)
-#   18004  mirror-flaky   100 mbit + 30% loss      (lossy mirror)
+#   18001  mirror-fast    no shaping               top reflector mirror
+#   18002  mirror-medium  10 mbit/s                mid-list mirror
+#   18003  mirror-slow    500 kbit/s               bottom-of-list mirror
+#   18004  mirror-flaky   30% packet loss          lossy / unstable mirror
+#   18005  mirror-fast2   no shaping               second fast host (multi-host)
+#   18006  mirror-fast3   no shaping               third fast host (multi-host)
+#   18007  mirror-http1   no shaping, HTTP/1.1     HTTP/1.1 baseline
+#   18008  mirror-laggy   netem delay 50ms         geo-distance mirror (RTT)
 #
 # A "dead" mirror is modeled by simply not running a container — point
-# the bench at e.g. localhost:18999 to get connection refused.
+# the bench at e.g. 127.0.0.1:18999 to get connection refused.
+#
+# fast2/fast3 are deliberately separate ports so reqwest/hyper sees them
+# as distinct origins (scheme + host + port) and opens separate TCP
+# connections to each — necessary for the multi_host bench group to
+# actually exercise multiple connections rather than one HTTP/2 session.
+#
+# mirror-http1 uses a separate nginx config (nginx-http1.conf) with
+# `http2 on;` removed so the bench can compare HTTP/2 multiplexing vs
+# HTTP/1.1 keep-alive on a single host.
 #
 # Each container needs NET_ADMIN to apply tc rules. The entrypoint script
 # (nginx/entrypoint.sh) reads the RATE_LIMIT / NETEM env vars, applies tc,
@@ -84,4 +97,68 @@ services:
     environment:
       RATE_LIMIT: ""
       NETEM: "loss 30%"
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  mirror-fast2:
+    image: nginx:1.27-alpine
+    container_name: bench-mirror-fast2
+    ports:
+      - "127.0.0.1:18005:80"
+    volumes:
+      - ./packages:/usr/share/nginx/html/pkgs:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      RATE_LIMIT: ""
+      NETEM: ""
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  mirror-fast3:
+    image: nginx:1.27-alpine
+    container_name: bench-mirror-fast3
+    ports:
+      - "127.0.0.1:18006:80"
+    volumes:
+      - ./packages:/usr/share/nginx/html/pkgs:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      RATE_LIMIT: ""
+      NETEM: ""
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  mirror-http1:
+    image: nginx:1.27-alpine
+    container_name: bench-mirror-http1
+    ports:
+      - "127.0.0.1:18007:80"
+    volumes:
+      - ./packages:/usr/share/nginx/html/pkgs:ro
+      - ./nginx/nginx-http1.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      RATE_LIMIT: ""
+      NETEM: ""
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  mirror-laggy:
+    image: nginx:1.27-alpine
+    container_name: bench-mirror-laggy
+    ports:
+      - "127.0.0.1:18008:80"
+    volumes:
+      - ./packages:/usr/share/nginx/html/pkgs:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/entrypoint.sh:/entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      RATE_LIMIT: ""
+      NETEM: "delay 50ms"
     entrypoint: ["/bin/sh", "/entrypoint.sh"]

--- a/tests/download_bench/nginx/nginx-http1.conf
+++ b/tests/download_bench/nginx/nginx-http1.conf
@@ -1,0 +1,27 @@
+# HTTP/1.1-only variant of nginx.conf for the `mirror-http1` container.
+# Used by the protocol bench group to compare HTTP/2 multiplexing against
+# HTTP/1.1 keep-alive on a single host. Identical to nginx.conf except
+# `http2 on;` is omitted — nginx defaults to HTTP/1.1 only when http2 is
+# not enabled on the listen directive.
+
+worker_processes  auto;
+events { worker_connections 1024; }
+
+http {
+    sendfile        on;
+    keepalive_timeout 65;
+    # NB: no `http2 on;` here — this server speaks HTTP/1.1 only.
+
+    server {
+        listen       80 default_server;
+        server_name  _;
+
+        location /pkgs/ {
+            alias    /usr/share/nginx/html/pkgs/;
+            autoindex off;
+            add_header Cache-Control "no-store";
+        }
+
+        location /healthz { return 200 "ok\n"; }
+    }
+}


### PR DESCRIPTION
Adds 4 new mirror containers and 3 new bench groups so we can measure download behavior in conditions the original loopback harness couldn't: multiple distinct hosts (separate TCP connections), HTTP/1.1 vs HTTP/2 on the same host, and RTT-bound geographic mirrors. No production code changes — pure infra extension on top of #43.

The most important finding is in the new \`latency\` group: at 50 ms RTT, concurrency=10 beats concurrency=5 by 19%, which is the **opposite** of what the loopback \`concurrency_sweep\` showed (where conc=3 was optimal and conc=10 was a slight regression). This means the optimal concurrency value depends on RTT, not on bandwidth, and any earlier suggestion to lower the default concurrency below 5 was loopback-bias talking. On realistic-RTT mirrors a higher concurrency is better.

The other findings are useful baselines for future strategy comparisons. The \`multi_host\` group with three distinct fast hosts measures the same as \`single_fast\` (171.62 vs 173.60 ms), confirming that the current "always try mirrors[0] first" code only ever uses one host even when several are available — that number is now the explicit baseline that any future multi-host strategy (round-robin / spread / slowness-failover) has to beat. The \`protocol\` group shows HTTP/2 buys nothing over HTTP/1.1 on loopback (172.80 vs 173.13 ms) because both protocols saturate loopback throughput; multiplexing wins only show up when RTT × request count dominates.

New mirror containers in \`docker-compose.yml\`:

| Port  | Container       | Shaping              | Protocol  | Models                           |
|-------|-----------------|----------------------|-----------|----------------------------------|
| 18005 | mirror-fast2    | none                 | HTTP/2    | second fast host                 |
| 18006 | mirror-fast3    | none                 | HTTP/2    | third fast host                  |
| 18007 | mirror-http1    | none                 | HTTP/1.1  | HTTP/1.1 baseline                |
| 18008 | mirror-laggy    | netem delay=50ms     | HTTP/2    | geographically distant mirror    |

\`mirror-fast2\` and \`mirror-fast3\` are deliberately on different ports so reqwest sees them as distinct origins (scheme + host + port) and opens **separate TCP connections** to each. Without the port difference HTTP/2 would multiplex everything over one connection and the multi_host bench group would degenerate to single-host. \`mirror-http1\` uses a separate \`nginx-http1.conf\` with \`http2 on;\` removed so the bench can compare HTTP/2 multiplexing vs HTTP/1.1 keep-alive on a single host.

New bench groups in \`core/benches/download.rs\`:

- \`multi_host\`: \`three_fast_concurrency_5\` and \`_10\` against \`[fast, fast2, fast3]\` — establishes the baseline for any future multi-host strategy
- \`protocol\`: \`http2_single_host\` vs \`http1_single_host\` on identical servers, isolating the protocol's impact
- \`latency\`: \`low_latency\` reference + \`geo_50ms_concurrency_5\` and \`_10\` against the netem-delayed mirror

Full numbers, observations, and the implication for default concurrency are in \`RESULTS.md\` (updated in this PR). \`README.md\` documents the new mirrors and groups.

## Test plan

- [ ] \`docker compose -f tests/download_bench/docker-compose.yml up -d\` brings up all 8 containers cleanly
- [ ] \`curl http://127.0.0.1:18001/healthz\` through \`:18008\` all return ok
- [ ] \`docker exec bench-mirror-laggy tc qdisc show dev eth0\` shows \`netem ... delay 50ms\`
- [ ] \`docker exec bench-mirror-http1 grep -c 'http2 on' /etc/nginx/nginx.conf\` returns 0 (HTTP/1.1 only)
- [ ] \`cargo bench -p archinstall-zfs-core --bench download -- multi_host\` completes
- [ ] \`cargo bench -p archinstall-zfs-core --bench download -- protocol\` completes
- [ ] \`cargo bench -p archinstall-zfs-core --bench download -- latency\` completes
- [ ] Numbers in RESULTS.md match what \`cargo bench\` produces locally (within criterion's noise threshold)