### PR TITLE
[codex] Support VirtIO disk discovery

### DIFF
--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -426,8 +426,21 @@ fn is_valid_dataset_prefix(prefix: &str) -> bool {
             .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
 }
 
-fn is_by_id_path(path: &std::path::Path) -> bool {
-    path.starts_with("/dev/disk/by-id/")
+fn is_supported_device_path(path: &std::path::Path) -> bool {
+    if path.starts_with("/dev/disk/by-id/") || path.starts_with("/dev/disk/by-path/") {
+        return true;
+    }
+
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+
+    path.starts_with("/dev/")
+        && (name.starts_with("sd")
+            || name.starts_with("vd")
+            || name.starts_with("xvd")
+            || name.starts_with("nvme")
+            || name.starts_with("mmcblk"))
 }
 
 /// Validates the config and returns a list of error messages.
@@ -459,34 +472,34 @@ impl GlobalConfig {
     pub fn validate_by_id_paths(&self) -> Vec<String> {
         let mut errors = Vec::new();
         if let Some(ref p) = self.disk_by_id
-            && !is_by_id_path(p)
+            && !is_supported_device_path(p)
         {
             errors.push(format!(
-                "disk_by_id must be a /dev/disk/by-id/ path, got: {}",
+                "disk_by_id must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
                 p.display()
             ));
         }
         if let Some(ref p) = self.efi_partition_by_id
-            && !is_by_id_path(p)
+            && !is_supported_device_path(p)
         {
             errors.push(format!(
-                "efi_partition_by_id must be a /dev/disk/by-id/ path, got: {}",
+                "efi_partition_by_id must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
                 p.display()
             ));
         }
         if let Some(ref p) = self.zfs_partition_by_id
-            && !is_by_id_path(p)
+            && !is_supported_device_path(p)
         {
             errors.push(format!(
-                "zfs_partition_by_id must be a /dev/disk/by-id/ path, got: {}",
+                "zfs_partition_by_id must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
                 p.display()
             ));
         }
         if let Some(ref p) = self.swap_partition_by_id
-            && !is_by_id_path(p)
+            && !is_supported_device_path(p)
         {
             errors.push(format!(
-                "swap_partition_by_id must be a /dev/disk/by-id/ path, got: {}",
+                "swap_partition_by_id must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
                 p.display()
             ));
         }

--- a/core/src/config/validation.rs
+++ b/core/src/config/validation.rs
@@ -329,11 +329,27 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_by_id_path() {
+    fn test_valid_by_path_disk_path() {
         let mut cfg = valid_full_disk_config();
-        cfg.disk_by_id = Some(PathBuf::from("/dev/sda"));
+        cfg.disk_by_id = Some(PathBuf::from("/dev/disk/by-path/pci-0000:00:04.0"));
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("/dev/disk/by-id/")));
+        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
+    }
+
+    #[test]
+    fn test_valid_virtio_devnode_disk_path() {
+        let mut cfg = valid_full_disk_config();
+        cfg.disk_by_id = Some(PathBuf::from("/dev/vda"));
+        let errors = cfg.validate_for_install();
+        assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
+    }
+
+    #[test]
+    fn test_invalid_device_path() {
+        let mut cfg = valid_full_disk_config();
+        cfg.disk_by_id = Some(PathBuf::from("/tmp/not-a-disk"));
+        let errors = cfg.validate_for_install();
+        assert!(errors.iter().any(|e| e.contains("supported /dev node")));
     }
 
     #[test]

--- a/core/src/disk/by_id.rs
+++ b/core/src/disk/by_id.rs
@@ -4,6 +4,17 @@ use std::path::{Path, PathBuf};
 use color_eyre::eyre::{Context, Result};
 
 pub fn list_disks_by_id() -> Result<Vec<PathBuf>> {
+    if let Ok(devices) = crate::disk::device::list_block_devices() {
+        return Ok(devices
+            .into_iter()
+            .map(|device| device.preferred_path().path)
+            .collect());
+    }
+
+    list_disks_by_id_legacy()
+}
+
+fn list_disks_by_id_legacy() -> Result<Vec<PathBuf>> {
     let by_id = Path::new("/dev/disk/by-id");
     if !by_id.exists() {
         return Ok(Vec::new());

--- a/core/src/disk/device.rs
+++ b/core/src/disk/device.rs
@@ -1,0 +1,377 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use color_eyre::eyre::{Result, WrapErr};
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DevicePathKind {
+    ById,
+    ByPath,
+    DevNode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DevicePath {
+    pub path: PathBuf,
+    pub kind: DevicePathKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockDevice {
+    pub devnode: PathBuf,
+    pub aliases: Vec<DevicePath>,
+    pub model: Option<String>,
+    pub serial: Option<String>,
+    pub size_bytes: Option<u64>,
+    pub transport: Option<String>,
+    pub rotational: Option<bool>,
+    pub removable: bool,
+}
+
+impl BlockDevice {
+    pub fn preferred_path(&self) -> DevicePath {
+        self.aliases
+            .iter()
+            .filter(|alias| alias.kind == DevicePathKind::ById)
+            .min_by_key(|alias| alias_preference_key(alias))
+            .or_else(|| {
+                self.aliases
+                    .iter()
+                    .filter(|alias| alias.kind == DevicePathKind::ByPath)
+                    .min_by_key(|alias| alias_preference_key(alias))
+            })
+            .cloned()
+            .unwrap_or_else(|| DevicePath {
+                path: self.devnode.clone(),
+                kind: DevicePathKind::DevNode,
+            })
+    }
+
+    pub fn selection_label(&self) -> String {
+        let mut parts = vec![self.devnode.display().to_string()];
+
+        if let Some(model) = self.model.as_deref() {
+            parts.push(model.to_string());
+        }
+        if let Some(size) = self.size_bytes {
+            parts.push(format_size(size));
+        }
+        if let Some(transport) = self.transport.as_deref() {
+            parts.push(transport.to_string());
+        }
+        if self.removable {
+            parts.push("removable".to_string());
+        }
+
+        let preferred = self.preferred_path();
+        if preferred.path != self.devnode {
+            parts.push(format!("using {}", preferred.path.display()));
+        }
+
+        parts.join(" | ")
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LsblkOutput {
+    blockdevices: Vec<LsblkDevice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LsblkDevice {
+    path: Option<PathBuf>,
+    #[serde(rename = "type")]
+    device_type: Option<String>,
+    size: Option<Value>,
+    model: Option<String>,
+    serial: Option<String>,
+    tran: Option<String>,
+    rota: Option<Value>,
+    rm: Option<Value>,
+    #[serde(default)]
+    children: Vec<LsblkDevice>,
+}
+
+pub fn list_block_devices() -> Result<Vec<BlockDevice>> {
+    let output = Command::new("lsblk")
+        .args([
+            "--json",
+            "--bytes",
+            "--output",
+            "PATH,TYPE,SIZE,MODEL,SERIAL,TRAN,ROTA,RM",
+        ])
+        .output()
+        .wrap_err("failed to run lsblk")?;
+
+    if !output.status.success() {
+        return Err(color_eyre::eyre::eyre!(
+            "lsblk failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let parsed: LsblkOutput =
+        serde_json::from_slice(&output.stdout).wrap_err("failed to parse lsblk JSON")?;
+    let aliases = collect_disk_aliases()?;
+
+    let mut devices = Vec::new();
+    for node in parsed.blockdevices {
+        collect_lsblk_disks(node, &aliases, &mut devices);
+    }
+
+    devices.sort_by(|a, b| a.devnode.cmp(&b.devnode));
+    Ok(devices)
+}
+
+fn collect_lsblk_disks(
+    node: LsblkDevice,
+    aliases: &HashMap<PathBuf, Vec<DevicePath>>,
+    devices: &mut Vec<BlockDevice>,
+) {
+    if node.device_type.as_deref() == Some("disk")
+        && let Some(devnode) = node.path.clone()
+        && is_installable_devnode(&devnode)
+    {
+        let canonical = fs::canonicalize(&devnode).unwrap_or_else(|_| devnode.clone());
+        let mut device_aliases = aliases.get(&canonical).cloned().unwrap_or_default();
+        device_aliases.sort_by_key(alias_preference_key);
+
+        devices.push(BlockDevice {
+            devnode,
+            aliases: device_aliases,
+            model: clean_string(node.model),
+            serial: clean_string(node.serial),
+            size_bytes: node.size.as_ref().and_then(value_as_u64),
+            transport: clean_string(node.tran),
+            rotational: node.rota.as_ref().and_then(value_as_bool),
+            removable: node.rm.as_ref().and_then(value_as_bool).unwrap_or(false),
+        });
+    }
+
+    for child in node.children {
+        collect_lsblk_disks(child, aliases, devices);
+    }
+}
+
+fn is_installable_devnode(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+
+    !(name.starts_with("loop") || name.starts_with("zram") || name.starts_with("sr"))
+}
+
+fn collect_disk_aliases() -> Result<HashMap<PathBuf, Vec<DevicePath>>> {
+    let mut aliases: HashMap<PathBuf, Vec<DevicePath>> = HashMap::new();
+    collect_alias_dir(
+        Path::new("/dev/disk/by-id"),
+        DevicePathKind::ById,
+        &mut aliases,
+    )?;
+    collect_alias_dir(
+        Path::new("/dev/disk/by-path"),
+        DevicePathKind::ByPath,
+        &mut aliases,
+    )?;
+    Ok(aliases)
+}
+
+fn collect_alias_dir(
+    dir: &Path,
+    kind: DevicePathKind,
+    aliases: &mut HashMap<PathBuf, Vec<DevicePath>>,
+) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(dir).wrap_err_with(|| format!("failed to read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let Ok(target) = fs::canonicalize(&path) else {
+            continue;
+        };
+
+        aliases
+            .entry(target)
+            .or_default()
+            .push(DevicePath { path, kind });
+    }
+
+    Ok(())
+}
+
+fn alias_preference_key(alias: &DevicePath) -> (u8, String) {
+    let name = alias
+        .path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+
+    let rank = match alias.kind {
+        DevicePathKind::ById => by_id_rank(name),
+        DevicePathKind::ByPath => 20,
+        DevicePathKind::DevNode => 30,
+    };
+
+    (rank, alias.path.display().to_string())
+}
+
+fn by_id_rank(name: &str) -> u8 {
+    if name.starts_with("wwn-") {
+        0
+    } else if name.starts_with("nvme-eui.") || name.starts_with("nvme-uuid.") {
+        1
+    } else if name.starts_with("ata-") || name.starts_with("nvme-") {
+        2
+    } else if name.starts_with("scsi-") {
+        3
+    } else if name.starts_with("virtio-") {
+        4
+    } else {
+        5
+    }
+}
+
+fn clean_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn value_as_u64(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(n) => n.as_u64(),
+        Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+fn value_as_bool(value: &Value) -> Option<bool> {
+    match value {
+        Value::Bool(value) => Some(*value),
+        Value::Number(n) => n.as_u64().map(|value| value != 0),
+        Value::String(s) => match s.as_str() {
+            "1" | "true" => Some(true),
+            "0" | "false" => Some(false),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn format_size(bytes: u64) -> String {
+    const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[unit])
+    } else if value >= 10.0 {
+        format!("{value:.0} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_by_id_over_by_path_and_devnode() {
+        let device = BlockDevice {
+            devnode: PathBuf::from("/dev/vda"),
+            aliases: vec![
+                DevicePath {
+                    path: PathBuf::from("/dev/disk/by-path/pci-0000:00:04.0"),
+                    kind: DevicePathKind::ByPath,
+                },
+                DevicePath {
+                    path: PathBuf::from("/dev/disk/by-id/virtio-test-disk"),
+                    kind: DevicePathKind::ById,
+                },
+            ],
+            model: None,
+            serial: None,
+            size_bytes: None,
+            transport: None,
+            rotational: None,
+            removable: false,
+        };
+
+        assert_eq!(
+            device.preferred_path().path,
+            PathBuf::from("/dev/disk/by-id/virtio-test-disk")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_by_path_before_devnode() {
+        let device = BlockDevice {
+            devnode: PathBuf::from("/dev/vda"),
+            aliases: vec![DevicePath {
+                path: PathBuf::from("/dev/disk/by-path/pci-0000:00:04.0"),
+                kind: DevicePathKind::ByPath,
+            }],
+            model: None,
+            serial: None,
+            size_bytes: None,
+            transport: None,
+            rotational: None,
+            removable: false,
+        };
+
+        assert_eq!(
+            device.preferred_path().path,
+            PathBuf::from("/dev/disk/by-path/pci-0000:00:04.0")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_devnode_without_aliases() {
+        let device = BlockDevice {
+            devnode: PathBuf::from("/dev/vda"),
+            aliases: Vec::new(),
+            model: None,
+            serial: None,
+            size_bytes: None,
+            transport: None,
+            rotational: None,
+            removable: false,
+        };
+
+        assert_eq!(device.preferred_path().path, PathBuf::from("/dev/vda"));
+    }
+
+    #[test]
+    fn selection_label_includes_identity_and_preferred_path() {
+        let device = BlockDevice {
+            devnode: PathBuf::from("/dev/vda"),
+            aliases: vec![DevicePath {
+                path: PathBuf::from("/dev/disk/by-path/pci-0000:00:04.0"),
+                kind: DevicePathKind::ByPath,
+            }],
+            model: Some("VirtIO Block Device".to_string()),
+            serial: None,
+            size_bytes: Some(64 * 1024 * 1024 * 1024),
+            transport: Some("virtio".to_string()),
+            rotational: Some(false),
+            removable: false,
+        };
+
+        assert_eq!(
+            device.selection_label(),
+            "/dev/vda | VirtIO Block Device | 64 GiB | virtio | using /dev/disk/by-path/pci-0000:00:04.0"
+        );
+    }
+}

--- a/core/src/disk/mod.rs
+++ b/core/src/disk/mod.rs
@@ -1,2 +1,3 @@
 pub mod by_id;
+pub mod device;
 pub mod partition;

--- a/core/src/disk/partition.rs
+++ b/core/src/disk/partition.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{Context, Result};
 
@@ -123,16 +123,17 @@ pub fn create_partitions(
     let _ = runner.run("udevadm", &["settle"]);
 
     // Wait for by-id symlinks to appear
-    let efi_dev = format!("{disk_str}-part{}", layout.efi_part_num);
+    let efi_dev = partition_path(disk, layout.efi_part_num);
+    let efi_dev_str = efi_dev.to_string_lossy();
     for _ in 0..50 {
-        if std::path::Path::new(&efi_dev).exists() {
+        if efi_dev.exists() {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(200));
     }
 
     // Format EFI partition
-    let output = runner.run("mkfs.fat", &["-I", "-F32", &efi_dev])?;
+    let output = runner.run("mkfs.fat", &["-I", "-F32", &efi_dev_str])?;
     check_exit(&output, "mkfs.fat EFI")?;
 
     Ok(layout)
@@ -140,18 +141,16 @@ pub fn create_partitions(
 
 /// Wait for /dev/disk/by-id partition symlinks to appear after partitioning.
 pub fn wait_for_by_id_partitions(disk: &Path, layout: &PartitionLayout) -> Vec<std::path::PathBuf> {
-    let disk_str = disk.to_string_lossy();
     let mut parts = vec![
-        format!("{disk_str}-part{}", layout.efi_part_num),
-        format!("{disk_str}-part{}", layout.zfs_part_num),
+        partition_path(disk, layout.efi_part_num),
+        partition_path(disk, layout.zfs_part_num),
     ];
     if let Some(swap) = layout.swap_part_num {
-        parts.push(format!("{disk_str}-part{swap}"));
+        parts.push(partition_path(disk, swap));
     }
 
     let mut result = Vec::new();
-    for part in &parts {
-        let path = std::path::PathBuf::from(part);
+    for path in parts {
         for _ in 0..50 {
             if path.exists() {
                 break;
@@ -161,6 +160,23 @@ pub fn wait_for_by_id_partitions(disk: &Path, layout: &PartitionLayout) -> Vec<s
         result.push(path);
     }
     result
+}
+
+pub fn partition_path(disk: &Path, part_num: u32) -> PathBuf {
+    let disk_str = disk.to_string_lossy();
+    let separator = if disk_str.starts_with("/dev/disk/") {
+        "-part"
+    } else if disk_str
+        .chars()
+        .next_back()
+        .is_some_and(|ch| ch.is_ascii_digit())
+    {
+        "p"
+    } else {
+        ""
+    };
+
+    PathBuf::from(format!("{disk_str}{separator}{part_num}"))
 }
 
 pub fn mount_efi(
@@ -244,5 +260,29 @@ mod tests {
         assert_eq!(layout.efi_part_num, 1);
         assert_eq!(layout.zfs_part_num, 2);
         assert_eq!(layout.swap_part_num, Some(3));
+    }
+
+    #[test]
+    fn test_partition_path_by_id() {
+        assert_eq!(
+            partition_path(Path::new("/dev/disk/by-id/test-disk"), 1),
+            PathBuf::from("/dev/disk/by-id/test-disk-part1")
+        );
+    }
+
+    #[test]
+    fn test_partition_path_virtio_devnode() {
+        assert_eq!(
+            partition_path(Path::new("/dev/vda"), 1),
+            PathBuf::from("/dev/vda1")
+        );
+    }
+
+    #[test]
+    fn test_partition_path_nvme_devnode() {
+        assert_eq!(
+            partition_path(Path::new("/dev/nvme0n1"), 1),
+            PathBuf::from("/dev/nvme0n1p1")
+        );
     }
 }

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -54,13 +54,13 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     );
 
     if matches!(mode, Some(InstallationMode::FullDisk) | None) {
-        let disks = archinstall_zfs_core::disk::by_id::list_disks_by_id().unwrap_or_default();
-        let disk_strs: Vec<String> = disks.iter().map(|p| p.display().to_string()).collect();
+        let disks = disk_choices();
+        let disk_strs: Vec<String> = disks.iter().map(|(_, label)| label.clone()).collect();
         let disk_refs: Vec<&str> = disk_strs.iter().map(|s| s.as_str()).collect();
         let selected = c
             .disk_by_id
             .as_ref()
-            .and_then(|sel| disks.iter().position(|d| d == sel))
+            .and_then(|sel| disks.iter().position(|(path, _)| path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
         items.extend(radio_group("disk_by_id", "Disk", &disk_refs, selected));
@@ -678,9 +678,8 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
             config.installation_mode = Some(new_mode);
         }
         "disk_by_id" => {
-            if let Ok(disks) = archinstall_zfs_core::disk::by_id::list_disks_by_id()
-                && let Some(path) = disks.get(idx as usize)
-            {
+            let disks = disk_choices();
+            if let Some((path, _)) = disks.get(idx as usize) {
                 config.disk_by_id = Some(path.clone());
             }
         }
@@ -766,6 +765,26 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
         }
         _ => {}
     }
+}
+
+fn disk_choices() -> Vec<(std::path::PathBuf, String)> {
+    archinstall_zfs_core::disk::device::list_block_devices()
+        .map(|devices| {
+            devices
+                .into_iter()
+                .map(|device| (device.preferred_path().path, device.selection_label()))
+                .collect()
+        })
+        .unwrap_or_else(|_| {
+            archinstall_zfs_core::disk::by_id::list_disks_by_id()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|path| {
+                    let label = path.display().to_string();
+                    (path, label)
+                })
+                .collect()
+        })
 }
 
 pub fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -66,16 +66,33 @@ pub fn pick_keyboard(
 }
 
 pub fn pick_disk(terminal: &mut ratatui::DefaultTerminal) -> Result<Option<PathBuf>> {
-    let disks = archinstall_zfs_core::disk::by_id::list_disks_by_id()?;
-    if disks.is_empty() {
+    let choices = disk_choices()?;
+    if choices.is_empty() {
         return Ok(None);
     }
-    let disk_strs: Vec<String> = disks.iter().map(|p| p.display().to_string()).collect();
+    let paths: Vec<PathBuf> = choices.iter().map(|(path, _)| path.clone()).collect();
+    let disk_strs: Vec<String> = choices.iter().map(|(_, label)| label.clone()).collect();
     let disk_refs: Vec<&str> = disk_strs.iter().map(|s| s.as_str()).collect();
     let result = run_select(terminal, "Select disk", &disk_refs, 0)?;
     match result.selected {
-        Some(idx) => Ok(Some(disks[idx].clone())),
+        Some(idx) => Ok(Some(paths[idx].clone())),
         None => Ok(None),
+    }
+}
+
+fn disk_choices() -> Result<Vec<(PathBuf, String)>> {
+    match archinstall_zfs_core::disk::device::list_block_devices() {
+        Ok(devices) => Ok(devices
+            .into_iter()
+            .map(|device| (device.preferred_path().path, device.selection_label()))
+            .collect()),
+        Err(_) => Ok(archinstall_zfs_core::disk::by_id::list_disks_by_id()?
+            .into_iter()
+            .map(|path| {
+                let label = path.display().to_string();
+                (path, label)
+            })
+            .collect()),
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a block-device discovery layer so the installer treats disks as devices with multiple aliases instead of exposing every `/dev/disk/by-*` link as a separate choice.

## Details

- Discovers disks via `lsblk --json` and collects `/dev/disk/by-id` and `/dev/disk/by-path` aliases for each canonical device.
- Chooses the backend path with the policy `by-id` -> `by-path` -> direct `/dev/*` node.
- Keeps the existing `list_disks_by_id()` API as a compatibility wrapper for current callers.
- Allows `/dev/disk/by-path` and supported direct devnodes such as `/dev/vda` in install validation.
- Fixes partition path construction for direct devnodes, e.g. `/dev/vda1` and `/dev/nvme0n1p1`.
- Updates TUI and Slint disk pickers to display one choice per disk with model, size, transport, and the path that will be used.

## Validation

- `cargo test -p archinstall-zfs-core`
- `cargo check -p archinstall-zfs-tui`
- `cargo check -p archinstall-zfs-slint`

Fixes #50.
