### PR TITLE
[codex] Improve Slint device choice rows

### DIFF
--- a/core/src/disk/device.rs
+++ b/core/src/disk/device.rs
@@ -43,6 +43,7 @@ pub struct BlockPartition {
 pub struct DeviceChoice {
     pub path: PathBuf,
     pub label: String,
+    pub description: String,
 }
 
 impl BlockDevice {
@@ -52,6 +53,34 @@ impl BlockDevice {
 
     pub fn selection_label(&self) -> String {
         let mut parts = vec![self.devnode.display().to_string()];
+
+        if let Some(model) = self.model.as_deref() {
+            parts.push(model.to_string());
+        }
+        if let Some(size) = self.size_bytes {
+            parts.push(format_size(size));
+        }
+        if let Some(transport) = self.transport.as_deref() {
+            parts.push(transport.to_string());
+        }
+        if self.removable {
+            parts.push("removable".to_string());
+        }
+
+        let preferred = self.preferred_path();
+        if preferred.path != self.devnode {
+            parts.push(format!("using {}", preferred.path.display()));
+        }
+
+        parts.join(" | ")
+    }
+
+    pub fn selection_title(&self) -> String {
+        self.devnode.display().to_string()
+    }
+
+    pub fn selection_description(&self) -> String {
+        let mut parts = Vec::new();
 
         if let Some(model) = self.model.as_deref() {
             parts.push(model.to_string());
@@ -94,6 +123,25 @@ impl BlockPartition {
 
         parts.join(" | ")
     }
+
+    pub fn selection_title(&self) -> String {
+        self.devnode.display().to_string()
+    }
+
+    pub fn selection_description(&self) -> String {
+        let mut parts = Vec::new();
+
+        if let Some(size) = self.size_bytes {
+            parts.push(format_size(size));
+        }
+
+        let preferred = self.preferred_path();
+        if preferred.path != self.devnode {
+            parts.push(format!("using {}", preferred.path.display()));
+        }
+
+        parts.join(" | ")
+    }
 }
 
 pub fn disk_choices() -> Result<Vec<DeviceChoice>> {
@@ -101,7 +149,8 @@ pub fn disk_choices() -> Result<Vec<DeviceChoice>> {
         .into_iter()
         .map(|device| DeviceChoice {
             path: device.preferred_path().path,
-            label: device.selection_label(),
+            label: device.selection_title(),
+            description: device.selection_description(),
         })
         .collect())
 }
@@ -111,7 +160,8 @@ pub fn partition_choices() -> Result<Vec<DeviceChoice>> {
         .into_iter()
         .map(|partition| DeviceChoice {
             path: partition.preferred_path().path,
-            label: partition.selection_label(),
+            label: partition.selection_title(),
+            description: partition.selection_description(),
         })
         .collect())
 }
@@ -472,6 +522,11 @@ mod tests {
             device.selection_label(),
             "/dev/vda | VirtIO Block Device | 64 GiB | virtio | using /dev/disk/by-path/pci-0000:00:04.0"
         );
+        assert_eq!(device.selection_title(), "/dev/vda");
+        assert_eq!(
+            device.selection_description(),
+            "VirtIO Block Device | 64 GiB | virtio | using /dev/disk/by-path/pci-0000:00:04.0"
+        );
     }
 
     #[test]
@@ -498,6 +553,11 @@ mod tests {
         assert_eq!(
             partition.selection_label(),
             "/dev/vda1 | 512 MiB | using /dev/disk/by-id/virtio-test-disk-part1"
+        );
+        assert_eq!(partition.selection_title(), "/dev/vda1");
+        assert_eq!(
+            partition.selection_description(),
+            "512 MiB | using /dev/disk/by-id/virtio-test-disk-part1"
         );
     }
 }

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -2,6 +2,7 @@
 //! coming back from radio/select/text widgets to the canonical `GlobalConfig`.
 
 use slint::SharedString;
+use std::path::PathBuf;
 
 use archinstall_zfs_core::config::types::{
     AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
@@ -15,6 +16,13 @@ pub const TOTAL_STEPS: usize = 7;
 pub const STEP_LABELS: [&str; TOTAL_STEPS] = [
     "Welcome", "Disk", "ZFS", "System", "Users", "Desktop", "Review",
 ];
+
+#[derive(Debug, Clone)]
+struct ChoiceRow {
+    path: PathBuf,
+    label: String,
+    description: String,
+}
 
 // ── Per-step item building ──────────────────────────
 
@@ -55,15 +63,13 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 
     if matches!(mode, Some(InstallationMode::FullDisk) | None) {
         let disks = disk_choices();
-        let disk_strs: Vec<String> = disks.iter().map(|(_, label)| label.clone()).collect();
-        let disk_refs: Vec<&str> = disk_strs.iter().map(|s| s.as_str()).collect();
         let selected = c
             .disk
             .as_ref()
-            .and_then(|sel| disks.iter().position(|(path, _)| path == sel))
+            .and_then(|sel| disks.iter().position(|choice| &choice.path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
-        items.extend(radio_group("disk", "Disk", &disk_refs, selected));
+        items.extend(radio_choice_group("disk", "Disk", &disks, selected));
     }
 
     if matches!(
@@ -71,19 +77,17 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         Some(InstallationMode::NewPool) | Some(InstallationMode::ExistingPool)
     ) {
         let parts = partition_choices();
-        let part_strs: Vec<String> = parts.iter().map(|(_, label)| label.clone()).collect();
-        let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
 
         let efi_selected = c
             .efi_partition
             .as_ref()
-            .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
+            .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
-        items.extend(radio_group(
+        items.extend(radio_choice_group(
             "efi_partition",
             "EFI partition",
-            &part_refs,
+            &parts,
             efi_selected,
         ));
 
@@ -91,13 +95,13 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             let zfs_selected = c
                 .zfs_partition
                 .as_ref()
-                .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
+                .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
                 .map(|i| i as i32)
                 .unwrap_or(-1);
-            items.extend(radio_group(
+            items.extend(radio_choice_group(
                 "zfs_partition",
                 "ZFS partition",
-                &part_refs,
+                &parts,
                 zfs_selected,
             ));
         }
@@ -195,18 +199,16 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     }
     if !matches!(mode, Some(InstallationMode::FullDisk) | None) && has_swap_partition {
         let parts = partition_choices();
-        let part_strs: Vec<String> = parts.iter().map(|(_, label)| label.clone()).collect();
-        let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
         let swap_selected = c
             .swap_partition
             .as_ref()
-            .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
+            .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
-        items.extend(radio_group(
+        items.extend(radio_choice_group(
             "swap_partition",
             "Swap partition",
-            &part_refs,
+            &parts,
             swap_selected,
         ));
     }
@@ -658,6 +660,34 @@ fn radio_group_inner(
     items
 }
 
+fn radio_choice_group(
+    key: &str,
+    label: &str,
+    options: &[ChoiceRow],
+    selected: i32,
+) -> Vec<ConfigItem> {
+    let mut items = vec![ConfigItem {
+        label: label.into(),
+        item_type: ItemType::RadioHeader,
+        ..Default::default()
+    }];
+    for (i, option) in options.iter().enumerate() {
+        items.push(ConfigItem {
+            key: format!("radio:{key}:{i}").into(),
+            label: option.label.as_str().into(),
+            description: option.description.as_str().into(),
+            value: if i as i32 == selected {
+                "selected".into()
+            } else {
+                SharedString::default()
+            },
+            item_type: ItemType::RadioOption,
+            ..Default::default()
+        });
+    }
+    items
+}
+
 // ── Section boundary marking ────────────────────────
 
 /// Walk a list of items after it's built and set `is_first_in_section` /
@@ -739,26 +769,26 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
         }
         "disk" => {
             let disks = disk_choices();
-            if let Some((path, _)) = disks.get(idx as usize) {
-                config.disk = Some(path.clone());
+            if let Some(choice) = disks.get(idx as usize) {
+                config.disk = Some(choice.path.clone());
             }
         }
         "efi_partition" => {
             let parts = partition_choices();
-            if let Some((path, _)) = parts.get(idx as usize) {
-                config.efi_partition = Some(path.clone());
+            if let Some(choice) = parts.get(idx as usize) {
+                config.efi_partition = Some(choice.path.clone());
             }
         }
         "zfs_partition" => {
             let parts = partition_choices();
-            if let Some((path, _)) = parts.get(idx as usize) {
-                config.zfs_partition = Some(path.clone());
+            if let Some(choice) = parts.get(idx as usize) {
+                config.zfs_partition = Some(choice.path.clone());
             }
         }
         "swap_partition" => {
             let parts = partition_choices();
-            if let Some((path, _)) = parts.get(idx as usize) {
-                config.swap_partition = Some(path.clone());
+            if let Some(choice) = parts.get(idx as usize) {
+                config.swap_partition = Some(choice.path.clone());
             }
         }
         "compression" => {
@@ -824,12 +854,16 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
     }
 }
 
-fn disk_choices() -> Vec<(std::path::PathBuf, String)> {
+fn disk_choices() -> Vec<ChoiceRow> {
     archinstall_zfs_core::disk::device::disk_choices()
         .map(|choices| {
             choices
                 .into_iter()
-                .map(|choice| (choice.path, choice.label))
+                .map(|choice| ChoiceRow {
+                    path: choice.path,
+                    label: choice.label,
+                    description: choice.description,
+                })
                 .collect()
         })
         .unwrap_or_else(|_| {
@@ -838,18 +872,26 @@ fn disk_choices() -> Vec<(std::path::PathBuf, String)> {
                 .into_iter()
                 .map(|path| {
                     let label = path.display().to_string();
-                    (path, label)
+                    ChoiceRow {
+                        path,
+                        label,
+                        description: String::new(),
+                    }
                 })
                 .collect()
         })
 }
 
-fn partition_choices() -> Vec<(std::path::PathBuf, String)> {
+fn partition_choices() -> Vec<ChoiceRow> {
     archinstall_zfs_core::disk::device::partition_choices()
         .map(|choices| {
             choices
                 .into_iter()
-                .map(|choice| (choice.path, choice.label))
+                .map(|choice| ChoiceRow {
+                    path: choice.path,
+                    label: choice.label,
+                    description: choice.description,
+                })
                 .collect()
         })
         .unwrap_or_else(|_| {
@@ -858,7 +900,11 @@ fn partition_choices() -> Vec<(std::path::PathBuf, String)> {
                 .into_iter()
                 .map(|path| {
                     let label = path.display().to_string();
-                    (path, label)
+                    ChoiceRow {
+                        path,
+                        label,
+                        description: String::new(),
+                    }
                 })
                 .collect()
         })

--- a/slint-ui/ui/components/config-item.slint
+++ b/slint-ui/ui/components/config-item.slint
@@ -56,7 +56,7 @@ export component ConfigItemRow inherits Rectangle {
     height: is-separator ? 8px
           : is-warning ? 32px
           : is-section-header ? 36px
-          : is-radio-option ? 36px
+          : is-radio-option ? (item.description == "" ? 36px : 52px)
           : is-action ? 40px
           : 44px;
 
@@ -146,13 +146,28 @@ export component ConfigItemRow inherits Rectangle {
             dot-color: item.value == "selected" ? Theme.c.green : Theme.c.overlay0;
         }
 
-        Text {
-            text: item.label;
-            color: item.value == "selected" ? Theme.c.text : Theme.c.subtext0;
-            font-size: 14px;
-            vertical-alignment: center;
+        VerticalLayout {
             horizontal-stretch: 1;
-            overflow: elide;
+            alignment: center;
+            spacing: 1px;
+
+            Text {
+                text: item.label;
+                color: item.value == "selected" ? Theme.c.text : Theme.c.subtext0;
+                font-size: 14px;
+                vertical-alignment: item.description == "" ? center : bottom;
+                horizontal-stretch: 1;
+                overflow: elide;
+            }
+
+            if item.description != "": Text {
+                text: item.description;
+                color: Theme.c.overlay0;
+                font-size: 12px;
+                vertical-alignment: top;
+                horizontal-stretch: 1;
+                overflow: elide;
+            }
         }
     }
 

--- a/slint-ui/ui/types.slint
+++ b/slint-ui/ui/types.slint
@@ -24,6 +24,7 @@ export struct ConfigItem {
     key: string,
     label: string,
     value: string,
+    description: string,
     item-type: ItemType,
     // True if this row is the first field row inside its section (i.e. the
     // previous item in the list is a SectionHeader). Used by ConfigItemRow
@@ -128,4 +129,3 @@ export struct WifiNetworkUi {
     // and shows a "Known" badge.
     known: bool,
 }
-

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -84,7 +84,10 @@ fn disk_choices() -> Result<Vec<(PathBuf, String)>> {
     match archinstall_zfs_core::disk::device::disk_choices() {
         Ok(choices) => Ok(choices
             .into_iter()
-            .map(|choice| (choice.path, choice.label))
+            .map(|choice| {
+                let label = choice_label(&choice.label, &choice.description);
+                (choice.path, label)
+            })
             .collect()),
         Err(_) => Ok(archinstall_zfs_core::disk::by_id::list_disks_by_id()?
             .into_iter()
@@ -104,7 +107,10 @@ pub fn pick_partition(
     if parts.is_empty() {
         return Ok(None);
     }
-    let part_strs: Vec<String> = parts.iter().map(|part| part.label.clone()).collect();
+    let part_strs: Vec<String> = parts
+        .iter()
+        .map(|part| choice_label(&part.label, &part.description))
+        .collect();
     let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
     let result = run_select(terminal, title, &part_refs, 0)?;
     match result.selected {
@@ -120,9 +126,18 @@ fn partition_choices() -> Result<Vec<archinstall_zfs_core::disk::device::DeviceC
             .into_iter()
             .map(|path| archinstall_zfs_core::disk::device::DeviceChoice {
                 label: path.display().to_string(),
+                description: String::new(),
                 path,
             })
             .collect()),
+    }
+}
+
+fn choice_label(label: &str, description: &str) -> String {
+    if description.is_empty() {
+        label.to_string()
+    } else {
+        format!("{label} | {description}")
     }
 }
 


### PR DESCRIPTION
## Summary

Improves how disk and partition choices are represented in the Slint wizard.

- splits device choices into a compact primary label plus secondary description
- renders radio options with descriptions as taller two-line rows
- keeps TUI pickers on the old one-line combined label so they retain device details
- adds tests for the new device title/description helpers

## Validation

- `cargo fmt --all --check`
- `cargo test -p archinstall-zfs-core disk::device`
- `cargo check -p archinstall-zfs-tui`
- `cargo check -p archinstall-zfs-slint`
- `SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 slint-viewer --check slint-ui/ui/app.slint`
- MCP smoke with `SLINT_MCP_PORT=9315`: clicked through Welcome to Disk step and verified the new two-line disk row screenshot

## Notes

This keeps the persistent by-id/by-path selection policy unchanged; only the UI display model changes.