### PR TITLE
[codex] Polish Slint wizard UI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [alias]
 xtask = "run --package xtask --"
+
+[env]
+# Enables FlexboxLayout in slint-ui (used by the package-search chip strip).
+SLINT_ENABLE_EXPERIMENTAL_FEATURES = "1"

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -115,10 +115,10 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 
     let mut items = vec![
         section_header("Pool"),
-        ci(
+        ci_opt(
             "pool_name",
             "Pool name",
-            &c.pool_name.clone().unwrap_or("Not set".into()),
+            c.pool_name.as_deref(),
             ItemType::Text,
         ),
         ci(
@@ -129,7 +129,7 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         ),
     ];
 
-    items.extend(radio_group(
+    items.extend(radio_group_with_off(
         "compression",
         "Compression",
         &["lz4", "zstd", "zstd-5", "zstd-10", "off"],
@@ -140,6 +140,7 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             CompressionAlgo::Zstd10 => 3,
             CompressionAlgo::Off => 4,
         },
+        4,
     ));
 
     items.extend(radio_group(
@@ -158,19 +159,15 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     ));
 
     if c.zfs_encryption_mode != ZfsEncryptionMode::None {
-        items.push(ci(
+        items.push(ci_opt(
             "encryption_password",
             "Encryption password",
-            if c.zfs_encryption_password.is_some() {
-                "Set"
-            } else {
-                "Not set"
-            },
+            c.zfs_encryption_password.as_ref().map(|_| "Set"),
             ItemType::Password,
         ));
     }
 
-    items.extend(radio_group(
+    items.extend(radio_group_with_off(
         "swap_mode",
         "Swap",
         &[
@@ -185,13 +182,14 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             SwapMode::ZswapPartition => 2,
             SwapMode::ZswapPartitionEncrypted => 3,
         },
+        0,
     ));
 
     if matches!(mode, Some(InstallationMode::FullDisk)) && has_swap_partition {
-        items.push(ci(
+        items.push(ci_opt(
             "swap_partition_size",
             "Swap size",
-            &c.swap_partition_size.clone().unwrap_or("Not set".into()),
+            c.swap_partition_size.as_deref(),
             ItemType::Text,
         ));
     }
@@ -242,18 +240,13 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             ),
             ItemType::Select,
         ),
-        ci(
+        ci_opt(
             "hostname",
             "Hostname",
-            &c.hostname.clone().unwrap_or("Not set".into()),
+            c.hostname.as_deref(),
             ItemType::Text,
         ),
-        ci(
-            "ntp",
-            "NTP (time sync)",
-            if c.ntp { "Enabled" } else { "Disabled" },
-            ItemType::Toggle,
-        ),
+        ci_toggle("ntp", "NTP (time sync)", c.ntp),
         ci(
             "parallel_downloads",
             "Parallel downloads",
@@ -261,16 +254,11 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             ItemType::Text,
         ),
         section_header("Locale"),
-        ci(
-            "locale",
-            "Locale",
-            &c.locale.clone().unwrap_or("Not set".into()),
-            ItemType::Select,
-        ),
-        ci(
+        ci_opt("locale", "Locale", c.locale.as_deref(), ItemType::Select),
+        ci_opt(
             "timezone",
             "Timezone",
-            &c.timezone.clone().unwrap_or("Not set".into()),
+            c.timezone.as_deref(),
             ItemType::Select,
         ),
         ci(
@@ -285,36 +273,41 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 fn build_users_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     vec![
         section_header("Authentication"),
-        ci(
+        ci_opt(
             "root_password",
             "Root password",
-            if c.root_password.is_some() {
-                "Set"
-            } else {
-                "Not set"
-            },
+            c.root_password.as_ref().map(|_| "Set"),
             ItemType::Password,
         ),
         section_header("Accounts"),
-        ci(
-            "users",
-            "User accounts",
-            &match &c.users {
-                Some(users) if !users.is_empty() => users
-                    .iter()
-                    .map(|u| {
-                        if u.sudo {
-                            format!("{} [sudo]", u.username)
-                        } else {
-                            u.username.clone()
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                _ => "None".into(),
-            },
-            ItemType::Text,
-        ),
+        {
+            let summary = match &c.users {
+                Some(users) if !users.is_empty() => Some(
+                    users
+                        .iter()
+                        .map(|u| {
+                            if u.sudo {
+                                format!("{} [sudo]", u.username)
+                            } else {
+                                u.username.clone()
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ),
+                _ => None,
+            };
+            // ci_opt's None → "Not set"; users semantically wants "None".
+            // Construct directly so we keep the established label.
+            ConfigItem {
+                key: "users".into(),
+                label: "User accounts".into(),
+                value: summary.clone().unwrap_or_else(|| "None".into()).into(),
+                item_type: ItemType::Text,
+                is_empty: summary.is_none(),
+                ..Default::default()
+            }
+        },
     ]
 }
 
@@ -322,17 +315,17 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     let sel = c.profile_selection.as_ref();
     let profile_def = sel.and_then(|s| s.profile_def());
 
+    let profile_name = profile_def.as_ref().map(|p| p.display_name.to_string());
     let mut items = vec![
         section_header("Desktop"),
-        ci(
-            "profile",
-            "Profile",
-            &profile_def
-                .as_ref()
-                .map(|p| p.display_name.to_string())
-                .unwrap_or_else(|| "None".into()),
-            ItemType::Select,
-        ),
+        ConfigItem {
+            key: "profile".into(),
+            label: "Profile".into(),
+            value: profile_name.clone().unwrap_or_else(|| "None".into()).into(),
+            item_type: ItemType::Select,
+            is_empty: profile_name.is_none(),
+            ..Default::default()
+        },
     ];
 
     // ── Profile configuration: only when a desktop profile is active ──
@@ -345,33 +338,38 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         let total = p.optional_packages().len();
         if total > 0 {
             let chosen = sel.optional_packages.len();
-            items.push(ci(
-                "optional_packages",
-                "Optional packages",
-                &format!("{chosen} of {total}"),
-                ItemType::Select,
-            ));
+            items.push(ConfigItem {
+                key: "optional_packages".into(),
+                label: "Optional packages".into(),
+                value: format!("{chosen} of {total}").into(),
+                item_type: ItemType::Select,
+                is_empty: chosen == 0,
+                ..Default::default()
+            });
         }
 
         // Display manager: shows the effective DM with (default) or
         // (override) suffix so the user can tell at a glance whether they
         // diverged from the profile.
-        let value = match (sel.display_manager_override, p.default_display_manager()) {
-            (Some(over), _) => format!("{} (override)", over.display_name()),
-            (None, Some(def)) => format!("{} (default)", def.display_name()),
-            (None, None) => "None".to_string(),
+        let (value, dm_is_empty) = match (sel.display_manager_override, p.default_display_manager())
+        {
+            (Some(over), _) => (format!("{} (override)", over.display_name()), false),
+            (None, Some(def)) => (format!("{} (default)", def.display_name()), false),
+            (None, None) => ("None".to_string(), true),
         };
-        items.push(ci(
-            "display_manager",
-            "Display manager",
-            &value,
-            ItemType::Select,
-        ));
+        items.push(ConfigItem {
+            key: "display_manager".into(),
+            label: "Display manager".into(),
+            value: value.into(),
+            item_type: ItemType::Select,
+            is_empty: dm_is_empty,
+            ..Default::default()
+        });
 
         // Seat access (Wayland compositors). Its own section card via
         // radio_group, like Audio.
         if p.needs_seat_access() {
-            items.extend(radio_group(
+            items.extend(radio_group_with_off(
                 "seat_access",
                 "Seat access",
                 &["None", "seatd", "polkit"],
@@ -380,11 +378,12 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                     Some(SeatAccess::Seatd) => 1,
                     Some(SeatAccess::Polkit) => 2,
                 },
+                0,
             ));
         }
     }
 
-    items.extend(radio_group(
+    items.extend(radio_group_with_off(
         "audio",
         "Audio",
         &["None", "pipewire", "pulseaudio"],
@@ -393,6 +392,7 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             Some(AudioServer::Pipewire) => 1,
             Some(AudioServer::Pulseaudio) => 2,
         },
+        0,
     ));
 
     items.push(section_header("Hardware"));
@@ -403,14 +403,17 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         .as_ref()
         .is_some_and(|p| p.supports_gfx_driver())
     {
-        items.push(ci(
-            "gpu_driver",
-            "GPU driver",
-            &c.gfx_driver
-                .map(|d| d.to_string())
-                .unwrap_or_else(|| "None".into()),
-            ItemType::Select,
-        ));
+        items.push({
+            let driver = c.gfx_driver.map(|d| d.to_string());
+            ConfigItem {
+                key: "gpu_driver".into(),
+                label: "GPU driver".into(),
+                value: driver.clone().unwrap_or_else(|| "None".into()).into(),
+                item_type: ItemType::Select,
+                is_empty: driver.is_none(),
+                ..Default::default()
+            }
+        });
 
         // Inline warning when the proprietary NVIDIA driver is paired with
         // a Wayland-only compositor. The TUI shows a confirmation dialog;
@@ -428,52 +431,46 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             });
         }
     }
-    items.push(ci(
-        "bluetooth",
-        "Bluetooth",
-        if c.bluetooth { "Enabled" } else { "Disabled" },
-        ItemType::Toggle,
-    ));
+    items.push(ci_toggle("bluetooth", "Bluetooth", c.bluetooth));
 
     items.push(section_header("Software"));
-    items.extend([
-        ci(
-            "packages",
-            "Extra packages",
-            &{
-                let total = c.additional_packages.len() + c.aur_packages.len();
-                if total == 0 {
-                    "None".to_string()
-                } else {
-                    let mut parts: Vec<&str> =
-                        c.additional_packages.iter().map(|s| s.as_str()).collect();
-                    parts.extend(c.aur_packages.iter().map(|s| s.as_str()));
-                    parts.join(", ")
-                }
-            },
-            ItemType::Text,
-        ),
-        ci(
-            "extra_services",
-            "Extra services",
-            &if c.extra_services.is_empty() {
-                "None".to_string()
-            } else {
-                c.extra_services.join(", ")
-            },
-            ItemType::Text,
-        ),
-        ci(
-            "zrepl",
-            "zrepl (snapshots)",
-            if c.zrepl_enabled {
-                "Enabled"
-            } else {
-                "Disabled"
-            },
-            ItemType::Toggle,
-        ),
-    ]);
+    items.push({
+        let parts: Vec<&str> = c
+            .additional_packages
+            .iter()
+            .chain(c.aur_packages.iter())
+            .map(|s| s.as_str())
+            .collect();
+        let joined = if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join(", "))
+        };
+        ConfigItem {
+            key: "packages".into(),
+            label: "Extra packages".into(),
+            value: joined.clone().unwrap_or_else(|| "None".into()).into(),
+            item_type: ItemType::Text,
+            is_empty: joined.is_none(),
+            ..Default::default()
+        }
+    });
+    items.push({
+        let joined = if c.extra_services.is_empty() {
+            None
+        } else {
+            Some(c.extra_services.join(", "))
+        };
+        ConfigItem {
+            key: "extra_services".into(),
+            label: "Extra services".into(),
+            value: joined.clone().unwrap_or_else(|| "None".into()).into(),
+            item_type: ItemType::Text,
+            is_empty: joined.is_none(),
+            ..Default::default()
+        }
+    });
+    items.push(ci_toggle("zrepl", "zrepl (snapshots)", c.zrepl_enabled));
 
     items
 }
@@ -495,10 +492,14 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                     // readonly row showing "Group: Selected option".
                     let header_label = item.label.clone();
                     let mut selected_label: SharedString = "Not set".into();
+                    // Default empty: nothing selected. Overwritten when we
+                    // find the selected option, taking its is_empty value.
+                    let mut selected_is_empty = true;
                     i += 1;
                     while i < step_items.len() && step_items[i].item_type == ItemType::RadioOption {
                         if step_items[i].value == "selected" {
                             selected_label = step_items[i].label.clone();
+                            selected_is_empty = step_items[i].is_empty;
                         }
                         i += 1;
                     }
@@ -506,6 +507,7 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                         label: header_label,
                         value: selected_label,
                         item_type: ItemType::Readonly,
+                        is_empty: selected_is_empty,
                         ..Default::default()
                     });
                 }
@@ -522,6 +524,7 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                         label: item.label.clone(),
                         value: item.value.clone(),
                         item_type: ItemType::Readonly,
+                        is_empty: item.is_empty,
                         ..Default::default()
                     });
                     i += 1;
@@ -555,6 +558,38 @@ fn ci(key: &str, label: &str, value: &str, item_type: ItemType) -> ConfigItem {
     }
 }
 
+/// Variant of [`ci`] that takes an `Option<&str>`. `None` is rendered as
+/// "Not set" with `is_empty: true` so the Slint side colors the value muted
+/// without string-matching the sentinel.
+fn ci_opt(key: &str, label: &str, value: Option<&str>, item_type: ItemType) -> ConfigItem {
+    let (display, is_empty) = match value {
+        Some(v) => (v, false),
+        None => ("Not set", true),
+    };
+    ConfigItem {
+        key: key.into(),
+        label: label.into(),
+        value: display.into(),
+        item_type,
+        is_empty,
+        ..Default::default()
+    }
+}
+
+/// Toggle row helper. `enabled=false` is rendered as the "off" state with
+/// `is_empty: true` so the value reads muted, matching how unset fields
+/// look on the rest of the wizard.
+fn ci_toggle(key: &str, label: &str, enabled: bool) -> ConfigItem {
+    ConfigItem {
+        key: key.into(),
+        label: label.into(),
+        value: if enabled { "Enabled" } else { "Disabled" }.into(),
+        item_type: ItemType::Toggle,
+        is_empty: !enabled,
+        ..Default::default()
+    }
+}
+
 #[cfg(test)]
 fn sep() -> ConfigItem {
     ConfigItem {
@@ -577,6 +612,30 @@ fn section_header(label: &str) -> ConfigItem {
 /// summary row, while bare section headers (used as visual dividers) get
 /// dropped in review entirely.
 fn radio_group(key: &str, label: &str, options: &[&str], selected: i32) -> Vec<ConfigItem> {
+    radio_group_inner(key, label, options, selected, None)
+}
+
+/// Variant of [`radio_group`] that marks one option as the semantic "off"
+/// state (e.g. compression "off", audio "None"). The off row's `is_empty`
+/// flag is propagated to the review screen's collapsed Readonly row when
+/// it's the selected option, so it renders muted instead of green.
+fn radio_group_with_off(
+    key: &str,
+    label: &str,
+    options: &[&str],
+    selected: i32,
+    off_index: usize,
+) -> Vec<ConfigItem> {
+    radio_group_inner(key, label, options, selected, Some(off_index))
+}
+
+fn radio_group_inner(
+    key: &str,
+    label: &str,
+    options: &[&str],
+    selected: i32,
+    off_index: Option<usize>,
+) -> Vec<ConfigItem> {
     let mut items = vec![ConfigItem {
         label: label.into(),
         item_type: ItemType::RadioHeader,
@@ -592,6 +651,7 @@ fn radio_group(key: &str, label: &str, options: &[&str], selected: i32) -> Vec<C
                 SharedString::default()
             },
             item_type: ItemType::RadioOption,
+            is_empty: off_index == Some(i),
             ..Default::default()
         });
     }

--- a/slint-ui/ui/components/badge.slint
+++ b/slint-ui/ui/components/badge.slint
@@ -2,8 +2,8 @@ import { Theme } from "../styling.slint";
 
 export component Badge inherits Rectangle {
     in property <string> label;
-    in property <color> bg: Theme.c.blue;
-    in property <color> fg: Theme.c.base;
+    in property <brush> bg: Theme.c.blue;
+    in property <brush> fg: Theme.c.base;
 
     width: badge-text.preferred-width + 12px;
     height: 20px;

--- a/slint-ui/ui/components/check-box.slint
+++ b/slint-ui/ui/components/check-box.slint
@@ -39,7 +39,7 @@ export component CheckBox inherits Rectangle {
             box := Rectangle {
                 width: 16px;
                 height: 16px;
-                background: root.checked ? Theme.c.blue : #00000000;
+                background: root.checked ? Theme.c.blue : transparent;
                 border-color: root.checked ? Theme.c.blue : Theme.c.overlay0;
                 border-width: 1.5px;
                 border-radius: 3px;

--- a/slint-ui/ui/components/config-item.slint
+++ b/slint-ui/ui/components/config-item.slint
@@ -18,7 +18,7 @@
 // is-first-in-section / is-last-in-section flags come from
 // `mark_section_boundaries` in Rust's config_items.rs.
 
-import { Theme } from "../styling.slint";
+import { Theme, Palette } from "../styling.slint";
 import { ConfigItem, ItemType } from "../types.slint";
 import { RadioDot } from "radio-dot.slint";
 
@@ -87,15 +87,15 @@ export component ConfigItemRow inherits Rectangle {
     // Hover / focus highlight overlay (interactive rows only).
     if is-field && !is-readonly: Rectangle {
         visible: row-ta.has-hover || index == focused-index;
-        background: #ffffff10;
+        background: Palette.state-hovered;
         border-top-left-radius: item.is-first-in-section ? 8px : 0px;
         border-top-right-radius: item.is-first-in-section ? 8px : 0px;
         border-bottom-left-radius: item.is-last-in-section ? 8px : 0px;
         border-bottom-right-radius: item.is-last-in-section ? 8px : 0px;
     }
 
-    // ── Separator (just empty vertical space between sections) ──
-    if is-separator: Rectangle { }
+    // Separator rows render as empty space; the row's outer `height`
+    // already provides the gap, no element needed.
 
     // ── Section header (small uppercase label above the connected card) ──
     if is-section-header: HorizontalLayout {
@@ -151,6 +151,8 @@ export component ConfigItemRow inherits Rectangle {
             color: item.value == "selected" ? Theme.c.text : Theme.c.subtext0;
             font-size: 14px;
             vertical-alignment: center;
+            horizontal-stretch: 1;
+            overflow: elide;
         }
     }
 
@@ -161,7 +163,7 @@ export component ConfigItemRow inherits Rectangle {
 
         Rectangle {
             visible: row-ta.has-hover || index == focused-index;
-            background: #ffffff18;
+            background: Palette.state-hovered;
             border-radius: parent.border-radius;
         }
 
@@ -191,9 +193,7 @@ export component ConfigItemRow inherits Rectangle {
 
         Text {
             text: item.value;
-            color: item.value == "Not set" || item.value == "None" || item.value == "Disabled"
-                ? Theme.c.overlay0
-                : Theme.c.green;
+            color: item.is-empty ? Theme.c.overlay0 : Theme.c.green;
             font-size: 13px;
             vertical-alignment: center;
             horizontal-alignment: right;
@@ -236,9 +236,7 @@ export component ConfigItemRow inherits Rectangle {
 
             Text {
                 text: item.value;
-                color: item.value == "Not set" || item.value == "None" || item.value == "Disabled"
-                    ? Theme.c.overlay0
-                    : Theme.c.green;
+                color: item.is-empty ? Theme.c.overlay0 : Theme.c.green;
                 font-size: 14px;
                 vertical-alignment: center;
                 horizontal-alignment: right;

--- a/slint-ui/ui/components/progress-bar.slint
+++ b/slint-ui/ui/components/progress-bar.slint
@@ -4,7 +4,7 @@ export component ProgressBar inherits Rectangle {
     in property <int> value: 0;
     in property <int> max: 100;
     in property <length> bar-height: 6px;
-    in property <color> fill-color: Theme.c.blue;
+    in property <brush> fill-color: Theme.c.blue;
 
     height: root.bar-height;
     background: Theme.c.mantle;

--- a/slint-ui/ui/components/radio-dot.slint
+++ b/slint-ui/ui/components/radio-dot.slint
@@ -14,7 +14,7 @@
 
 export component RadioDot inherits Rectangle {
     in property <bool> filled;
-    in property <color> dot-color;
+    in property <brush> dot-color;
     in property <length> dot-size: 12px;
 
     width: 18px;
@@ -26,7 +26,7 @@ export component RadioDot inherits Rectangle {
         x: (parent.width - self.width) / 2;
         y: (parent.height - self.height) / 2;
         border-radius: self.width / 2;
-        background: root.filled ? root.dot-color : #00000000;
+        background: root.filled ? root.dot-color : transparent;
         border-width: root.filled ? 0px : 1.5px;
         border-color: root.dot-color;
     }

--- a/slint-ui/ui/components/sidebar-item.slint
+++ b/slint-ui/ui/components/sidebar-item.slint
@@ -10,7 +10,7 @@ export component SidebarItem inherits Rectangle {
     callback clicked <=> touch-area.clicked;
 
     height: 36px;
-    background: state == 1 ? Theme.c.surface0 : #00000000;
+    background: state == 1 ? Theme.c.surface0 : transparent;
     border-radius: Theme.radius-sm;
     forward-focus: touch-area;
     accessible-role: button;

--- a/slint-ui/ui/components/styled-text-input.slint
+++ b/slint-ui/ui/components/styled-text-input.slint
@@ -38,7 +38,7 @@ export component StyledTextInput inherits Rectangle {
         x: 8px;
         width: parent.width - 16px;
         text: (input.text == "" && input.preedit-text == "") ? root.placeholder : "";
-        color: Theme.c.overlay0;
+        color: Palette.placeholder-foreground;
         font-size: root.font-size;
         vertical-alignment: center;
         accessible-role: none;

--- a/slint-ui/ui/popups/multi-select-popup.slint
+++ b/slint-ui/ui/popups/multi-select-popup.slint
@@ -26,7 +26,10 @@ export component MultiSelectPopup inherits Rectangle {
         background: #00000080;
         width: 100%; height: 100%;
 
-        TouchArea { clicked => { closed(); } }
+        TouchArea {
+            clicked => { closed(); }
+            scroll-event(e) => { return accept; }
+        }
 
         Rectangle {
             x: (parent.width - self.width) / 2;

--- a/slint-ui/ui/popups/package-search-popup.slint
+++ b/slint-ui/ui/popups/package-search-popup.slint
@@ -22,7 +22,10 @@ export component PackageSearchPopup inherits Rectangle {
         background: #00000080;
         width: 100%; height: 100%;
 
-        TouchArea { clicked => { closed(); } }
+        TouchArea {
+            clicked => { closed(); }
+            scroll-event(e) => { return accept; }
+        }
 
         Rectangle {
             x: (parent.width - self.width) / 2;
@@ -147,7 +150,6 @@ export component PackageSearchPopup inherits Rectangle {
 
                 if root.selected-packages.length > 0: VerticalLayout {
                     spacing: Theme.spacing-xs;
-                    height: min(self.preferred-height, 100px);
 
                     Text {
                         text: "Selected";
@@ -157,39 +159,40 @@ export component PackageSearchPopup inherits Rectangle {
                         height: Theme.spacing-lg;
                     }
 
-                    Flickable {
-                        HorizontalLayout {
-                            spacing: Theme.spacing-xs + 2px;
-                            alignment: start;
+                    // Wrapping chip cloud — FlexboxLayout flows chips onto
+                    // multiple lines instead of a single overflowing row.
+                    chips-flow := FlexboxLayout {
+                        flex-direction: row;
+                        flex-wrap: wrap;
+                        spacing: Theme.spacing-xs + 2px;
 
-                            for pkg[index] in root.selected-packages: Rectangle {
-                                width: pkg-chip-layout.preferred-width;
-                                height: Theme.control-height-sm - 4px;
-                                background: pkg-del-ta.has-hover ? Theme.c.red : Theme.c.surface0;
-                                border-radius: Theme.radius-sm;
+                        for pkg[index] in root.selected-packages: Rectangle {
+                            width: pkg-chip-layout.preferred-width;
+                            height: Theme.control-height-sm - 4px;
+                            background: pkg-del-ta.has-hover ? Theme.c.red : Theme.c.surface0;
+                            border-radius: Theme.radius-sm;
 
-                                pkg-del-ta := TouchArea {
-                                    clicked => { root.package-removed(index); }
+                            pkg-del-ta := TouchArea {
+                                clicked => { root.package-removed(index); }
+                            }
+
+                            pkg-chip-layout := HorizontalLayout {
+                                padding-left: Theme.spacing-sm;
+                                padding-right: Theme.spacing-sm;
+                                spacing: Theme.spacing-xs;
+
+                                Text {
+                                    text: pkg.name;
+                                    color: pkg-del-ta.has-hover ? Theme.c.base : Theme.c.text;
+                                    font-size: Theme.font-sm;
+                                    vertical-alignment: center;
                                 }
 
-                                pkg-chip-layout := HorizontalLayout {
-                                    padding-left: Theme.spacing-sm;
-                                    padding-right: Theme.spacing-sm;
-                                    spacing: Theme.spacing-xs;
-
-                                    Text {
-                                        text: pkg.name;
-                                        color: pkg-del-ta.has-hover ? Theme.c.base : Theme.c.text;
-                                        font-size: Theme.font-sm;
-                                        vertical-alignment: center;
-                                    }
-
-                                    Text {
-                                        text: pkg.repo == "aur" ? "[aur]" : "[repo]";
-                                        color: pkg-del-ta.has-hover ? Theme.c.base : Theme.c.overlay0;
-                                        font-size: 10px;
-                                        vertical-alignment: center;
-                                    }
+                                Text {
+                                    text: pkg.repo == "aur" ? "[aur]" : "[repo]";
+                                    color: pkg-del-ta.has-hover ? Theme.c.base : Theme.c.overlay0;
+                                    font-size: 10px;
+                                    vertical-alignment: center;
                                 }
                             }
                         }

--- a/slint-ui/ui/popups/select-popup.slint
+++ b/slint-ui/ui/popups/select-popup.slint
@@ -12,7 +12,7 @@ export component SelectPopup inherits Rectangle {
     // the initial one driven directly by `selected-index`. Earlier
     // versions had an `out property result-index: selected-index;` that
     // got broken by the first click and then leaked across re-opens.
-    in property <int> selected-index;
+    in-out property <int> selected-index;
     in property <bool> popup-visible;
     in property <bool> show-filter: false;
 
@@ -27,6 +27,41 @@ export component SelectPopup inherits Rectangle {
         TouchArea {
             clicked => { closed(); }
             scroll-event(e) => { return accept; }
+        }
+
+        // Keyboard navigation for the option list. Arrow / j / k move
+        // selected-index; Enter accepts; Esc closes. When the filter is
+        // visible the input itself owns text-typing keys, so we only
+        // intercept the navigation set.
+        focus-scope := FocusScope {
+            key-pressed(ev) => {
+                if ev.text == Key.Escape {
+                    root.closed();
+                    return accept;
+                }
+                if ev.text == Key.Return {
+                    if root.selected-index >= 0
+                        && root.selected-index < root.options.length {
+                        root.accepted(root.selected-index);
+                    }
+                    return accept;
+                }
+                if ev.text == Key.DownArrow {
+                    if root.options.length > 0 {
+                        root.selected-index = min(
+                            root.options.length - 1,
+                            max(0, root.selected-index) + 1);
+                    }
+                    return accept;
+                }
+                if ev.text == Key.UpArrow {
+                    if root.selected-index > 0 {
+                        root.selected-index = root.selected-index - 1;
+                    }
+                    return accept;
+                }
+                return reject;
+            }
         }
 
         Rectangle {
@@ -54,16 +89,22 @@ export component SelectPopup inherits Rectangle {
                     height: Theme.spacing-xl;
                 }
 
-                if root.show-filter: StyledTextInput {
+                // Focus the filter input on open if present so the user
+                // can type straight away. The `init` lives on the input
+                // itself because ids inside `if`-conditional elements
+                // aren't reachable from outer-scope handlers.
+                if root.show-filter: filter-input := StyledTextInput {
                     height: Theme.control-height-sm;
                     border-color: Theme.c.blue;
                     edited(text) => { root.filter-changed(text); }
+                    init => { filter-input.focus-input(); }
                 }
 
-                init => {
-                    if root.show-filter {
-                        // Focus handled by StyledTextInput auto-focus on creation
-                    }
+                // No filter → grab the FocusScope so arrow / Enter
+                // navigation is live without an extra click.
+                if !root.show-filter: Rectangle {
+                    height: 0px;
+                    init => { focus-scope.focus(); }
                 }
 
                 ListView {

--- a/slint-ui/ui/popups/string-list-popup.slint
+++ b/slint-ui/ui/popups/string-list-popup.slint
@@ -38,7 +38,10 @@ export component StringListPopup inherits Rectangle {
         background: #00000080;
         width: 100%; height: 100%;
 
-        TouchArea { clicked => { closed(); } }
+        TouchArea {
+            clicked => { closed(); }
+            scroll-event(e) => { return accept; }
+        }
 
         Rectangle {
             x: (parent.width - self.width) / 2;

--- a/slint-ui/ui/popups/text-input-popup.slint
+++ b/slint-ui/ui/popups/text-input-popup.slint
@@ -11,7 +11,7 @@ export component TextInputPopup inherits Rectangle {
     in property <int> strength-score: -1;
     in property <string> strength-label;
     in property <string> strength-hint;
-    in property <color> strength-color: Theme.c.overlay0;
+    in property <brush> strength-color: Theme.c.overlay0;
 
     callback confirmed(string);
     callback closed();
@@ -21,7 +21,10 @@ export component TextInputPopup inherits Rectangle {
         background: #00000080;
         width: 100%; height: 100%;
 
-        TouchArea { clicked => { closed(); } }
+        TouchArea {
+            clicked => { closed(); }
+            scroll-event(e) => { return accept; }
+        }
 
         Rectangle {
             x: (parent.width - self.width) / 2;

--- a/slint-ui/ui/popups/user-manage-popup.slint
+++ b/slint-ui/ui/popups/user-manage-popup.slint
@@ -26,7 +26,10 @@ export component UserManagePopup inherits Rectangle {
         background: #00000080;
         width: 100%; height: 100%;
 
-        TouchArea { clicked => { closed(); } }
+        TouchArea {
+            clicked => { closed(); }
+            scroll-event(e) => { return accept; }
+        }
 
         Rectangle {
             x: (parent.width - self.width) / 2;

--- a/slint-ui/ui/popups/wifi-popup.slint
+++ b/slint-ui/ui/popups/wifi-popup.slint
@@ -40,23 +40,21 @@ import { SignalBars } from "../components/signal-bars.slint";
 export component WifiPopup inherits Rectangle {
     in property <bool> popup-visible;
 
-    visible: popup-visible;
-    background: #000000c0;
+    if popup-visible: Rectangle {
+        background: #000000c0;
+        width: 100%;
+        height: 100%;
 
-    // Grab keyboard focus every time the popup becomes visible, so
-    // arrow/Enter/Esc work immediately without the user clicking
-    // anywhere first. `changed popup-visible` fires on every flip,
-    // unlike `init` which runs only once.
-    changed popup-visible => {
-        if popup-visible {
-            focus-scope.focus();
+        // Dismiss-on-outside-click + scroll-swallow so wheel events
+        // don't leak into the wizard underneath.
+        TouchArea {
+            clicked => { WifiState.close(); }
+            scroll-event(e) => { return accept; }
         }
-    }
 
-    // Dismiss-on-outside-click.
-    TouchArea {
-        clicked => { WifiState.close(); }
-    }
+        // Grab keyboard focus on each open; the `if` subtree is created
+        // fresh every time so this fires once per show.
+        init => { focus-scope.focus(); }
 
     // Wifi-popup-local keyboard navigation:
     //
@@ -68,12 +66,9 @@ export component WifiPopup inherits Rectangle {
     //                    already handles it so we don't double-fire)
     //   r              → rescan (picking phase only)
     //
-    // Enabled only while the popup itself is visible; the App-root
-    // FocusScope is already gated !PopupState.wifi-visible so the
-    // two can never fight.
+    // The whole subtree is gated by `if popup-visible:` above, so this
+    // scope only exists while the popup is open — no enabled gate needed.
     focus-scope := FocusScope {
-        enabled: popup-visible;
-
         key-pressed(ev) => {
             if ev.text == Key.Escape {
                 if WifiState.phase == WifiPhase.auth {
@@ -237,6 +232,9 @@ export component WifiPopup inherits Rectangle {
                         source: @image-url("../../assets/icons/refresh-cw.svg");
                         size: 28px;
                         tint: Theme.c.blue;
+                        // Drives the rotation off `animation-tick()` so the
+                        // icon spins continuously while this branch is live.
+                        transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
                     }
 
                     Text {
@@ -506,6 +504,7 @@ export component WifiPopup inherits Rectangle {
                         source: @image-url("../../assets/icons/refresh-cw.svg");
                         size: 28px;
                         tint: Theme.c.blue;
+                        transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
                     }
 
                     Text {
@@ -610,5 +609,6 @@ export component WifiPopup inherits Rectangle {
                 }
             }
         }
+    }
     }
 }

--- a/slint-ui/ui/styling.slint
+++ b/slint-ui/ui/styling.slint
@@ -266,6 +266,8 @@ export global Theme {
         foreground: Palette.destructive-foreground,
     };
     out property <ButtonStyle> button-ghost: {
+        // `transparent` keyword isn't accepted inside struct literals,
+        // so use the hex form for the fully-transparent fill.
         background: #00000000,
         foreground: Catppuccin.current.subtext_0,
     };

--- a/slint-ui/ui/types.slint
+++ b/slint-ui/ui/types.slint
@@ -33,6 +33,11 @@ export struct ConfigItem {
     // next item in the list is a SectionHeader, Separator, or end of list).
     // Used to round bottom corners and skip the trailing hairline divider.
     is-last-in-section: bool,
+    // True when `value` represents an unset / off / none state and should
+    // be rendered in muted color. Set by the Rust builder; replaces the
+    // older "Not set" / "None" / "Disabled" string matching that broke as
+    // soon as Rust localized or reworded those sentinels.
+    is-empty: bool,
 }
 
 export struct SelectOption {

--- a/slint-ui/ui/views/install-view.slint
+++ b/slint-ui/ui/views/install-view.slint
@@ -34,9 +34,13 @@ export component InstallView inherits VerticalLayout {
         }
     }
 
+    // Auto-pin to the bottom whenever a new log line lands. Computed from
+    // the live viewport height so it stays correct when the log overflows
+    // the visible area; clamped to 0 so a short log doesn't push above
+    // the top.
     property <int> scroll-trigger: InstallState.log-messages.length;
     changed scroll-trigger => {
-        log-view.viewport-y = -100000px;
+        log-view.viewport-y = -max(0px, log-view.viewport-height - log-view.height);
     }
 
     // Progress card (always visible during install)

--- a/slint-ui/ui/views/welcome-view.slint
+++ b/slint-ui/ui/views/welcome-view.slint
@@ -218,6 +218,12 @@ export component WelcomeView inherits Rectangle {
                                     font-size: 18px;
                                     vertical-alignment: center;
                                     width: 24px;
+                                    // Spin only while installing; the
+                                    // ↻ glyph is set by the `installing`
+                                    // state below.
+                                    transform-rotation: WelcomeState.zfs-installing
+                                        ? 360deg * mod(animation-tick(), 1.2s) / 1.2s
+                                        : 0deg;
                                 }
 
                                 Text {


### PR DESCRIPTION
## Summary

Polishes the Slint wizard UI and popup behavior after the device-selection abstraction landed.

- replaces sentinel string matching with explicit empty-state metadata for config rows
- improves popup keyboard navigation, scroll handling, and package chip wrapping
- adds small visual polish for state indicators, install log scrolling, and long radio labels

## Validation

- `SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 slint-viewer --check slint-ui/ui/app.slint`
- `cargo check -p archinstall-zfs-slint`
- `cargo fmt --all --check`
- MCP smoke test against `SLINT_MCP_PORT=9315`: initialize, list tools/windows, get element tree, screenshot, click Get Started, dispatch keyboard event

## Notes

The MCP smoke test also caught a long disk radio label clipping issue on the Disk step; this PR includes the elide fix for radio-option labels.