### PR TITLE
Publish CI-created releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
         name: ${{ env.RELEASE_NAME }}
         body: ${{ env.BODY || '' }}
         generate_release_notes: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        draft: true
+        draft: false
         files: |
           binaries/*
           isos/*.iso


### PR DESCRIPTION
## Summary
- publish releases created by the Build workflow instead of leaving them as drafts

## Context
The scheduled monthly release job passed draft=true to softprops/action-gh-release, so automated releases appeared as drafts.

## Checks
- git diff --check