### PR TITLE
[codex] Improve Slint device choice rows

### DIFF
--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -572,9 +572,11 @@ mod tests {
 
     #[test]
     fn test_all_aur_packages_with_zrepl() {
-        let mut cfg = GlobalConfig::default();
-        cfg.aur_packages = vec!["custom-pkg".to_string()];
-        cfg.zrepl_enabled = true;
+        let cfg = GlobalConfig {
+            aur_packages: vec!["custom-pkg".to_string()],
+            zrepl_enabled: true,
+            ..Default::default()
+        };
 
         let pkgs = cfg.all_aur_packages();
         assert!(pkgs.contains(&"custom-pkg"));

--- a/core/src/disk/device.rs
+++ b/core/src/disk/device.rs
@@ -36,13 +36,125 @@ pub struct BlockDevice {
 pub struct BlockPartition {
     pub devnode: PathBuf,
     pub aliases: Vec<DevicePath>,
+    pub parent_devnode: Option<PathBuf>,
+    pub model: Option<String>,
+    pub serial: Option<String>,
     pub size_bytes: Option<u64>,
+    pub parent_size_bytes: Option<u64>,
+    pub transport: Option<String>,
+    pub rotational: Option<bool>,
+    pub removable: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeviceChoice {
     pub path: PathBuf,
     pub label: String,
+    pub icon: String,
+    pub model: String,
+    pub serial: String,
+    pub size: String,
+    pub transport: String,
+    pub media: String,
+    pub removable: bool,
+    pub persistent_path: String,
+    pub persistent_kind: String,
+    pub group_label: String,
+    pub group_model: String,
+    pub group_serial: String,
+    pub group_size: String,
+    pub group_transport: String,
+    pub group_media: String,
+    pub group_removable: bool,
+}
+
+impl DeviceChoice {
+    pub fn detail_summary(&self) -> String {
+        let mut parts = Vec::new();
+
+        if !self.model.is_empty() {
+            parts.push(self.model.clone());
+        }
+        if !self.serial.is_empty() {
+            parts.push(format!("SN {}", self.serial));
+        }
+        if !self.size.is_empty() {
+            parts.push(self.size.clone());
+        }
+        if !self.media.is_empty() {
+            parts.push(self.media.clone());
+        }
+        if !self.transport.is_empty() {
+            parts.push(self.transport.clone());
+        }
+        if self.removable {
+            parts.push("removable".to_string());
+        }
+        if !self.persistent_path.is_empty() {
+            parts.push(format!("using {}", self.persistent_path));
+        }
+
+        parts.join(" | ")
+    }
+
+    pub fn display_label(&self) -> String {
+        let detail_summary = self.detail_summary();
+        if detail_summary.is_empty() {
+            self.label.clone()
+        } else {
+            format!("{} | {}", self.label, detail_summary)
+        }
+    }
+}
+
+impl From<BlockDevice> for DeviceChoice {
+    fn from(device: BlockDevice) -> Self {
+        Self {
+            path: device.preferred_path().path,
+            label: device.selection_title(),
+            icon: device.selection_icon().to_string(),
+            model: device.selection_model(),
+            serial: device.selection_serial(),
+            size: device.selection_size(),
+            transport: device.selection_transport(),
+            media: device.selection_media(),
+            removable: device.removable,
+            persistent_path: device.selection_persistent_path(),
+            persistent_kind: device.selection_persistent_kind(),
+            group_label: String::new(),
+            group_model: String::new(),
+            group_serial: String::new(),
+            group_size: String::new(),
+            group_transport: String::new(),
+            group_media: String::new(),
+            group_removable: false,
+        }
+    }
+}
+
+impl From<BlockPartition> for DeviceChoice {
+    fn from(partition: BlockPartition) -> Self {
+        Self {
+            path: partition.preferred_path().path,
+            label: partition.selection_title(),
+            icon: partition.selection_icon().to_string(),
+            model: partition.selection_model(),
+            serial: partition.selection_serial(),
+            size: partition.selection_size(),
+            transport: partition.selection_transport(),
+            media: partition.selection_media(),
+            removable: partition.removable,
+            persistent_path: partition.selection_persistent_path(),
+            persistent_kind: partition.selection_persistent_kind(),
+            group_label: partition.selection_group_label(),
+            group_model: partition.selection_group_model(),
+            group_serial: partition.selection_group_serial(),
+            group_size: partition.selection_group_size(),
+            group_transport: partition.selection_group_transport(),
+            group_media: partition.selection_group_media(),
+            group_removable: partition.removable,
+        }
+    }
 }
 
 impl BlockDevice {
@@ -50,28 +162,49 @@ impl BlockDevice {
         preferred_path_for(&self.aliases, &self.devnode)
     }
 
-    pub fn selection_label(&self) -> String {
-        let mut parts = vec![self.devnode.display().to_string()];
+    pub fn selection_title(&self) -> String {
+        self.devnode.display().to_string()
+    }
 
-        if let Some(model) = self.model.as_deref() {
-            parts.push(model.to_string());
-        }
-        if let Some(size) = self.size_bytes {
-            parts.push(format_size(size));
-        }
-        if let Some(transport) = self.transport.as_deref() {
-            parts.push(transport.to_string());
-        }
-        if self.removable {
-            parts.push("removable".to_string());
-        }
+    pub fn selection_model(&self) -> String {
+        self.model.clone().unwrap_or_default()
+    }
 
-        let preferred = self.preferred_path();
-        if preferred.path != self.devnode {
-            parts.push(format!("using {}", preferred.path.display()));
-        }
+    pub fn selection_serial(&self) -> String {
+        self.serial.clone().unwrap_or_default()
+    }
 
-        parts.join(" | ")
+    pub fn selection_size(&self) -> String {
+        self.size_bytes.map(format_size).unwrap_or_default()
+    }
+
+    pub fn selection_transport(&self) -> String {
+        self.transport.clone().unwrap_or_default()
+    }
+
+    pub fn selection_media(&self) -> String {
+        media_label(self.rotational)
+    }
+
+    pub fn selection_icon(&self) -> &'static str {
+        if self.removable
+            || self
+                .transport
+                .as_deref()
+                .is_some_and(|transport| transport.eq_ignore_ascii_case("usb"))
+        {
+            "usb"
+        } else {
+            "hard-drive"
+        }
+    }
+
+    pub fn selection_persistent_path(&self) -> String {
+        persistent_path_label(&self.preferred_path(), &self.devnode)
+    }
+
+    pub fn selection_persistent_kind(&self) -> String {
+        persistent_kind_label(&self.preferred_path(), &self.devnode)
     }
 }
 
@@ -80,39 +213,81 @@ impl BlockPartition {
         preferred_path_for(&self.aliases, &self.devnode)
     }
 
-    pub fn selection_label(&self) -> String {
-        let mut parts = vec![self.devnode.display().to_string()];
+    pub fn selection_title(&self) -> String {
+        self.devnode.display().to_string()
+    }
 
-        if let Some(size) = self.size_bytes {
-            parts.push(format_size(size));
-        }
+    pub fn selection_group_label(&self) -> String {
+        self.parent_devnode
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_default()
+    }
 
-        let preferred = self.preferred_path();
-        if preferred.path != self.devnode {
-            parts.push(format!("using {}", preferred.path.display()));
-        }
+    pub fn selection_group_model(&self) -> String {
+        self.selection_model()
+    }
 
-        parts.join(" | ")
+    pub fn selection_group_serial(&self) -> String {
+        self.selection_serial()
+    }
+
+    pub fn selection_group_size(&self) -> String {
+        self.parent_size_bytes.map(format_size).unwrap_or_default()
+    }
+
+    pub fn selection_group_transport(&self) -> String {
+        self.selection_transport()
+    }
+
+    pub fn selection_group_media(&self) -> String {
+        self.selection_media()
+    }
+
+    pub fn selection_model(&self) -> String {
+        self.model.clone().unwrap_or_default()
+    }
+
+    pub fn selection_serial(&self) -> String {
+        self.serial.clone().unwrap_or_default()
+    }
+
+    pub fn selection_size(&self) -> String {
+        self.size_bytes.map(format_size).unwrap_or_default()
+    }
+
+    pub fn selection_transport(&self) -> String {
+        self.transport.clone().unwrap_or_default()
+    }
+
+    pub fn selection_media(&self) -> String {
+        media_label(self.rotational)
+    }
+
+    pub fn selection_icon(&self) -> &'static str {
+        "hard-drive"
+    }
+
+    pub fn selection_persistent_path(&self) -> String {
+        persistent_path_label(&self.preferred_path(), &self.devnode)
+    }
+
+    pub fn selection_persistent_kind(&self) -> String {
+        persistent_kind_label(&self.preferred_path(), &self.devnode)
     }
 }
 
 pub fn disk_choices() -> Result<Vec<DeviceChoice>> {
     Ok(list_block_devices()?
         .into_iter()
-        .map(|device| DeviceChoice {
-            path: device.preferred_path().path,
-            label: device.selection_label(),
-        })
+        .map(DeviceChoice::from)
         .collect())
 }
 
 pub fn partition_choices() -> Result<Vec<DeviceChoice>> {
     Ok(list_block_partitions()?
         .into_iter()
-        .map(|partition| DeviceChoice {
-            path: partition.preferred_path().path,
-            label: partition.selection_label(),
-        })
+        .map(DeviceChoice::from)
         .collect())
 }
 
@@ -136,6 +311,17 @@ struct LsblkDevice {
     children: Vec<LsblkDevice>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct ParentDiskDetails {
+    devnode: PathBuf,
+    model: Option<String>,
+    serial: Option<String>,
+    size_bytes: Option<u64>,
+    transport: Option<String>,
+    rotational: Option<bool>,
+    removable: bool,
+}
+
 pub fn list_block_devices() -> Result<Vec<BlockDevice>> {
     let (parsed, aliases) = inspect_block_devices()?;
 
@@ -151,9 +337,16 @@ pub fn list_block_devices() -> Result<Vec<BlockDevice>> {
 pub fn list_block_partitions() -> Result<Vec<BlockPartition>> {
     let (parsed, aliases) = inspect_block_devices()?;
 
+    let parent_details_by_devnode = collect_parent_disk_details(&parsed.blockdevices);
     let mut partitions = Vec::new();
     for node in parsed.blockdevices {
-        collect_lsblk_partitions(node, &aliases, &mut partitions);
+        collect_lsblk_partitions(
+            node,
+            &aliases,
+            &parent_details_by_devnode,
+            &mut partitions,
+            None,
+        );
     }
 
     partitions.sort_by(|a, b| a.devnode.cmp(&b.devnode));
@@ -217,24 +410,90 @@ fn collect_lsblk_disks(
 fn collect_lsblk_partitions(
     node: LsblkDevice,
     aliases: &HashMap<PathBuf, Vec<DevicePath>>,
+    parent_details_by_devnode: &HashMap<PathBuf, ParentDiskDetails>,
     partitions: &mut Vec<BlockPartition>,
+    parent_details: Option<ParentDiskDetails>,
 ) {
+    let current_details = if node.device_type.as_deref() == Some("disk") {
+        node.path.clone().map(|devnode| ParentDiskDetails {
+            devnode,
+            model: clean_string(node.model.clone()),
+            serial: clean_string(node.serial.clone()),
+            size_bytes: node.size.as_ref().and_then(value_as_u64),
+            transport: clean_string(node.tran.clone()),
+            rotational: node.rota.as_ref().and_then(value_as_bool),
+            removable: node.rm.as_ref().and_then(value_as_bool).unwrap_or(false),
+        })
+    } else {
+        parent_details.clone()
+    };
+
     if node.device_type.as_deref() == Some("part")
         && let Some(devnode) = node.path.clone()
     {
         let canonical = fs::canonicalize(&devnode).unwrap_or_else(|_| devnode.clone());
         let mut partition_aliases = aliases.get(&canonical).cloned().unwrap_or_default();
         partition_aliases.sort_by_key(alias_preference_key);
+        let flat_parent_details = parent_devnode_for_partition(&devnode)
+            .and_then(|parent| parent_details_by_devnode.get(&parent));
+        let details = current_details.as_ref().or(flat_parent_details);
 
         partitions.push(BlockPartition {
             devnode,
             aliases: partition_aliases,
+            parent_devnode: details.map(|details| details.devnode.clone()),
+            model: details.and_then(|details| details.model.clone()),
+            serial: details.and_then(|details| details.serial.clone()),
             size_bytes: node.size.as_ref().and_then(value_as_u64),
+            parent_size_bytes: details.and_then(|details| details.size_bytes),
+            transport: details.and_then(|details| details.transport.clone()),
+            rotational: details.and_then(|details| details.rotational),
+            removable: details.is_some_and(|details| details.removable),
         });
     }
 
     for child in node.children {
-        collect_lsblk_partitions(child, aliases, partitions);
+        collect_lsblk_partitions(
+            child,
+            aliases,
+            parent_details_by_devnode,
+            partitions,
+            current_details.clone(),
+        );
+    }
+}
+
+fn collect_parent_disk_details(nodes: &[LsblkDevice]) -> HashMap<PathBuf, ParentDiskDetails> {
+    let mut details = HashMap::new();
+    for node in nodes {
+        collect_parent_disk_details_inner(node, &mut details);
+    }
+    details
+}
+
+fn collect_parent_disk_details_inner(
+    node: &LsblkDevice,
+    details: &mut HashMap<PathBuf, ParentDiskDetails>,
+) {
+    if node.device_type.as_deref() == Some("disk")
+        && let Some(devnode) = node.path.clone()
+    {
+        details.insert(
+            devnode.clone(),
+            ParentDiskDetails {
+                devnode,
+                model: clean_string(node.model.clone()),
+                serial: clean_string(node.serial.clone()),
+                size_bytes: node.size.as_ref().and_then(value_as_u64),
+                transport: clean_string(node.tran.clone()),
+                rotational: node.rota.as_ref().and_then(value_as_bool),
+                removable: node.rm.as_ref().and_then(value_as_bool).unwrap_or(false),
+            },
+        );
+    }
+
+    for child in &node.children {
+        collect_parent_disk_details_inner(child, details);
     }
 }
 
@@ -244,6 +503,30 @@ fn is_installable_devnode(path: &Path) -> bool {
     };
 
     !(name.starts_with("loop") || name.starts_with("zram") || name.starts_with("sr"))
+}
+
+fn parent_devnode_for_partition(path: &Path) -> Option<PathBuf> {
+    let name = path.file_name()?.to_str()?;
+    let parent_name = strip_partition_suffix(name);
+    if parent_name == name || parent_name.is_empty() {
+        return None;
+    }
+
+    Some(match path.parent() {
+        Some(parent) => parent.join(parent_name),
+        None => PathBuf::from(parent_name),
+    })
+}
+
+fn strip_partition_suffix(name: &str) -> &str {
+    if let Some(pos) = name.rfind('p') {
+        let after = &name[pos + 1..];
+        if !after.is_empty() && after.bytes().all(|b| b.is_ascii_digit()) {
+            return &name[..pos];
+        }
+    }
+
+    name.trim_end_matches(|c: char| c.is_ascii_digit())
 }
 
 fn collect_device_aliases() -> Result<HashMap<PathBuf, Vec<DevicePath>>> {
@@ -318,6 +601,35 @@ fn preferred_path_for(aliases: &[DevicePath], devnode: &Path) -> DevicePath {
             path: devnode.to_path_buf(),
             kind: DevicePathKind::DevNode,
         })
+}
+
+fn persistent_path_label(preferred: &DevicePath, devnode: &Path) -> String {
+    if preferred.path == devnode {
+        String::new()
+    } else {
+        preferred.path.display().to_string()
+    }
+}
+
+fn persistent_kind_label(preferred: &DevicePath, devnode: &Path) -> String {
+    if preferred.path == devnode {
+        return String::new();
+    }
+
+    match preferred.kind {
+        DevicePathKind::ById => "by-id",
+        DevicePathKind::ByPath => "by-path",
+        DevicePathKind::DevNode => "",
+    }
+    .to_string()
+}
+
+fn media_label(rotational: Option<bool>) -> String {
+    match rotational {
+        Some(true) => "HDD".to_string(),
+        Some(false) => "SSD".to_string(),
+        None => String::new(),
+    }
 }
 
 fn by_id_rank(name: &str) -> u8 {
@@ -453,7 +765,7 @@ mod tests {
     }
 
     #[test]
-    fn selection_label_includes_identity_and_preferred_path() {
+    fn device_choice_includes_identity_and_preferred_path() {
         let device = BlockDevice {
             devnode: PathBuf::from("/dev/vda"),
             aliases: vec![DevicePath {
@@ -468,9 +780,27 @@ mod tests {
             removable: false,
         };
 
+        assert_eq!(device.selection_title(), "/dev/vda");
+        assert_eq!(device.selection_icon(), "hard-drive");
+        assert_eq!(device.selection_model(), "VirtIO Block Device");
+        assert_eq!(device.selection_serial(), "");
+        assert_eq!(device.selection_size(), "64 GiB");
+        assert_eq!(device.selection_transport(), "virtio");
+        assert_eq!(device.selection_media(), "SSD");
         assert_eq!(
-            device.selection_label(),
-            "/dev/vda | VirtIO Block Device | 64 GiB | virtio | using /dev/disk/by-path/pci-0000:00:04.0"
+            device.selection_persistent_path(),
+            "/dev/disk/by-path/pci-0000:00:04.0"
+        );
+        assert_eq!(device.selection_persistent_kind(), "by-path");
+
+        let choice = DeviceChoice::from(device);
+        assert_eq!(
+            choice.detail_summary(),
+            "VirtIO Block Device | 64 GiB | SSD | virtio | using /dev/disk/by-path/pci-0000:00:04.0"
+        );
+        assert_eq!(
+            choice.display_label(),
+            "/dev/vda | VirtIO Block Device | 64 GiB | SSD | virtio | using /dev/disk/by-path/pci-0000:00:04.0"
         );
     }
 
@@ -488,16 +818,176 @@ mod tests {
                     kind: DevicePathKind::ById,
                 },
             ],
+            parent_devnode: Some(PathBuf::from("/dev/vda")),
+            model: Some("VirtIO Block Device".to_string()),
+            serial: Some("test-serial".to_string()),
             size_bytes: Some(512 * 1024 * 1024),
+            parent_size_bytes: Some(64 * 1024 * 1024 * 1024),
+            transport: Some("virtio".to_string()),
+            rotational: Some(false),
+            removable: false,
         };
 
         assert_eq!(
             partition.preferred_path().path,
             PathBuf::from("/dev/disk/by-id/virtio-test-disk-part1")
         );
+        assert_eq!(partition.selection_title(), "/dev/vda1");
+        assert_eq!(partition.selection_group_label(), "/dev/vda");
+        assert_eq!(partition.selection_group_model(), "VirtIO Block Device");
+        assert_eq!(partition.selection_group_serial(), "test-serial");
+        assert_eq!(partition.selection_group_size(), "64 GiB");
+        assert_eq!(partition.selection_group_transport(), "virtio");
+        assert_eq!(partition.selection_group_media(), "SSD");
+        assert_eq!(partition.selection_icon(), "hard-drive");
+        assert_eq!(partition.selection_model(), "VirtIO Block Device");
+        assert_eq!(partition.selection_serial(), "test-serial");
+        assert_eq!(partition.selection_size(), "512 MiB");
+        assert_eq!(partition.selection_transport(), "virtio");
+        assert_eq!(partition.selection_media(), "SSD");
         assert_eq!(
-            partition.selection_label(),
-            "/dev/vda1 | 512 MiB | using /dev/disk/by-id/virtio-test-disk-part1"
+            partition.selection_persistent_path(),
+            "/dev/disk/by-id/virtio-test-disk-part1"
+        );
+        assert_eq!(partition.selection_persistent_kind(), "by-id");
+
+        let choice = DeviceChoice::from(partition);
+        assert_eq!(
+            choice.detail_summary(),
+            "VirtIO Block Device | SN test-serial | 512 MiB | SSD | virtio | using /dev/disk/by-id/virtio-test-disk-part1"
+        );
+        assert_eq!(
+            choice.display_label(),
+            "/dev/vda1 | VirtIO Block Device | SN test-serial | 512 MiB | SSD | virtio | using /dev/disk/by-id/virtio-test-disk-part1"
+        );
+        assert_eq!(choice.group_label, "/dev/vda");
+        assert_eq!(choice.group_size, "64 GiB");
+    }
+
+    #[test]
+    fn removable_or_usb_disks_use_usb_icon() {
+        let device = BlockDevice {
+            devnode: PathBuf::from("/dev/sdb"),
+            aliases: Vec::new(),
+            model: Some("USB Flash Drive".to_string()),
+            serial: None,
+            size_bytes: Some(16 * 1024 * 1024 * 1024),
+            transport: Some("usb".to_string()),
+            rotational: Some(false),
+            removable: false,
+        };
+
+        assert_eq!(device.selection_icon(), "usb");
+    }
+
+    #[test]
+    fn partition_collection_inherits_parent_disk_details() {
+        let root = LsblkDevice {
+            path: Some(PathBuf::from("/dev/sda")),
+            device_type: Some("disk".to_string()),
+            size: None,
+            model: Some("Samsung SSD".to_string()),
+            serial: Some("S123".to_string()),
+            tran: Some("sata".to_string()),
+            rota: Some(Value::Number(0.into())),
+            rm: Some(Value::Number(1.into())),
+            children: vec![LsblkDevice {
+                path: Some(PathBuf::from("/dev/sda1")),
+                device_type: Some("part".to_string()),
+                size: Some(Value::Number((1024 * 1024 * 1024).into())),
+                model: None,
+                serial: None,
+                tran: None,
+                rota: None,
+                rm: None,
+                children: Vec::new(),
+            }],
+        };
+
+        let aliases = HashMap::new();
+        let parent_details_by_devnode = collect_parent_disk_details(std::slice::from_ref(&root));
+        let mut partitions = Vec::new();
+        collect_lsblk_partitions(
+            root,
+            &aliases,
+            &parent_details_by_devnode,
+            &mut partitions,
+            None,
+        );
+
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(partitions[0].selection_model(), "Samsung SSD");
+        assert_eq!(partitions[0].selection_serial(), "S123");
+        assert_eq!(partitions[0].selection_group_label(), "/dev/sda");
+        assert_eq!(partitions[0].selection_group_size(), "");
+        assert_eq!(partitions[0].selection_transport(), "sata");
+        assert_eq!(partitions[0].selection_media(), "SSD");
+        assert!(partitions[0].removable);
+    }
+
+    #[test]
+    fn flat_partition_collection_looks_up_parent_disk_details() {
+        let disk = LsblkDevice {
+            path: Some(PathBuf::from("/dev/nvme0n1")),
+            device_type: Some("disk".to_string()),
+            size: None,
+            model: Some("Samsung SSD".to_string()),
+            serial: Some("S123".to_string()),
+            tran: Some("nvme".to_string()),
+            rota: Some(Value::Bool(false)),
+            rm: Some(Value::Bool(false)),
+            children: Vec::new(),
+        };
+        let partition = LsblkDevice {
+            path: Some(PathBuf::from("/dev/nvme0n1p1")),
+            device_type: Some("part".to_string()),
+            size: Some(Value::Number((1024 * 1024 * 1024).into())),
+            model: None,
+            serial: None,
+            tran: Some("nvme".to_string()),
+            rota: None,
+            rm: None,
+            children: Vec::new(),
+        };
+
+        let aliases = HashMap::new();
+        let parent_details_by_devnode = collect_parent_disk_details(std::slice::from_ref(&disk));
+        let mut partitions = Vec::new();
+        collect_lsblk_partitions(
+            partition,
+            &aliases,
+            &parent_details_by_devnode,
+            &mut partitions,
+            None,
+        );
+
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(partitions[0].selection_model(), "Samsung SSD");
+        assert_eq!(partitions[0].selection_serial(), "S123");
+        assert_eq!(partitions[0].selection_group_label(), "/dev/nvme0n1");
+        assert_eq!(partitions[0].selection_group_size(), "");
+        assert_eq!(partitions[0].selection_transport(), "nvme");
+        assert_eq!(partitions[0].selection_media(), "SSD");
+        assert!(!partitions[0].removable);
+    }
+
+    #[test]
+    fn parent_devnode_for_partition_handles_common_names() {
+        assert_eq!(
+            parent_devnode_for_partition(Path::new("/dev/sda1")),
+            Some(PathBuf::from("/dev/sda"))
+        );
+        assert_eq!(
+            parent_devnode_for_partition(Path::new("/dev/vda12")),
+            Some(PathBuf::from("/dev/vda"))
+        );
+        assert_eq!(
+            parent_devnode_for_partition(Path::new("/dev/nvme0n1p1")),
+            Some(PathBuf::from("/dev/nvme0n1"))
+        );
+        assert_eq!(
+            parent_devnode_for_partition(Path::new("/dev/mmcblk0p2")),
+            Some(PathBuf::from("/dev/mmcblk0"))
         );
     }
 }

--- a/core/src/installer/initramfs/mkinitcpio.rs
+++ b/core/src/installer/initramfs/mkinitcpio.rs
@@ -148,10 +148,10 @@ mod tests {
     fn test_patch_conf_array_adds_zfs() {
         let input = "MODULES=()\nHOOKS=(base udev autodetect modconf block filesystems fsck)\n";
         let result = patch_conf_array(input, "HOOKS", |hooks| {
-            if !hooks.contains(&"zfs".to_string()) {
-                if let Some(pos) = hooks.iter().position(|h| h == "filesystems") {
-                    hooks.insert(pos, "zfs".to_string());
-                }
+            if !hooks.contains(&"zfs".to_string())
+                && let Some(pos) = hooks.iter().position(|h| h == "filesystems")
+            {
+                hooks.insert(pos, "zfs".to_string());
             }
         });
         assert!(result.contains("zfs filesystems"));

--- a/core/src/kernel/scanner.rs
+++ b/core/src/kernel/scanner.rs
@@ -657,7 +657,7 @@ mod tests {
     #[test]
     fn test_menu_option_generation_logic() {
         // Simulate scan results and verify filtering logic
-        let results = vec![
+        let results = [
             CompatibilityResult {
                 kernel_name: "linux-lts".into(),
                 kernel_version: Some("6.12.41-2".into()),

--- a/core/src/system/cmd.rs
+++ b/core/src/system/cmd.rs
@@ -202,21 +202,11 @@ pub mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Default)]
     pub struct CannedResponse {
         pub stdout: String,
         pub stderr: String,
         pub exit_code: i32,
-    }
-
-    impl Default for CannedResponse {
-        fn default() -> Self {
-            Self {
-                stdout: String::new(),
-                stderr: String::new(),
-                exit_code: 0,
-            }
-        }
     }
 
     #[derive(Debug, Clone)]

--- a/slint-ui/assets/icons/hard-drive.svg
+++ b/slint-ui/assets/icons/hard-drive.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 16h.01" />
+  <path d="M2.212 11.577a2 2 0 0 0-.212.896V18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-5.527a2 2 0 0 0-.212-.896L18.55 5.11A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+  <path d="M21.946 12.013H2.054" />
+  <path d="M6 16h.01" />
+</svg>

--- a/slint-ui/assets/icons/usb.svg
+++ b/slint-ui/assets/icons/usb.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="10" cy="7" r="1" />
+  <circle cx="4" cy="20" r="1" />
+  <path d="M4.7 19.3 19 5" />
+  <path d="m21 3-3 1 2 2Z" />
+  <path d="M9.26 7.68 5 12l2 5" />
+  <path d="m10 14 5 2 3.5-3.5" />
+  <path d="m18 12 1-1 1 1-1 1Z" />
+</svg>

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -2,11 +2,13 @@
 //! coming back from radio/select/text widgets to the canonical `GlobalConfig`.
 
 use slint::SharedString;
+use std::path::PathBuf;
 
 use archinstall_zfs_core::config::types::{
     AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
     SeatAccess, SwapMode, ZfsEncryptionMode,
 };
+use archinstall_zfs_core::disk::device::DeviceChoice;
 
 use crate::ui::{ConfigItem, ItemType};
 
@@ -15,6 +17,87 @@ pub const TOTAL_STEPS: usize = 7;
 pub const STEP_LABELS: [&str; TOTAL_STEPS] = [
     "Welcome", "Disk", "ZFS", "System", "Users", "Desktop", "Review",
 ];
+
+#[derive(Debug, Clone)]
+struct ChoiceRow {
+    path: PathBuf,
+    label: String,
+    icon: String,
+    model: String,
+    serial: String,
+    size: String,
+    transport: String,
+    media: String,
+    removable: bool,
+    persistent_path: String,
+    persistent_kind: String,
+    group_label: String,
+    group_model: String,
+    group_serial: String,
+    group_size: String,
+    group_transport: String,
+    group_media: String,
+    group_removable: bool,
+}
+
+impl From<DeviceChoice> for ChoiceRow {
+    fn from(choice: DeviceChoice) -> Self {
+        Self {
+            path: choice.path,
+            label: choice.label,
+            icon: choice.icon,
+            model: choice.model,
+            serial: choice.serial,
+            size: choice.size,
+            transport: choice.transport,
+            media: choice.media,
+            removable: choice.removable,
+            persistent_path: choice.persistent_path,
+            persistent_kind: choice.persistent_kind,
+            group_label: choice.group_label,
+            group_model: choice.group_model,
+            group_serial: choice.group_serial,
+            group_size: choice.group_size,
+            group_transport: choice.group_transport,
+            group_media: choice.group_media,
+            group_removable: choice.group_removable,
+        }
+    }
+}
+
+impl ChoiceRow {
+    fn path_only(path: PathBuf) -> Self {
+        let label = path.display().to_string();
+        Self {
+            path,
+            label,
+            icon: "hard-drive".to_string(),
+            model: String::new(),
+            serial: String::new(),
+            size: String::new(),
+            transport: String::new(),
+            media: String::new(),
+            removable: false,
+            persistent_path: String::new(),
+            persistent_kind: String::new(),
+            group_label: String::new(),
+            group_model: String::new(),
+            group_serial: String::new(),
+            group_size: String::new(),
+            group_transport: String::new(),
+            group_media: String::new(),
+            group_removable: false,
+        }
+    }
+
+    fn group_key(&self) -> &str {
+        if self.group_label.is_empty() {
+            self.label.as_str()
+        } else {
+            self.group_label.as_str()
+        }
+    }
+}
 
 // ── Per-step item building ──────────────────────────
 
@@ -49,21 +132,19 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             Some(InstallationMode::FullDisk) => 0,
             Some(InstallationMode::NewPool) => 1,
             Some(InstallationMode::ExistingPool) => 2,
-            None => -1,
+            None => 0,
         },
     );
 
     if matches!(mode, Some(InstallationMode::FullDisk) | None) {
         let disks = disk_choices();
-        let disk_strs: Vec<String> = disks.iter().map(|(_, label)| label.clone()).collect();
-        let disk_refs: Vec<&str> = disk_strs.iter().map(|s| s.as_str()).collect();
         let selected = c
             .disk
             .as_ref()
-            .and_then(|sel| disks.iter().position(|(path, _)| path == sel))
+            .and_then(|sel| disks.iter().position(|choice| &choice.path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
-        items.extend(radio_group("disk", "Disk", &disk_refs, selected));
+        items.extend(radio_choice_group("disk", "Disk", &disks, selected));
     }
 
     if matches!(
@@ -71,19 +152,17 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         Some(InstallationMode::NewPool) | Some(InstallationMode::ExistingPool)
     ) {
         let parts = partition_choices();
-        let part_strs: Vec<String> = parts.iter().map(|(_, label)| label.clone()).collect();
-        let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
 
         let efi_selected = c
             .efi_partition
             .as_ref()
-            .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
+            .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
-        items.extend(radio_group(
+        items.extend(radio_partition_choice_group(
             "efi_partition",
             "EFI partition",
-            &part_refs,
+            &parts,
             efi_selected,
         ));
 
@@ -91,13 +170,13 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             let zfs_selected = c
                 .zfs_partition
                 .as_ref()
-                .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
+                .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
                 .map(|i| i as i32)
                 .unwrap_or(-1);
-            items.extend(radio_group(
+            items.extend(radio_partition_choice_group(
                 "zfs_partition",
                 "ZFS partition",
-                &part_refs,
+                &parts,
                 zfs_selected,
             ));
         }
@@ -195,18 +274,16 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     }
     if !matches!(mode, Some(InstallationMode::FullDisk) | None) && has_swap_partition {
         let parts = partition_choices();
-        let part_strs: Vec<String> = parts.iter().map(|(_, label)| label.clone()).collect();
-        let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
         let swap_selected = c
             .swap_partition
             .as_ref()
-            .and_then(|sel| parts.iter().position(|(path, _)| path == sel))
+            .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
-        items.extend(radio_group(
+        items.extend(radio_choice_group(
             "swap_partition",
             "Swap partition",
-            &part_refs,
+            &parts,
             swap_selected,
         ));
     }
@@ -492,20 +569,51 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                     // readonly row showing "Group: Selected option".
                     let header_label = item.label.clone();
                     let mut selected_label: SharedString = "Not set".into();
+                    let mut selected_detail_model = SharedString::default();
+                    let mut selected_detail_serial = SharedString::default();
+                    let mut selected_detail_size = SharedString::default();
+                    let mut selected_detail_transport = SharedString::default();
+                    let mut selected_detail_media = SharedString::default();
+                    let mut selected_is_removable = false;
+                    let mut selected_persistent_path = SharedString::default();
+                    let mut selected_persistent_kind = SharedString::default();
                     // Default empty: nothing selected. Overwritten when we
                     // find the selected option, taking its is_empty value.
                     let mut selected_is_empty = true;
                     i += 1;
-                    while i < step_items.len() && step_items[i].item_type == ItemType::RadioOption {
-                        if step_items[i].value == "selected" {
+                    while i < step_items.len()
+                        && matches!(
+                            step_items[i].item_type,
+                            ItemType::RadioOption | ItemType::RadioSubheader
+                        )
+                    {
+                        if step_items[i].item_type == ItemType::RadioOption
+                            && step_items[i].value == "selected"
+                        {
                             selected_label = step_items[i].label.clone();
                             selected_is_empty = step_items[i].is_empty;
+                            selected_detail_model = step_items[i].detail_model.clone();
+                            selected_detail_serial = step_items[i].detail_serial.clone();
+                            selected_detail_size = step_items[i].detail_size.clone();
+                            selected_detail_transport = step_items[i].detail_transport.clone();
+                            selected_detail_media = step_items[i].detail_media.clone();
+                            selected_is_removable = step_items[i].is_removable;
+                            selected_persistent_path = step_items[i].persistent_path.clone();
+                            selected_persistent_kind = step_items[i].persistent_kind.clone();
                         }
                         i += 1;
                     }
                     items.push(ConfigItem {
                         label: header_label,
                         value: selected_label,
+                        detail_model: selected_detail_model,
+                        detail_serial: selected_detail_serial,
+                        detail_size: selected_detail_size,
+                        detail_transport: selected_detail_transport,
+                        detail_media: selected_detail_media,
+                        is_removable: selected_is_removable,
+                        persistent_path: selected_persistent_path,
+                        persistent_kind: selected_persistent_kind,
                         item_type: ItemType::Readonly,
                         is_empty: selected_is_empty,
                         ..Default::default()
@@ -523,6 +631,7 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                         key: item.key.clone(),
                         label: item.label.clone(),
                         value: item.value.clone(),
+                        description: item.description.clone(),
                         item_type: ItemType::Readonly,
                         is_empty: item.is_empty,
                         ..Default::default()
@@ -658,6 +767,105 @@ fn radio_group_inner(
     items
 }
 
+fn radio_choice_group(
+    key: &str,
+    label: &str,
+    options: &[ChoiceRow],
+    selected: i32,
+) -> Vec<ConfigItem> {
+    let mut items = vec![ConfigItem {
+        label: label.into(),
+        item_type: ItemType::RadioHeader,
+        ..Default::default()
+    }];
+    for (i, option) in options.iter().enumerate() {
+        items.push(ConfigItem {
+            key: format!("radio:{key}:{i}").into(),
+            label: option.label.as_str().into(),
+            icon: option.icon.as_str().into(),
+            detail_model: option.model.as_str().into(),
+            detail_serial: option.serial.as_str().into(),
+            detail_size: option.size.as_str().into(),
+            detail_transport: option.transport.as_str().into(),
+            detail_media: option.media.as_str().into(),
+            is_removable: option.removable,
+            persistent_path: option.persistent_path.as_str().into(),
+            persistent_kind: option.persistent_kind.as_str().into(),
+            group_label: option.group_label.as_str().into(),
+            group_model: option.group_model.as_str().into(),
+            group_serial: option.group_serial.as_str().into(),
+            group_size: option.group_size.as_str().into(),
+            group_transport: option.group_transport.as_str().into(),
+            group_media: option.group_media.as_str().into(),
+            group_removable: option.group_removable,
+            value: if i as i32 == selected {
+                "selected".into()
+            } else {
+                SharedString::default()
+            },
+            item_type: ItemType::RadioOption,
+            ..Default::default()
+        });
+    }
+    items
+}
+
+fn radio_partition_choice_group(
+    key: &str,
+    label: &str,
+    options: &[ChoiceRow],
+    selected: i32,
+) -> Vec<ConfigItem> {
+    let mut items = vec![ConfigItem {
+        label: label.into(),
+        item_type: ItemType::RadioHeader,
+        ..Default::default()
+    }];
+    let mut current_group = "";
+
+    for (i, option) in options.iter().enumerate() {
+        let group_key = option.group_key();
+        if group_key != current_group {
+            current_group = group_key;
+            items.push(ConfigItem {
+                label: option.group_key().into(),
+                icon: "hard-drive".into(),
+                detail_model: option.group_model.as_str().into(),
+                detail_serial: option.group_serial.as_str().into(),
+                detail_size: option.group_size.as_str().into(),
+                detail_transport: option.group_transport.as_str().into(),
+                detail_media: option.group_media.as_str().into(),
+                is_removable: option.group_removable,
+                item_type: ItemType::RadioSubheader,
+                ..Default::default()
+            });
+        }
+
+        items.push(ConfigItem {
+            key: format!("radio:{key}:{i}").into(),
+            label: option.label.as_str().into(),
+            detail_size: option.size.as_str().into(),
+            persistent_path: option.persistent_path.as_str().into(),
+            persistent_kind: option.persistent_kind.as_str().into(),
+            group_label: option.group_label.as_str().into(),
+            group_model: option.group_model.as_str().into(),
+            group_serial: option.group_serial.as_str().into(),
+            group_size: option.group_size.as_str().into(),
+            group_transport: option.group_transport.as_str().into(),
+            group_media: option.group_media.as_str().into(),
+            group_removable: option.group_removable,
+            value: if i as i32 == selected {
+                "selected".into()
+            } else {
+                SharedString::default()
+            },
+            item_type: ItemType::RadioOption,
+            ..Default::default()
+        });
+    }
+    items
+}
+
 // ── Section boundary marking ────────────────────────
 
 /// Walk a list of items after it's built and set `is_first_in_section` /
@@ -673,6 +881,7 @@ fn mark_section_boundaries(items: &mut [ConfigItem]) {
                 | ItemType::Select
                 | ItemType::Password
                 | ItemType::Toggle
+                | ItemType::RadioSubheader
                 | ItemType::RadioOption
                 | ItemType::Readonly
         )
@@ -711,6 +920,7 @@ pub fn next_selectable_index(items: &[ConfigItem], current: i32, dir: i32) -> i3
             && t != ItemType::Warning
             && t != ItemType::SectionHeader
             && t != ItemType::RadioHeader
+            && t != ItemType::RadioSubheader
         {
             return idx;
         }
@@ -739,26 +949,27 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
         }
         "disk" => {
             let disks = disk_choices();
-            if let Some((path, _)) = disks.get(idx as usize) {
-                config.disk = Some(path.clone());
+            if let Some(choice) = disks.get(idx as usize) {
+                config.installation_mode = Some(InstallationMode::FullDisk);
+                config.disk = Some(choice.path.clone());
             }
         }
         "efi_partition" => {
             let parts = partition_choices();
-            if let Some((path, _)) = parts.get(idx as usize) {
-                config.efi_partition = Some(path.clone());
+            if let Some(choice) = parts.get(idx as usize) {
+                config.efi_partition = Some(choice.path.clone());
             }
         }
         "zfs_partition" => {
             let parts = partition_choices();
-            if let Some((path, _)) = parts.get(idx as usize) {
-                config.zfs_partition = Some(path.clone());
+            if let Some(choice) = parts.get(idx as usize) {
+                config.zfs_partition = Some(choice.path.clone());
             }
         }
         "swap_partition" => {
             let parts = partition_choices();
-            if let Some((path, _)) = parts.get(idx as usize) {
-                config.swap_partition = Some(path.clone());
+            if let Some(choice) = parts.get(idx as usize) {
+                config.swap_partition = Some(choice.path.clone());
             }
         }
         "compression" => {
@@ -824,42 +1035,26 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
     }
 }
 
-fn disk_choices() -> Vec<(std::path::PathBuf, String)> {
+fn disk_choices() -> Vec<ChoiceRow> {
     archinstall_zfs_core::disk::device::disk_choices()
-        .map(|choices| {
-            choices
-                .into_iter()
-                .map(|choice| (choice.path, choice.label))
-                .collect()
-        })
+        .map(|choices| choices.into_iter().map(ChoiceRow::from).collect())
         .unwrap_or_else(|_| {
             archinstall_zfs_core::disk::by_id::list_disks_by_id()
                 .unwrap_or_default()
                 .into_iter()
-                .map(|path| {
-                    let label = path.display().to_string();
-                    (path, label)
-                })
+                .map(ChoiceRow::path_only)
                 .collect()
         })
 }
 
-fn partition_choices() -> Vec<(std::path::PathBuf, String)> {
+fn partition_choices() -> Vec<ChoiceRow> {
     archinstall_zfs_core::disk::device::partition_choices()
-        .map(|choices| {
-            choices
-                .into_iter()
-                .map(|choice| (choice.path, choice.label))
-                .collect()
-        })
+        .map(|choices| choices.into_iter().map(ChoiceRow::from).collect())
         .unwrap_or_else(|_| {
             archinstall_zfs_core::disk::by_id::list_partitions_by_id()
                 .unwrap_or_default()
                 .into_iter()
-                .map(|path| {
-                    let label = path.display().to_string();
-                    (path, label)
-                })
+                .map(ChoiceRow::path_only)
                 .collect()
         })
 }

--- a/slint-ui/ui/components/config-item.slint
+++ b/slint-ui/ui/components/config-item.slint
@@ -20,7 +20,26 @@
 
 import { Theme, Palette } from "../styling.slint";
 import { ConfigItem, ItemType } from "../types.slint";
+import { Icon } from "icon.slint";
 import { RadioDot } from "radio-dot.slint";
+
+component DetailPill inherits Rectangle {
+    in property <string> label;
+
+    width: detail-pill-text.preferred-width + 10px;
+    height: 18px;
+    background: Theme.c.surface1;
+    border-radius: 4px;
+
+    detail-pill-text := Text {
+        text: root.label;
+        color: Theme.c.subtext0;
+        font-size: 11px;
+        font-weight: FontWeight.semi-bold;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
 
 export component ConfigItemRow inherits Rectangle {
     in property <ConfigItem> item;
@@ -42,22 +61,33 @@ export component ConfigItemRow inherits Rectangle {
     property <bool> is-separator: item.item-type == ItemType.separator;
     property <bool> is-warning: item.item-type == ItemType.warning;
     property <bool> is-action: item.item-type == ItemType.action;
+    property <bool> is-radio-subheader: item.item-type == ItemType.radio-subheader;
     property <bool> is-radio-option: item.item-type == ItemType.radio-option;
+    property <bool> is-grouped-radio-option: is-radio-option && item.group-label != "";
     property <bool> is-readonly: item.item-type == ItemType.readonly;
     property <bool> is-toggle: item.item-type == ItemType.toggle;
+    property <bool> has-choice-details: item.icon != "";
+    property <bool> has-device-secondary-text: item.detail-model != ""
+        || item.detail-serial != "" || item.persistent-path != "";
+    property <bool> has-secondary-text: has-device-secondary-text || item.description != "";
     property <bool> is-field: item.item-type == ItemType.text
         || item.item-type == ItemType.select
         || item.item-type == ItemType.password
         || is-toggle
+        || is-radio-subheader
         || is-radio-option
         || is-readonly;
-    property <bool> is-non-interactive: is-separator || is-warning || is-section-header || is-readonly;
+    property <bool> is-non-interactive: is-separator || is-warning || is-section-header || is-readonly
+        || is-radio-subheader;
 
     height: is-separator ? 8px
           : is-warning ? 32px
           : is-section-header ? 36px
-          : is-radio-option ? 36px
+          : is-radio-subheader ? (has-secondary-text ? 48px : 40px)
+          : is-grouped-radio-option ? (has-secondary-text ? 46px : 36px)
+          : is-radio-option ? (has-secondary-text ? 58px : 40px)
           : is-action ? 40px
+          : is-readonly && has-secondary-text ? 52px
           : 44px;
 
     // Section card background — only field rows draw it. Corner radius is
@@ -85,7 +115,7 @@ export component ConfigItemRow inherits Rectangle {
     }
 
     // Hover / focus highlight overlay (interactive rows only).
-    if is-field && !is-readonly: Rectangle {
+    if is-field && !is-non-interactive: Rectangle {
         visible: row-ta.has-hover || index == focused-index;
         background: Palette.state-hovered;
         border-top-left-radius: item.is-first-in-section ? 8px : 0px;
@@ -134,6 +164,91 @@ export component ConfigItemRow inherits Rectangle {
         }
     }
 
+    // ── Radio subheader (groups partition choices by parent disk) ──
+    if is-radio-subheader: HorizontalLayout {
+        padding-left: 14px;
+        padding-right: 14px;
+        spacing: 10px;
+        alignment: start;
+
+        if item.icon != "": Rectangle {
+            width: 20px;
+            horizontal-stretch: 0;
+
+            Icon {
+                source: @image-url("../../assets/icons/hard-drive.svg");
+                size: 20px;
+                tint: Theme.c.blue;
+                y: (parent.height - self.height) / 2;
+            }
+        }
+
+        VerticalLayout {
+            horizontal-stretch: 1;
+            alignment: center;
+            spacing: 3px;
+
+            HorizontalLayout {
+                spacing: 6px;
+                horizontal-stretch: 1;
+
+                Text {
+                    text: item.label;
+                    color: Theme.c.text;
+                    font-size: 14px;
+                    font-weight: FontWeight.semi-bold;
+                    vertical-alignment: has-secondary-text ? bottom : center;
+                    horizontal-stretch: 1;
+                    overflow: elide;
+                }
+
+                if item.detail-size != "": DetailPill {
+                    label: item.detail-size;
+                    horizontal-stretch: 0;
+                }
+
+                if item.detail-media != "": DetailPill {
+                    label: item.detail-media;
+                    horizontal-stretch: 0;
+                }
+
+                if item.detail-transport != "": DetailPill {
+                    label: item.detail-transport;
+                    horizontal-stretch: 0;
+                }
+
+                if item.is-removable: DetailPill {
+                    label: "removable";
+                    horizontal-stretch: 0;
+                }
+            }
+
+            if has-secondary-text: HorizontalLayout {
+                spacing: 6px;
+                horizontal-stretch: 1;
+
+                if item.detail-model != "": Text {
+                    text: item.detail-model;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: item.detail-serial == "" ? 1 : 0;
+                    overflow: elide;
+                }
+
+                if item.detail-serial != "": Text {
+                    text: "SN " + item.detail-serial;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: item.detail-model == "" ? 1 : 0;
+                    max-width: 180px;
+                    overflow: elide;
+                }
+            }
+        }
+    }
+
     // ── Radio option (sits on the section card) ──
     if is-radio-option: HorizontalLayout {
         padding-left: 14px;
@@ -146,13 +261,110 @@ export component ConfigItemRow inherits Rectangle {
             dot-color: item.value == "selected" ? Theme.c.green : Theme.c.overlay0;
         }
 
-        Text {
-            text: item.label;
-            color: item.value == "selected" ? Theme.c.text : Theme.c.subtext0;
-            font-size: 14px;
-            vertical-alignment: center;
+        if item.icon != "": Rectangle {
+            width: 20px;
+            horizontal-stretch: 0;
+
+            Icon {
+                source: item.icon == "usb"
+                    ? @image-url("../../assets/icons/usb.svg")
+                    : @image-url("../../assets/icons/hard-drive.svg");
+                size: 20px;
+                tint: item.value == "selected" ? Theme.c.blue : Theme.c.overlay0;
+                y: (parent.height - self.height) / 2;
+            }
+        }
+
+        VerticalLayout {
             horizontal-stretch: 1;
-            overflow: elide;
+            alignment: center;
+            spacing: 3px;
+
+            HorizontalLayout {
+                spacing: 6px;
+                horizontal-stretch: 1;
+
+                Text {
+                    text: item.label;
+                    color: item.value == "selected" ? Theme.c.text : Theme.c.subtext0;
+                    font-size: 14px;
+                    font-weight: has-choice-details ? FontWeight.semi-bold : FontWeight.normal;
+                    vertical-alignment: has-secondary-text ? bottom : center;
+                    horizontal-stretch: 1;
+                    overflow: elide;
+                }
+
+                if item.detail-size != "": DetailPill {
+                    label: item.detail-size;
+                    horizontal-stretch: 0;
+                }
+
+                if item.detail-media != "": DetailPill {
+                    label: item.detail-media;
+                    horizontal-stretch: 0;
+                }
+
+                if item.detail-transport != "": DetailPill {
+                    label: item.detail-transport;
+                    horizontal-stretch: 0;
+                }
+
+                if item.is-removable: DetailPill {
+                    label: "removable";
+                    horizontal-stretch: 0;
+                }
+            }
+
+            if has-secondary-text: HorizontalLayout {
+                spacing: 6px;
+                horizontal-stretch: 1;
+
+                if item.detail-model != "": Text {
+                    text: item.detail-model;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: item.persistent-path == "" ? 1 : 0;
+                    overflow: elide;
+                }
+
+                if item.detail-serial != "": Text {
+                    text: "SN " + item.detail-serial;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: item.detail-model == "" && item.persistent-path == "" ? 1 : 0;
+                    max-width: 160px;
+                    overflow: elide;
+                }
+
+                if item.persistent-path != "": Text {
+                    text: item.persistent-kind;
+                    color: Theme.c.blue;
+                    font-size: 12px;
+                    font-weight: FontWeight.semi-bold;
+                    vertical-alignment: top;
+                    horizontal-stretch: 0;
+                }
+
+                if item.persistent-path != "": Text {
+                    text: item.persistent-path;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: 1;
+                    overflow: elide;
+                }
+
+                if !has-device-secondary-text && item.description != "": Text {
+                    text: item.description;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: 1;
+                    overflow: elide;
+                }
+            }
         }
     }
 
@@ -191,14 +403,97 @@ export component ConfigItemRow inherits Rectangle {
             horizontal-stretch: 0;
         }
 
-        Text {
-            text: item.value;
-            color: item.is-empty ? Theme.c.overlay0 : Theme.c.green;
-            font-size: 13px;
-            vertical-alignment: center;
-            horizontal-alignment: right;
+        VerticalLayout {
             horizontal-stretch: 1;
-            overflow: elide;
+            alignment: center;
+            spacing: 1px;
+
+            Text {
+                text: item.value;
+                color: item.is-empty ? Theme.c.overlay0 : Theme.c.green;
+                font-size: 13px;
+                vertical-alignment: has-secondary-text ? bottom : center;
+                horizontal-alignment: right;
+                horizontal-stretch: 1;
+                overflow: elide;
+            }
+
+            if has-secondary-text: HorizontalLayout {
+                spacing: 6px;
+                horizontal-stretch: 1;
+
+                Rectangle { horizontal-stretch: 1; }
+
+                if item.detail-model != "": Text {
+                    text: item.detail-model;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: 0;
+                    max-width: 160px;
+                    overflow: elide;
+                }
+
+                if item.detail-serial != "": Text {
+                    text: "SN " + item.detail-serial;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: 0;
+                    max-width: 100px;
+                    overflow: elide;
+                }
+
+                if item.detail-size != "": DetailPill {
+                    label: item.detail-size;
+                    horizontal-stretch: 0;
+                }
+
+                if item.detail-media != "": DetailPill {
+                    label: item.detail-media;
+                    horizontal-stretch: 0;
+                }
+
+                if item.detail-transport != "": DetailPill {
+                    label: item.detail-transport;
+                    horizontal-stretch: 0;
+                }
+
+                if item.is-removable: DetailPill {
+                    label: "removable";
+                    horizontal-stretch: 0;
+                }
+
+                if item.persistent-path != "": Text {
+                    text: item.persistent-kind;
+                    color: Theme.c.blue;
+                    font-size: 12px;
+                    font-weight: FontWeight.semi-bold;
+                    vertical-alignment: top;
+                    horizontal-stretch: 0;
+                }
+
+                if item.persistent-path != "": Text {
+                    text: item.persistent-path;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-stretch: 0;
+                    max-width: 240px;
+                    overflow: elide;
+                }
+
+                if !has-device-secondary-text && item.description != "": Text {
+                    text: item.description;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    vertical-alignment: top;
+                    horizontal-alignment: right;
+                    horizontal-stretch: 0;
+                    max-width: 300px;
+                    overflow: elide;
+                }
+            }
         }
     }
 

--- a/slint-ui/ui/types.slint
+++ b/slint-ui/ui/types.slint
@@ -17,6 +17,7 @@ export enum ItemType {
     // The review screen collapses (radio-header + N radio-options) into a
     // single readonly summary row.
     radio-header,
+    radio-subheader,
     radio-option,
 }
 
@@ -24,6 +25,23 @@ export struct ConfigItem {
     key: string,
     label: string,
     value: string,
+    description: string,
+    icon: string,
+    detail-model: string,
+    detail-serial: string,
+    detail-size: string,
+    detail-transport: string,
+    detail-media: string,
+    is-removable: bool,
+    persistent-path: string,
+    persistent-kind: string,
+    group-label: string,
+    group-model: string,
+    group-serial: string,
+    group-size: string,
+    group-transport: string,
+    group-media: string,
+    group-removable: bool,
     item-type: ItemType,
     // True if this row is the first field row inside its section (i.e. the
     // previous item in the list is a SectionHeader). Used by ConfigItemRow
@@ -128,4 +146,3 @@ export struct WifiNetworkUi {
     // and shows a "Known" badge.
     known: bool,
 }
-

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -84,7 +84,10 @@ fn disk_choices() -> Result<Vec<(PathBuf, String)>> {
     match archinstall_zfs_core::disk::device::disk_choices() {
         Ok(choices) => Ok(choices
             .into_iter()
-            .map(|choice| (choice.path, choice.label))
+            .map(|choice| {
+                let label = choice.display_label();
+                (choice.path, label)
+            })
             .collect()),
         Err(_) => Ok(archinstall_zfs_core::disk::by_id::list_disks_by_id()?
             .into_iter()
@@ -104,23 +107,29 @@ pub fn pick_partition(
     if parts.is_empty() {
         return Ok(None);
     }
-    let part_strs: Vec<String> = parts.iter().map(|part| part.label.clone()).collect();
+    let part_strs: Vec<String> = parts.iter().map(|(_, label)| label.clone()).collect();
     let part_refs: Vec<&str> = part_strs.iter().map(|s| s.as_str()).collect();
     let result = run_select(terminal, title, &part_refs, 0)?;
     match result.selected {
-        Some(idx) => Ok(Some(parts[idx].path.clone())),
+        Some(idx) => Ok(Some(parts[idx].0.clone())),
         None => Ok(None),
     }
 }
 
-fn partition_choices() -> Result<Vec<archinstall_zfs_core::disk::device::DeviceChoice>> {
+fn partition_choices() -> Result<Vec<(PathBuf, String)>> {
     match archinstall_zfs_core::disk::device::partition_choices() {
-        Ok(choices) => Ok(choices),
+        Ok(choices) => Ok(choices
+            .into_iter()
+            .map(|choice| {
+                let label = choice.display_label();
+                (choice.path, label)
+            })
+            .collect()),
         Err(_) => Ok(archinstall_zfs_core::disk::by_id::list_partitions_by_id()?
             .into_iter()
-            .map(|path| archinstall_zfs_core::disk::device::DeviceChoice {
-                label: path.display().to_string(),
-                path,
+            .map(|path| {
+                let label = path.display().to_string();
+                (path, label)
             })
             .collect()),
     }


### PR DESCRIPTION
## Summary
- Replace device choice display plumbing with structured disk metadata instead of by-id-only labels or legacy description strings.
- Render richer Slint disk/partition rows with device icons, size/media/transport chips, model/serial text, and preferred persistent paths.
- Preserve TUI selection labels through a formatter while removing the old DeviceChoice description transport field.
- Improve partition metadata collection for both tree-shaped and flat lsblk JSON output so partitions inherit parent disk details.

## Validation
- cargo fmt --all --check
- SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 slint-viewer --check slint-ui/ui/app.slint
- cargo check -p archinstall-zfs-tui
- cargo check -p archinstall-zfs-slint
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- Slint MCP smoke screenshots for Full Disk, New Pool, Existing Pool, and Review flows

## Notes
- The New Pool partition list is intentionally scrollable at 800x600. The rows now have richer metadata, but the view is dense when both EFI and ZFS partition groups are visible.