### PR TITLE
[codex] Finish device selection abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset"
 version = "0.2.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset-macro"
 version = "0.2.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1958,6 +1958,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
+name = "fixed_decimal"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c3c892f121fff406e5dd6b28c1b30096b95111c30701a899d4f2b18da6d1bd"
+dependencies = [
+ "displaydoc",
+ "smallvec",
+ "writeable",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
+checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
 dependencies = [
  "hashbrown 0.17.0",
  "linebender_resource_handle",
@@ -2425,13 +2436,12 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.6.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ce5e848d21ba97a324266e41c70e0eb5e2577a610c1fbd546e15096f2e8e37"
+checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
- "core_maths",
  "read-fonts 0.39.2",
  "smallvec",
 ]
@@ -2585,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-linuxkms"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "calloop 0.14.4",
  "cfg_aliases",
@@ -2597,7 +2607,7 @@ dependencies = [
  "i-slint-renderer-skia",
  "input",
  "memmap2",
- "nix 0.30.1",
+ "nix 0.31.2",
  "raw-window-handle",
  "xkbcommon",
 ]
@@ -2605,20 +2615,35 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-selector"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "cfg-if",
+ "cfg_aliases",
  "i-slint-backend-linuxkms",
+ "i-slint-backend-testing",
  "i-slint-backend-winit",
  "i-slint-common",
  "i-slint-core",
  "i-slint-core-macros",
+ "i-slint-renderer-skia",
+]
+
+[[package]]
+name = "i-slint-backend-testing"
+version = "1.17.0"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
+dependencies = [
+ "cfg_aliases",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-renderer-skia",
+ "vtable",
 ]
 
 [[package]]
 name = "i-slint-backend-winit"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "block2 0.6.2",
  "cfg-if",
@@ -2657,11 +2682,14 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "derive_more",
  "fontique",
  "htmlparser",
+ "icu_decimal",
+ "icu_locale_core",
+ "icu_provider",
  "pulldown-cmark",
  "skrifa 0.42.1",
 ]
@@ -2669,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "i-slint-compiler"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "annotate-snippets",
  "by_address",
@@ -2701,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "auto_enums",
  "bitflags 2.11.0",
@@ -2720,6 +2748,9 @@ dependencies = [
  "lyon_geom",
  "lyon_path",
  "num-traits",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parley",
  "pin-project",
@@ -2728,7 +2759,6 @@ dependencies = [
  "raw-window-handle",
  "resvg",
  "rgb",
- "scoped-tls-hkt",
  "scopeguard",
  "skrifa 0.42.1",
  "slab",
@@ -2743,12 +2773,13 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "web-time",
+ "windows",
 ]
 
 [[package]]
 name = "i-slint-core-macros"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "quote",
  "serde_json",
@@ -2758,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-skia"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2794,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-software"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "bytemuck",
  "clru",
@@ -2847,6 +2878,29 @@ dependencies = [
  "zerofrom",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_decimal"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288247df2e32aa776ac54fdd64de552149ac43cb840f2761811f0e8d09719dd4"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_decimal_data",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_plurals",
+ "icu_provider",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_decimal_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f14a5ca9e8af29eef62064f269078424283d90dbaffeac5225addf62aaabc22"
 
 [[package]]
 name = "icu_locale"
@@ -2902,6 +2956,25 @@ name = "icu_normalizer_data"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_plurals"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a50023f1d49ad5c4333380328a0d4a19e4b9d6d842ec06639affd5ba47c8103"
+dependencies = [
+ "fixed_decimal",
+ "icu_locale",
+ "icu_plurals_data",
+ "icu_provider",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8485497155dc865f901decb93ecc20d3e467df67bfeceb91e3ba34e2b11e8e1d"
 
 [[package]]
 name = "icu_properties"
@@ -3008,7 +3081,7 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png 0.18.1",
+ "png",
  "qoi",
  "ravif",
  "rayon",
@@ -3069,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
+checksum = "f9793345a65d71317763a33066b5d8351f8760dde8d4930fe9e39b5f14a7959d"
 dependencies = [
  "bitflags 2.11.0",
  "input-sys",
@@ -3082,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "input-sys"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
+checksum = "36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7"
 
 [[package]]
 name = "instability"
@@ -3642,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.18.0"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20e2339ef964849496bd6dab1bcd8ceb7a3a5a268dc64c8b84c833e75d66dab"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -3654,9 +3727,9 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
+ "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3712,18 +3785,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -4417,9 +4478,9 @@ checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "parley"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
+checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
 dependencies = [
  "fontique",
  "harfrust",
@@ -4435,9 +4496,9 @@ dependencies = [
 
 [[package]]
 name = "parley_data"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ab9ace3fad1b9ed603ddac5b595e69931fc50263d7e04e4055015b77b02da5"
+checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
 dependencies = [
  "icu_properties",
 ]
@@ -4648,19 +4709,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -5098,7 +5146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
- "core_maths",
  "font-types",
 ]
 
@@ -5655,9 +5702,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skia-bindings"
-version = "0.90.0"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6f96e00735f14a781aac8a6870c862b8cc831df6d8e4ad77ab78e11411b9af"
+checksum = "e6a38f4d460276ea40588c958396a9de0eec808c679009a5b52afdf6ebf34132"
 dependencies = [
  "bindgen",
  "cc",
@@ -5672,9 +5719,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.90.0"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a71c01d325d40b1031dee67d251a5e0132e79e2a9ec272149a4f4a0d4b8b3be"
+checksum = "1ecfc54fcd40dc5dea15dd2a84f8422cdb0f76c6a51ebb8835ce0b7ef590a21f"
 dependencies = [
  "bitflags 2.11.0",
  "skia-bindings",
@@ -5710,7 +5757,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slint"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "const-field-offset",
  "i-slint-backend-selector",
@@ -5730,7 +5777,7 @@ dependencies = [
 [[package]]
 name = "slint-build"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "derive_more",
  "fontique",
@@ -5742,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "slint-macros"
 version = "1.17.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -6119,9 +6166,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ba83ebaf2954d31d05d67340fd46cebe99da2b7133b0dd68d70c65473a437b"
+checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
 dependencies = [
  "arrayvec",
  "grid",
@@ -6343,7 +6390,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png 0.18.1",
+ "png",
  "tiny-skia-path 0.12.0",
 ]
 
@@ -6472,26 +6519,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -6510,7 +6548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.1",
@@ -6909,7 +6947,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vtable"
 version = "0.4.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -6920,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "vtable-macro"
 version = "0.4.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#14052c6a4172e9725100a2c98fdde6173b194953"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Frenderer-skia-software-linuxkms#5979232d58b1ffed3c9fd7357bad6580082c81a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7497,15 +7535,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -7537,28 +7566,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7583,12 +7595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7599,12 +7605,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7619,22 +7619,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7649,12 +7637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7665,12 +7647,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7685,12 +7661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7701,12 +7671,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -147,9 +147,12 @@ impl std::fmt::Display for SwapMode {
 pub struct GlobalConfig {
     // Flow control
     pub installation_mode: Option<InstallationMode>,
-    pub disk_by_id: Option<PathBuf>,
-    pub efi_partition_by_id: Option<PathBuf>,
-    pub zfs_partition_by_id: Option<PathBuf>,
+    #[serde(default, alias = "disk_by_id")]
+    pub disk: Option<PathBuf>,
+    #[serde(default, alias = "efi_partition_by_id")]
+    pub efi_partition: Option<PathBuf>,
+    #[serde(default, alias = "zfs_partition_by_id")]
+    pub zfs_partition: Option<PathBuf>,
     pub pool_name: Option<String>,
 
     // ZFS specifics
@@ -169,7 +172,8 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub swap_mode: SwapMode,
     pub swap_partition_size: Option<String>,
-    pub swap_partition_by_id: Option<PathBuf>,
+    #[serde(default, alias = "swap_partition_by_id")]
+    pub swap_partition: Option<PathBuf>,
     #[serde(default = "default_zram_size_expr")]
     pub zram_size_expr: Option<String>,
 
@@ -343,9 +347,9 @@ impl Default for GlobalConfig {
     fn default() -> Self {
         Self {
             installation_mode: None,
-            disk_by_id: None,
-            efi_partition_by_id: None,
-            zfs_partition_by_id: None,
+            disk: None,
+            efi_partition: None,
+            zfs_partition: None,
             pool_name: Some("zroot".to_string()),
             dataset_prefix: default_dataset_prefix(),
             init_system: InitSystem::default(),
@@ -355,7 +359,7 @@ impl Default for GlobalConfig {
             compression: CompressionAlgo::default(),
             swap_mode: SwapMode::default(),
             swap_partition_size: None,
-            swap_partition_by_id: None,
+            swap_partition: None,
             zram_size_expr: default_zram_size_expr(),
             set_bootfs: true,
             zrepl_enabled: false,
@@ -469,37 +473,37 @@ impl GlobalConfig {
         errors
     }
 
-    pub fn validate_by_id_paths(&self) -> Vec<String> {
+    pub fn validate_device_paths(&self) -> Vec<String> {
         let mut errors = Vec::new();
-        if let Some(ref p) = self.disk_by_id
+        if let Some(ref p) = self.disk
             && !is_supported_device_path(p)
         {
             errors.push(format!(
-                "disk_by_id must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
+                "disk must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
                 p.display()
             ));
         }
-        if let Some(ref p) = self.efi_partition_by_id
+        if let Some(ref p) = self.efi_partition
             && !is_supported_device_path(p)
         {
             errors.push(format!(
-                "efi_partition_by_id must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
+                "efi_partition must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
                 p.display()
             ));
         }
-        if let Some(ref p) = self.zfs_partition_by_id
+        if let Some(ref p) = self.zfs_partition
             && !is_supported_device_path(p)
         {
             errors.push(format!(
-                "zfs_partition_by_id must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
+                "zfs_partition must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
                 p.display()
             ));
         }
-        if let Some(ref p) = self.swap_partition_by_id
+        if let Some(ref p) = self.swap_partition
             && !is_supported_device_path(p)
         {
             errors.push(format!(
-                "swap_partition_by_id must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
+                "swap_partition must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
                 p.display()
             ));
         }

--- a/core/src/config/validation.rs
+++ b/core/src/config/validation.rs
@@ -43,14 +43,13 @@ impl GlobalConfig {
         }
         errors.extend(self.validate_pool_name());
         errors.extend(self.validate_dataset_prefix());
-        errors.extend(self.validate_by_id_paths());
+        errors.extend(self.validate_device_paths());
 
         // Mode-dependent validation
         match mode {
             InstallationMode::FullDisk => {
-                if self.disk_by_id.is_none() {
-                    errors
-                        .push("Full disk mode requires a disk selection (disk_by_id)".to_string());
+                if self.disk.is_none() {
+                    errors.push("Full disk mode requires a disk selection (disk)".to_string());
                 }
                 if matches!(
                     self.swap_mode,
@@ -64,41 +63,38 @@ impl GlobalConfig {
                 }
             }
             InstallationMode::NewPool => {
-                if self.efi_partition_by_id.is_none() {
+                if self.efi_partition.is_none() {
                     errors.push(
-                        "New pool mode requires an EFI partition (efi_partition_by_id)".to_string(),
+                        "New pool mode requires an EFI partition (efi_partition)".to_string(),
                     );
                 }
-                if self.zfs_partition_by_id.is_none() {
-                    errors.push(
-                        "New pool mode requires a ZFS partition (zfs_partition_by_id)".to_string(),
-                    );
+                if self.zfs_partition.is_none() {
+                    errors
+                        .push("New pool mode requires a ZFS partition (zfs_partition)".to_string());
                 }
                 if matches!(
                     self.swap_mode,
                     SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-                ) && self.swap_partition_by_id.is_none()
+                ) && self.swap_partition.is_none()
                 {
                     errors.push(
-                        "Swap partition mode requires swap_partition_by_id in new pool mode"
-                            .to_string(),
+                        "Swap partition mode requires swap_partition in new pool mode".to_string(),
                     );
                 }
             }
             InstallationMode::ExistingPool => {
-                if self.efi_partition_by_id.is_none() {
+                if self.efi_partition.is_none() {
                     errors.push(
-                        "Existing pool mode requires an EFI partition (efi_partition_by_id)"
-                            .to_string(),
+                        "Existing pool mode requires an EFI partition (efi_partition)".to_string(),
                     );
                 }
                 if matches!(
                     self.swap_mode,
                     SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-                ) && self.swap_partition_by_id.is_none()
+                ) && self.swap_partition.is_none()
                 {
                     errors.push(
-                        "Swap partition mode requires swap_partition_by_id in existing pool mode"
+                        "Swap partition mode requires swap_partition in existing pool mode"
                             .to_string(),
                     );
                 }
@@ -173,7 +169,7 @@ mod tests {
     fn valid_full_disk_config() -> GlobalConfig {
         GlobalConfig {
             installation_mode: Some(InstallationMode::FullDisk),
-            disk_by_id: Some(PathBuf::from("/dev/disk/by-id/virtio-archzfs-test-disk")),
+            disk: Some(PathBuf::from("/dev/disk/by-id/virtio-archzfs-test-disk")),
             pool_name: Some("testpool".to_string()),
             ..Default::default()
         }
@@ -182,10 +178,10 @@ mod tests {
     fn valid_new_pool_config() -> GlobalConfig {
         GlobalConfig {
             installation_mode: Some(InstallationMode::NewPool),
-            efi_partition_by_id: Some(PathBuf::from(
+            efi_partition: Some(PathBuf::from(
                 "/dev/disk/by-id/virtio-archzfs-test-disk-part1",
             )),
-            zfs_partition_by_id: Some(PathBuf::from(
+            zfs_partition: Some(PathBuf::from(
                 "/dev/disk/by-id/virtio-archzfs-test-disk-part2",
             )),
             pool_name: Some("testpool".to_string()),
@@ -196,7 +192,7 @@ mod tests {
     fn valid_existing_pool_config() -> GlobalConfig {
         GlobalConfig {
             installation_mode: Some(InstallationMode::ExistingPool),
-            efi_partition_by_id: Some(PathBuf::from(
+            efi_partition: Some(PathBuf::from(
                 "/dev/disk/by-id/virtio-archzfs-test-disk-part1",
             )),
             pool_name: Some("testpool".to_string()),
@@ -235,7 +231,7 @@ mod tests {
     #[test]
     fn test_full_disk_missing_disk() {
         let mut cfg = valid_full_disk_config();
-        cfg.disk_by_id = None;
+        cfg.disk = None;
         let errors = cfg.validate_for_install();
         assert!(errors.iter().any(|e| e.contains("disk selection")));
     }
@@ -243,8 +239,8 @@ mod tests {
     #[test]
     fn test_new_pool_missing_partitions() {
         let mut cfg = valid_new_pool_config();
-        cfg.efi_partition_by_id = None;
-        cfg.zfs_partition_by_id = None;
+        cfg.efi_partition = None;
+        cfg.zfs_partition = None;
         let errors = cfg.validate_for_install();
         assert!(errors.iter().any(|e| e.contains("EFI partition")));
         assert!(errors.iter().any(|e| e.contains("ZFS partition")));
@@ -253,7 +249,7 @@ mod tests {
     #[test]
     fn test_existing_pool_missing_efi() {
         let mut cfg = valid_existing_pool_config();
-        cfg.efi_partition_by_id = None;
+        cfg.efi_partition = None;
         let errors = cfg.validate_for_install();
         assert!(errors.iter().any(|e| e.contains("EFI partition")));
     }
@@ -315,9 +311,9 @@ mod tests {
     fn test_new_pool_swap_needs_partition() {
         let mut cfg = valid_new_pool_config();
         cfg.swap_mode = SwapMode::ZswapPartitionEncrypted;
-        cfg.swap_partition_by_id = None;
+        cfg.swap_partition = None;
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("swap_partition_by_id")));
+        assert!(errors.iter().any(|e| e.contains("swap_partition")));
     }
 
     #[test]
@@ -331,7 +327,7 @@ mod tests {
     #[test]
     fn test_valid_by_path_disk_path() {
         let mut cfg = valid_full_disk_config();
-        cfg.disk_by_id = Some(PathBuf::from("/dev/disk/by-path/pci-0000:00:04.0"));
+        cfg.disk = Some(PathBuf::from("/dev/disk/by-path/pci-0000:00:04.0"));
         let errors = cfg.validate_for_install();
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
     }
@@ -339,7 +335,7 @@ mod tests {
     #[test]
     fn test_valid_virtio_devnode_disk_path() {
         let mut cfg = valid_full_disk_config();
-        cfg.disk_by_id = Some(PathBuf::from("/dev/vda"));
+        cfg.disk = Some(PathBuf::from("/dev/vda"));
         let errors = cfg.validate_for_install();
         assert!(errors.is_empty(), "Expected no errors, got: {errors:?}");
     }
@@ -347,7 +343,7 @@ mod tests {
     #[test]
     fn test_invalid_device_path() {
         let mut cfg = valid_full_disk_config();
-        cfg.disk_by_id = Some(PathBuf::from("/tmp/not-a-disk"));
+        cfg.disk = Some(PathBuf::from("/tmp/not-a-disk"));
         let errors = cfg.validate_for_install();
         assert!(errors.iter().any(|e| e.contains("supported /dev node")));
     }
@@ -468,7 +464,7 @@ mod tests {
     fn test_serde_roundtrip_full_config() {
         let cfg = GlobalConfig {
             installation_mode: Some(InstallationMode::FullDisk),
-            disk_by_id: Some(PathBuf::from("/dev/disk/by-id/virtio-archzfs-test-disk")),
+            disk: Some(PathBuf::from("/dev/disk/by-id/virtio-archzfs-test-disk")),
             pool_name: Some("mypool".to_string()),
             dataset_prefix: "arch0".to_string(),
             compression: CompressionAlgo::Zstd5,
@@ -485,5 +481,35 @@ mod tests {
         assert_eq!(back.compression, CompressionAlgo::Zstd5);
         assert_eq!(back.swap_mode, SwapMode::Zram);
         assert_eq!(back.pool_name.as_deref(), Some("mypool"));
+    }
+
+    #[test]
+    fn test_serde_accepts_legacy_device_field_names() {
+        let json = r#"{
+            "installation_mode": "new_pool",
+            "disk_by_id": "/dev/disk/by-id/legacy-disk",
+            "efi_partition_by_id": "/dev/disk/by-id/legacy-disk-part1",
+            "zfs_partition_by_id": "/dev/disk/by-id/legacy-disk-part2",
+            "swap_partition_by_id": "/dev/disk/by-id/legacy-disk-part3",
+            "pool_name": "testpool"
+        }"#;
+
+        let cfg: GlobalConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            cfg.disk.as_deref(),
+            Some(std::path::Path::new("/dev/disk/by-id/legacy-disk"))
+        );
+        assert_eq!(
+            cfg.efi_partition.as_deref(),
+            Some(std::path::Path::new("/dev/disk/by-id/legacy-disk-part1"))
+        );
+        assert_eq!(
+            cfg.zfs_partition.as_deref(),
+            Some(std::path::Path::new("/dev/disk/by-id/legacy-disk-part2"))
+        );
+        assert_eq!(
+            cfg.swap_partition.as_deref(),
+            Some(std::path::Path::new("/dev/disk/by-id/legacy-disk-part3"))
+        );
     }
 }

--- a/core/src/disk/by_id.rs
+++ b/core/src/disk/by_id.rs
@@ -4,11 +4,8 @@ use std::path::{Path, PathBuf};
 use color_eyre::eyre::{Context, Result};
 
 pub fn list_disks_by_id() -> Result<Vec<PathBuf>> {
-    if let Ok(devices) = crate::disk::device::list_block_devices() {
-        return Ok(devices
-            .into_iter()
-            .map(|device| device.preferred_path().path)
-            .collect());
+    if let Ok(choices) = crate::disk::device::disk_choices() {
+        return Ok(choices.into_iter().map(|choice| choice.path).collect());
     }
 
     list_disks_by_id_legacy()
@@ -38,6 +35,14 @@ fn list_disks_by_id_legacy() -> Result<Vec<PathBuf>> {
 }
 
 pub fn list_partitions_by_id() -> Result<Vec<PathBuf>> {
+    if let Ok(choices) = crate::disk::device::partition_choices() {
+        return Ok(choices.into_iter().map(|choice| choice.path).collect());
+    }
+
+    list_partitions_by_id_legacy()
+}
+
+fn list_partitions_by_id_legacy() -> Result<Vec<PathBuf>> {
     let by_id = Path::new("/dev/disk/by-id");
     if !by_id.exists() {
         return Ok(Vec::new());

--- a/core/src/disk/device.rs
+++ b/core/src/disk/device.rs
@@ -32,23 +32,22 @@ pub struct BlockDevice {
     pub removable: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockPartition {
+    pub devnode: PathBuf,
+    pub aliases: Vec<DevicePath>,
+    pub size_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceChoice {
+    pub path: PathBuf,
+    pub label: String,
+}
+
 impl BlockDevice {
     pub fn preferred_path(&self) -> DevicePath {
-        self.aliases
-            .iter()
-            .filter(|alias| alias.kind == DevicePathKind::ById)
-            .min_by_key(|alias| alias_preference_key(alias))
-            .or_else(|| {
-                self.aliases
-                    .iter()
-                    .filter(|alias| alias.kind == DevicePathKind::ByPath)
-                    .min_by_key(|alias| alias_preference_key(alias))
-            })
-            .cloned()
-            .unwrap_or_else(|| DevicePath {
-                path: self.devnode.clone(),
-                kind: DevicePathKind::DevNode,
-            })
+        preferred_path_for(&self.aliases, &self.devnode)
     }
 
     pub fn selection_label(&self) -> String {
@@ -76,6 +75,47 @@ impl BlockDevice {
     }
 }
 
+impl BlockPartition {
+    pub fn preferred_path(&self) -> DevicePath {
+        preferred_path_for(&self.aliases, &self.devnode)
+    }
+
+    pub fn selection_label(&self) -> String {
+        let mut parts = vec![self.devnode.display().to_string()];
+
+        if let Some(size) = self.size_bytes {
+            parts.push(format_size(size));
+        }
+
+        let preferred = self.preferred_path();
+        if preferred.path != self.devnode {
+            parts.push(format!("using {}", preferred.path.display()));
+        }
+
+        parts.join(" | ")
+    }
+}
+
+pub fn disk_choices() -> Result<Vec<DeviceChoice>> {
+    Ok(list_block_devices()?
+        .into_iter()
+        .map(|device| DeviceChoice {
+            path: device.preferred_path().path,
+            label: device.selection_label(),
+        })
+        .collect())
+}
+
+pub fn partition_choices() -> Result<Vec<DeviceChoice>> {
+    Ok(list_block_partitions()?
+        .into_iter()
+        .map(|partition| DeviceChoice {
+            path: partition.preferred_path().path,
+            label: partition.selection_label(),
+        })
+        .collect())
+}
+
 #[derive(Debug, Deserialize)]
 struct LsblkOutput {
     blockdevices: Vec<LsblkDevice>,
@@ -97,6 +137,30 @@ struct LsblkDevice {
 }
 
 pub fn list_block_devices() -> Result<Vec<BlockDevice>> {
+    let (parsed, aliases) = inspect_block_devices()?;
+
+    let mut devices = Vec::new();
+    for node in parsed.blockdevices {
+        collect_lsblk_disks(node, &aliases, &mut devices);
+    }
+
+    devices.sort_by(|a, b| a.devnode.cmp(&b.devnode));
+    Ok(devices)
+}
+
+pub fn list_block_partitions() -> Result<Vec<BlockPartition>> {
+    let (parsed, aliases) = inspect_block_devices()?;
+
+    let mut partitions = Vec::new();
+    for node in parsed.blockdevices {
+        collect_lsblk_partitions(node, &aliases, &mut partitions);
+    }
+
+    partitions.sort_by(|a, b| a.devnode.cmp(&b.devnode));
+    Ok(partitions)
+}
+
+fn inspect_block_devices() -> Result<(LsblkOutput, HashMap<PathBuf, Vec<DevicePath>>)> {
     let output = Command::new("lsblk")
         .args([
             "--json",
@@ -116,15 +180,8 @@ pub fn list_block_devices() -> Result<Vec<BlockDevice>> {
 
     let parsed: LsblkOutput =
         serde_json::from_slice(&output.stdout).wrap_err("failed to parse lsblk JSON")?;
-    let aliases = collect_disk_aliases()?;
-
-    let mut devices = Vec::new();
-    for node in parsed.blockdevices {
-        collect_lsblk_disks(node, &aliases, &mut devices);
-    }
-
-    devices.sort_by(|a, b| a.devnode.cmp(&b.devnode));
-    Ok(devices)
+    let aliases = collect_device_aliases()?;
+    Ok((parsed, aliases))
 }
 
 fn collect_lsblk_disks(
@@ -157,6 +214,30 @@ fn collect_lsblk_disks(
     }
 }
 
+fn collect_lsblk_partitions(
+    node: LsblkDevice,
+    aliases: &HashMap<PathBuf, Vec<DevicePath>>,
+    partitions: &mut Vec<BlockPartition>,
+) {
+    if node.device_type.as_deref() == Some("part")
+        && let Some(devnode) = node.path.clone()
+    {
+        let canonical = fs::canonicalize(&devnode).unwrap_or_else(|_| devnode.clone());
+        let mut partition_aliases = aliases.get(&canonical).cloned().unwrap_or_default();
+        partition_aliases.sort_by_key(alias_preference_key);
+
+        partitions.push(BlockPartition {
+            devnode,
+            aliases: partition_aliases,
+            size_bytes: node.size.as_ref().and_then(value_as_u64),
+        });
+    }
+
+    for child in node.children {
+        collect_lsblk_partitions(child, aliases, partitions);
+    }
+}
+
 fn is_installable_devnode(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;
@@ -165,7 +246,7 @@ fn is_installable_devnode(path: &Path) -> bool {
     !(name.starts_with("loop") || name.starts_with("zram") || name.starts_with("sr"))
 }
 
-fn collect_disk_aliases() -> Result<HashMap<PathBuf, Vec<DevicePath>>> {
+fn collect_device_aliases() -> Result<HashMap<PathBuf, Vec<DevicePath>>> {
     let mut aliases: HashMap<PathBuf, Vec<DevicePath>> = HashMap::new();
     collect_alias_dir(
         Path::new("/dev/disk/by-id"),
@@ -219,6 +300,24 @@ fn alias_preference_key(alias: &DevicePath) -> (u8, String) {
     };
 
     (rank, alias.path.display().to_string())
+}
+
+fn preferred_path_for(aliases: &[DevicePath], devnode: &Path) -> DevicePath {
+    aliases
+        .iter()
+        .filter(|alias| alias.kind == DevicePathKind::ById)
+        .min_by_key(|alias| alias_preference_key(alias))
+        .or_else(|| {
+            aliases
+                .iter()
+                .filter(|alias| alias.kind == DevicePathKind::ByPath)
+                .min_by_key(|alias| alias_preference_key(alias))
+        })
+        .cloned()
+        .unwrap_or_else(|| DevicePath {
+            path: devnode.to_path_buf(),
+            kind: DevicePathKind::DevNode,
+        })
 }
 
 fn by_id_rank(name: &str) -> u8 {
@@ -372,6 +471,33 @@ mod tests {
         assert_eq!(
             device.selection_label(),
             "/dev/vda | VirtIO Block Device | 64 GiB | virtio | using /dev/disk/by-path/pci-0000:00:04.0"
+        );
+    }
+
+    #[test]
+    fn partition_selection_prefers_persistent_aliases() {
+        let partition = BlockPartition {
+            devnode: PathBuf::from("/dev/vda1"),
+            aliases: vec![
+                DevicePath {
+                    path: PathBuf::from("/dev/disk/by-path/pci-0000:00:04.0-part1"),
+                    kind: DevicePathKind::ByPath,
+                },
+                DevicePath {
+                    path: PathBuf::from("/dev/disk/by-id/virtio-test-disk-part1"),
+                    kind: DevicePathKind::ById,
+                },
+            ],
+            size_bytes: Some(512 * 1024 * 1024),
+        };
+
+        assert_eq!(
+            partition.preferred_path().path,
+            PathBuf::from("/dev/disk/by-id/virtio-test-disk-part1")
+        );
+        assert_eq!(
+            partition.selection_label(),
+            "/dev/vda1 | 512 MiB | using /dev/disk/by-id/virtio-test-disk-part1"
         );
     }
 }

--- a/core/src/disk/partition.rs
+++ b/core/src/disk/partition.rs
@@ -122,7 +122,7 @@ pub fn create_partitions(
     let _ = runner.run("partprobe", &[&*disk_str]);
     let _ = runner.run("udevadm", &["settle"]);
 
-    // Wait for by-id symlinks to appear
+    // Wait for the newly created EFI partition path to appear.
     let efi_dev = partition_path(disk, layout.efi_part_num);
     let efi_dev_str = efi_dev.to_string_lossy();
     for _ in 0..50 {
@@ -139,8 +139,8 @@ pub fn create_partitions(
     Ok(layout)
 }
 
-/// Wait for /dev/disk/by-id partition symlinks to appear after partitioning.
-pub fn wait_for_by_id_partitions(disk: &Path, layout: &PartitionLayout) -> Vec<std::path::PathBuf> {
+/// Wait for partition paths to appear after partitioning.
+pub fn wait_for_partitions(disk: &Path, layout: &PartitionLayout) -> Vec<std::path::PathBuf> {
     let mut parts = vec![
         partition_path(disk, layout.efi_part_num),
         partition_path(disk, layout.zfs_part_num),

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -28,7 +28,7 @@ pub struct Installer {
     cancel: CancellationToken,
     download_progress_tx: Option<Arc<tokio::sync::watch::Sender<DownloadProgress>>>,
     /// Swap partition computed at runtime (e.g. from full-disk partitioning).
-    /// Overrides `config.swap_partition_by_id` when set.
+    /// Overrides `config.swap_partition` when set.
     swap_partition: Option<PathBuf>,
     _target_mounts: Option<TargetMounts>,
     alpm_ctx: Option<AlpmContext>,
@@ -547,7 +547,7 @@ impl Installer {
     fn effective_swap_partition(&self) -> Option<&Path> {
         self.swap_partition
             .as_deref()
-            .or(self.config.swap_partition_by_id.as_deref())
+            .or(self.config.swap_partition.as_deref())
     }
 
     fn finalize_zfs(&self) -> Result<()> {

--- a/core/src/prepare.rs
+++ b/core/src/prepare.rs
@@ -36,7 +36,7 @@ pub fn prepare_disk(
     match mode {
         InstallationMode::FullDisk => {
             let disk = config
-                .disk_by_id
+                .disk
                 .as_ref()
                 .ok_or_else(|| eyre!("disk not selected for full disk mode"))?;
             crate::disk::partition::zap_disk(runner, disk)?;
@@ -48,7 +48,7 @@ pub fn prepare_disk(
                 _ => None,
             };
             let layout = crate::disk::partition::create_partitions(runner, disk, swap_size)?;
-            let parts = crate::disk::partition::wait_for_by_id_partitions(disk, &layout);
+            let parts = crate::disk::partition::wait_for_partitions(disk, &layout);
             let efi = parts[0].clone();
             let zfs = parts[1].clone();
             let swap = parts.get(2).cloned();
@@ -60,14 +60,14 @@ pub fn prepare_disk(
         }
         InstallationMode::NewPool => {
             let efi = config
-                .efi_partition_by_id
+                .efi_partition
                 .clone()
                 .ok_or_else(|| eyre!("EFI partition not selected"))?;
             let zfs = config
-                .zfs_partition_by_id
+                .zfs_partition
                 .clone()
                 .ok_or_else(|| eyre!("ZFS partition not selected"))?;
-            let swap = config.swap_partition_by_id.clone();
+            let swap = config.swap_partition.clone();
             Ok(PreparedPartitions {
                 efi,
                 zfs: Some(zfs),
@@ -76,10 +76,10 @@ pub fn prepare_disk(
         }
         InstallationMode::ExistingPool => {
             let efi = config
-                .efi_partition_by_id
+                .efi_partition
                 .clone()
                 .ok_or_else(|| eyre!("EFI partition not selected"))?;
-            let swap = config.swap_partition_by_id.clone();
+            let swap = config.swap_partition.clone();
             Ok(PreparedPartitions {
                 efi,
                 zfs: None,

--- a/core/src/zfs_trim.rs
+++ b/core/src/zfs_trim.rs
@@ -28,8 +28,8 @@ pub async fn configure_zfs_trim(
     // Only configure TRIM when we created (or know) the disk. ExistingPool
     // mode leaves the pool's autotrim property and any timer untouched.
     let disk_path = match config.installation_mode {
-        Some(InstallationMode::FullDisk) => config.disk_by_id.as_deref(),
-        Some(InstallationMode::NewPool) => config.zfs_partition_by_id.as_deref(),
+        Some(InstallationMode::FullDisk) => config.disk.as_deref(),
+        Some(InstallationMode::NewPool) => config.zfs_partition.as_deref(),
         _ => None,
     };
 

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -58,26 +58,26 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         let disk_strs: Vec<String> = disks.iter().map(|(_, label)| label.clone()).collect();
         let disk_refs: Vec<&str> = disk_strs.iter().map(|s| s.as_str()).collect();
         let selected = c
-            .disk_by_id
+            .disk
             .as_ref()
             .and_then(|sel| disks.iter().position(|(path, _)| path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
-        items.extend(radio_group("disk_by_id", "Disk", &disk_refs, selected));
+        items.extend(radio_group("disk", "Disk", &disk_refs, selected));
     }
 
     if matches!(
         mode,
         Some(InstallationMode::NewPool) | Some(InstallationMode::ExistingPool)
     ) {
-        let parts = archinstall_zfs_core::disk::by_id::list_partitions_by_id().unwrap_or_default();
-        let part_strs: Vec<String> = parts.iter().map(|p| p.display().to_string()).collect();
+        let parts = partition_choices();
+        let part_strs: Vec<String> = parts.iter().map(|(_, label)| label.clone()).collect();
         let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
 
         let efi_selected = c
-            .efi_partition_by_id
+            .efi_partition
             .as_ref()
-            .and_then(|sel| parts.iter().position(|p| p == sel))
+            .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
         items.extend(radio_group(
@@ -89,9 +89,9 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 
         if matches!(mode, Some(InstallationMode::NewPool)) {
             let zfs_selected = c
-                .zfs_partition_by_id
+                .zfs_partition
                 .as_ref()
-                .and_then(|sel| parts.iter().position(|p| p == sel))
+                .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
                 .map(|i| i as i32)
                 .unwrap_or(-1);
             items.extend(radio_group(
@@ -196,13 +196,13 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         ));
     }
     if !matches!(mode, Some(InstallationMode::FullDisk) | None) && has_swap_partition {
-        let parts = archinstall_zfs_core::disk::by_id::list_partitions_by_id().unwrap_or_default();
-        let part_strs: Vec<String> = parts.iter().map(|p| p.display().to_string()).collect();
+        let parts = partition_choices();
+        let part_strs: Vec<String> = parts.iter().map(|(_, label)| label.clone()).collect();
         let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
         let swap_selected = c
-            .swap_partition_by_id
+            .swap_partition
             .as_ref()
-            .and_then(|sel| parts.iter().position(|p| p == sel))
+            .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
         items.extend(radio_group(
@@ -670,38 +670,35 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
                 _ => InstallationMode::ExistingPool,
             };
             if config.installation_mode != Some(new_mode) {
-                config.disk_by_id = None;
-                config.efi_partition_by_id = None;
-                config.zfs_partition_by_id = None;
-                config.swap_partition_by_id = None;
+                config.disk = None;
+                config.efi_partition = None;
+                config.zfs_partition = None;
+                config.swap_partition = None;
             }
             config.installation_mode = Some(new_mode);
         }
-        "disk_by_id" => {
+        "disk" => {
             let disks = disk_choices();
             if let Some((path, _)) = disks.get(idx as usize) {
-                config.disk_by_id = Some(path.clone());
+                config.disk = Some(path.clone());
             }
         }
         "efi_partition" => {
-            if let Ok(parts) = archinstall_zfs_core::disk::by_id::list_partitions_by_id()
-                && let Some(path) = parts.get(idx as usize)
-            {
-                config.efi_partition_by_id = Some(path.clone());
+            let parts = partition_choices();
+            if let Some((path, _)) = parts.get(idx as usize) {
+                config.efi_partition = Some(path.clone());
             }
         }
         "zfs_partition" => {
-            if let Ok(parts) = archinstall_zfs_core::disk::by_id::list_partitions_by_id()
-                && let Some(path) = parts.get(idx as usize)
-            {
-                config.zfs_partition_by_id = Some(path.clone());
+            let parts = partition_choices();
+            if let Some((path, _)) = parts.get(idx as usize) {
+                config.zfs_partition = Some(path.clone());
             }
         }
         "swap_partition" => {
-            if let Ok(parts) = archinstall_zfs_core::disk::by_id::list_partitions_by_id()
-                && let Some(path) = parts.get(idx as usize)
-            {
-                config.swap_partition_by_id = Some(path.clone());
+            let parts = partition_choices();
+            if let Some((path, _)) = parts.get(idx as usize) {
+                config.swap_partition = Some(path.clone());
             }
         }
         "compression" => {
@@ -768,15 +765,35 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
 }
 
 fn disk_choices() -> Vec<(std::path::PathBuf, String)> {
-    archinstall_zfs_core::disk::device::list_block_devices()
-        .map(|devices| {
-            devices
+    archinstall_zfs_core::disk::device::disk_choices()
+        .map(|choices| {
+            choices
                 .into_iter()
-                .map(|device| (device.preferred_path().path, device.selection_label()))
+                .map(|choice| (choice.path, choice.label))
                 .collect()
         })
         .unwrap_or_else(|_| {
             archinstall_zfs_core::disk::by_id::list_disks_by_id()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|path| {
+                    let label = path.display().to_string();
+                    (path, label)
+                })
+                .collect()
+        })
+}
+
+fn partition_choices() -> Vec<(std::path::PathBuf, String)> {
+    archinstall_zfs_core::disk::device::partition_choices()
+        .map(|choices| {
+            choices
+                .into_iter()
+                .map(|choice| (choice.path, choice.label))
+                .collect()
+        })
+        .unwrap_or_else(|_| {
+            archinstall_zfs_core::disk::by_id::list_partitions_by_id()
                 .unwrap_or_default()
                 .into_iter()
                 .map(|path| {
@@ -826,28 +843,28 @@ mod tests {
     #[test]
     fn radio_installation_mode_sets_and_clears_dependents() {
         let mut c = cfg();
-        c.disk_by_id = Some("/dev/sda".into());
-        c.efi_partition_by_id = Some("/dev/sda1".into());
+        c.disk = Some("/dev/sda".into());
+        c.efi_partition = Some("/dev/sda1".into());
 
-        // Switching mode should clear all by-id selections
+        // Switching mode should clear all device selections
         apply_radio(&mut c, "installation_mode", 1);
         assert_eq!(c.installation_mode, Some(InstallationMode::NewPool));
-        assert!(c.disk_by_id.is_none());
-        assert!(c.efi_partition_by_id.is_none());
-        assert!(c.zfs_partition_by_id.is_none());
-        assert!(c.swap_partition_by_id.is_none());
+        assert!(c.disk.is_none());
+        assert!(c.efi_partition.is_none());
+        assert!(c.zfs_partition.is_none());
+        assert!(c.swap_partition.is_none());
     }
 
     #[test]
     fn radio_installation_mode_no_clear_when_unchanged() {
         let mut c = cfg();
         c.installation_mode = Some(InstallationMode::FullDisk);
-        c.disk_by_id = Some("/dev/sda".into());
+        c.disk = Some("/dev/sda".into());
 
         apply_radio(&mut c, "installation_mode", 0); // Same mode (FullDisk)
         assert_eq!(c.installation_mode, Some(InstallationMode::FullDisk));
         // Selections should be preserved when mode doesn't actually change
-        assert!(c.disk_by_id.is_some());
+        assert!(c.disk.is_some());
     }
 
     #[test]

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -81,10 +81,10 @@ pub fn pick_disk(terminal: &mut ratatui::DefaultTerminal) -> Result<Option<PathB
 }
 
 fn disk_choices() -> Result<Vec<(PathBuf, String)>> {
-    match archinstall_zfs_core::disk::device::list_block_devices() {
-        Ok(devices) => Ok(devices
+    match archinstall_zfs_core::disk::device::disk_choices() {
+        Ok(choices) => Ok(choices
             .into_iter()
-            .map(|device| (device.preferred_path().path, device.selection_label()))
+            .map(|choice| (choice.path, choice.label))
             .collect()),
         Err(_) => Ok(archinstall_zfs_core::disk::by_id::list_disks_by_id()?
             .into_iter()
@@ -100,16 +100,29 @@ pub fn pick_partition(
     terminal: &mut ratatui::DefaultTerminal,
     title: &str,
 ) -> Result<Option<PathBuf>> {
-    let parts = archinstall_zfs_core::disk::by_id::list_partitions_by_id()?;
+    let parts = partition_choices()?;
     if parts.is_empty() {
         return Ok(None);
     }
-    let part_strs: Vec<String> = parts.iter().map(|p| p.display().to_string()).collect();
+    let part_strs: Vec<String> = parts.iter().map(|part| part.label.clone()).collect();
     let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
     let result = run_select(terminal, title, &part_refs, 0)?;
     match result.selected {
-        Some(idx) => Ok(Some(parts[idx].clone())),
+        Some(idx) => Ok(Some(parts[idx].path.clone())),
         None => Ok(None),
+    }
+}
+
+fn partition_choices() -> Result<Vec<archinstall_zfs_core::disk::device::DeviceChoice>> {
+    match archinstall_zfs_core::disk::device::partition_choices() {
+        Ok(choices) => Ok(choices),
+        Err(_) => Ok(archinstall_zfs_core::disk::by_id::list_partitions_by_id()?
+            .into_iter()
+            .map(|path| archinstall_zfs_core::disk::device::DeviceChoice {
+                label: path.display().to_string(),
+                path,
+            })
+            .collect()),
     }
 }
 
@@ -594,10 +607,10 @@ pub fn apply_select(
                 _ => return Ok(()),
             };
             if config.installation_mode != Some(new_mode) {
-                config.disk_by_id = None;
-                config.efi_partition_by_id = None;
-                config.zfs_partition_by_id = None;
-                config.swap_partition_by_id = None;
+                config.disk = None;
+                config.efi_partition = None;
+                config.zfs_partition = None;
+                config.swap_partition = None;
             }
             config.installation_mode = Some(new_mode);
         }

--- a/tui/src/tui/screens/steps/disk.rs
+++ b/tui/src/tui/screens/steps/disk.rs
@@ -9,10 +9,10 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     // Show disk picker for FullDisk mode
     if matches!(mode, Some(InstallationMode::FullDisk) | None) {
         items.push(MenuItem {
-            key: "disk_by_id",
+            key: "disk",
             label: "Disk",
             value: config
-                .disk_by_id
+                .disk
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or("Not set".into()),
@@ -29,7 +29,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             key: "efi_partition",
             label: "EFI partition",
             value: config
-                .efi_partition_by_id
+                .efi_partition
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or("Not set".into()),
@@ -41,7 +41,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             key: "zfs_partition",
             label: "ZFS partition",
             value: config
-                .zfs_partition_by_id
+                .zfs_partition
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or("Not set".into()),

--- a/tui/src/tui/screens/steps/zfs.rs
+++ b/tui/src/tui/screens/steps/zfs.rs
@@ -104,7 +104,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             key: "swap_partition",
             label: "Swap partition",
             value: config
-                .swap_partition_by_id
+                .swap_partition
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or("Not set".into()),

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -240,24 +240,24 @@ impl Wizard {
                         self.config.keyboard_layout = km;
                     }
                 }
-                "disk_by_id" => {
+                "disk" => {
                     if let Some(disk) = pickers::pick_disk(terminal)? {
-                        self.config.disk_by_id = Some(disk);
+                        self.config.disk = Some(disk);
                     }
                 }
                 "efi_partition" => {
                     if let Some(part) = pickers::pick_partition(terminal, "EFI partition")? {
-                        self.config.efi_partition_by_id = Some(part);
+                        self.config.efi_partition = Some(part);
                     }
                 }
                 "zfs_partition" => {
                     if let Some(part) = pickers::pick_partition(terminal, "ZFS partition")? {
-                        self.config.zfs_partition_by_id = Some(part);
+                        self.config.zfs_partition = Some(part);
                     }
                 }
                 "swap_partition" => {
                     if let Some(part) = pickers::pick_partition(terminal, "Swap partition")? {
-                        self.config.swap_partition_by_id = Some(part);
+                        self.config.swap_partition = Some(part);
                     }
                 }
                 "kernel" => {

--- a/xtask/configs/default.json
+++ b/xtask/configs/default.json
@@ -1,6 +1,6 @@
 {
     "installation_mode": "full_disk",
-    "disk_by_id": "/dev/disk/by-id/virtio-archzfs-test-disk",
+    "disk": "/dev/disk/by-id/virtio-archzfs-test-disk",
     "pool_name": "testpool",
     "dataset_prefix": "arch0",
     "init_system": "dracut",


### PR DESCRIPTION
## Summary

Completes the device-selection cleanup started in the VirtIO disk support work by making the config and pickers model disks and partitions as generic block-device paths rather than by-id-specific selections.

## Details

- Renames canonical config fields from `*_by_id` to `disk`, `efi_partition`, `zfs_partition`, and `swap_partition`.
- Keeps backward compatibility for existing configs with `serde(alias = "*_by_id")`.
- Adds partition discovery and selection through `disk::device`, using the same preferred-path policy as whole disks.
- Keeps `disk::by_id` as a compatibility wrapper and fallback path.
- Updates TUI and Slint pickers to use the shared disk/partition choice APIs.
- Updates the xtask default install config to use the new canonical `disk` field.

## Validation

- `cargo test -p archinstall-zfs-core`
- `cargo check -p archinstall-zfs-tui`
- `cargo check -p archinstall-zfs-slint`
- `cargo check -p xtask`
