### PR TITLE
Polish WiFi popup layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,172 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Project Overview
+
+`archinstall_zfs` is an Arch Linux installer focused on ZFS root setups. It has:
+
+- `core/`: shared installer logic, config, ZFS/disk/network/system helpers.
+- `tui/`: ratatui terminal installer.
+- `slint-ui/`: graphical installer built with Slint.
+- `xtask/`: development and QEMU install-test harnesses.
+- `gen_iso/`: Arch ISO profiles and build assets.
+
+The workspace is Rust. Keep changes scoped and prefer existing local patterns over new abstractions.
+
+## Common Commands
+
+Use these before committing unless the change clearly does not require the full set:
+
+```sh
+cargo fmt --all --check
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Useful targeted checks:
+
+```sh
+cargo test -p archinstall-zfs-core prepare
+cargo test -p archinstall-zfs-slint
+cargo check -p archinstall-zfs-slint --no-default-features --features desktop-mock
+```
+
+Real install tests require a built `xtask` and installer binary plus QEMU/KVM:
+
+```sh
+cargo build --release --bin azfs-tui --bin xtask
+just test-install-encrypted-pool --tmpfs --timeout 1800
+```
+
+## Git Workflow
+
+- Work from a feature branch off `main`.
+- Do not revert unrelated local changes.
+- Delete local branches only when they are merged and unrelated to active work.
+- Prefer focused commits with clear messages.
+
+## Wi-Fi Backends
+
+`slint-ui` chooses the core Wi-Fi backend by feature:
+
+- `linuxkms` (default): installer ISO path, Slint Linux KMS backend, `wifi-iwd`.
+- `desktop`: local desktop development path, winit backend, `wifi-nm`.
+- `desktop-mock`: deterministic canned Wi-Fi data, winit backend, `wifi-mock`.
+
+For UI iteration, prefer `desktop-mock` so tests do not depend on host Wi-Fi hardware, iwd, NetworkManager, or real credentials.
+
+## Slint UI Development Loop
+
+When touching `.slint` files, do not rely on compile success alone. Render and interact with the UI yourself.
+
+Recommended agentic loop:
+
+1. Build the app with Slint MCP support and debug info:
+
+   ```sh
+   SLINT_EMIT_DEBUG_INFO=1 cargo build \
+     -p archinstall-zfs-slint \
+     --no-default-features \
+     --features desktop-mock,slint/mcp
+   ```
+
+   `SLINT_EMIT_DEBUG_INFO=1` must be present at build time. Setting it only when running the already-built binary is not enough for MCP element-tree and id lookup.
+
+2. Run the app headlessly with MCP:
+
+   ```sh
+   SLINT_MCP_PORT=9315 SLINT_BACKEND=headless target/debug/azfs
+   ```
+
+   The app should log:
+
+   ```text
+   Slint MCP server listening on http://127.0.0.1:9315/mcp
+   ```
+
+3. Use MCP over HTTP to inspect and drive the UI:
+
+   ```sh
+   curl -s -X POST http://127.0.0.1:9315/mcp \
+     -H 'Content-Type: application/json' \
+     -H 'Accept: application/json, text/event-stream' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_windows","arguments":{}}}'
+   ```
+
+   Useful MCP tools:
+
+   - `list_windows`
+   - `get_window_properties`
+   - `get_element_tree`
+   - `find_elements_by_id`
+   - `query_element_descendants`
+   - `click_element`
+   - `set_element_value`
+   - `dispatch_key_event`
+   - `take_screenshot`
+
+4. Save screenshots and inspect them visually:
+
+   ```sh
+   curl -s -X POST http://127.0.0.1:9315/mcp \
+     -H 'Content-Type: application/json' \
+     -H 'Accept: application/json, text/event-stream' \
+     -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"take_screenshot","arguments":{"windowHandle":{"index":"1","generation":"1"},"imageMimeType":"image/png"}}}' \
+     > /tmp/azfs-screenshot.json
+
+   jq -r '.result.content[] | select(.type=="image") | .data' /tmp/azfs-screenshot.json \
+     | base64 -d > /tmp/azfs-screenshot.png
+   ```
+
+   Then inspect with the local image viewer tool. Do not ask the human to verify basic layout and interaction issues that the agent can verify with screenshots and MCP.
+
+5. Drive realistic flows end to end:
+
+   - Open the Wi-Fi popup from the welcome connectivity pill.
+   - Wait for mock scan results.
+   - Select a secured unknown network and verify password entry.
+   - Set a passphrase with `set_element_value`.
+   - Click `Connect` and wait through connecting/verifying/connected states.
+   - Test enterprise-network error state.
+   - Test `Back`, `Rescan`, `Disconnect`, and known-network `Forget`.
+   - Take screenshots for the important states and inspect for clipping, overlap, off-center icons, missing buttons, and truncated text.
+
+6. After visual and interaction checks, run normal Rust checks:
+
+   ```sh
+   cargo fmt --all --check
+   cargo test --workspace
+   cargo clippy --workspace --all-targets -- -D warnings
+   ```
+
+## Slint Layout Notes
+
+- Use layouts (`VerticalLayout`, `HorizontalLayout`, `GridLayout`) instead of manual positions, except for overlays.
+- A layout with no visible children can still affect sizing if it exists unconditionally. For phase-specific footers, wrap the whole layout in an `if` so it is not allocated in phases that do not need it.
+- Scrollable content should fill the allocated body area. Avoid binding a `ScrollView` preferred height to its content height when the parent is meant to constrain it.
+- Set `clip: true` on body containers where phase-specific content must not draw outside its allocated area.
+- For status icons inside `VerticalLayout`, wrap the icon in a centered `HorizontalLayout` if visual centering matters.
+- Prefer existing shared components such as `StyledButton`, `StyledTextInput`, `Icon`, and `SignalBars`.
+- Keep UI state in Slint globals and async/business logic in Rust controllers.
+
+## Slint MCP Pitfalls
+
+- `slint/mcp` is a Cargo feature. Add it only on the command line for debug runs.
+- `SLINT_MCP_PORT` starts the MCP server at runtime.
+- `SLINT_EMIT_DEBUG_INFO=1` is needed at build time for element ids and tree traversal.
+- If MCP returns errors about `ElementHandle API requires debug info`, rebuild with `SLINT_EMIT_DEBUG_INFO=1`.
+- Window handles and element handles have the same shape but are not interchangeable.
+- Headless screenshots can work even when element-tree lookup is broken; do not mistake screenshot success for full MCP readiness.
+
+## Slint References
+
+The local Slint checkout contains agent docs and deeper MCP documentation:
+
+- `/home/okhsunrog/code/rust/slint/ai-plugins/skills/slint/SKILL.md`
+- `/home/okhsunrog/code/rust/slint/ai-plugins/skills/slint/reference/debugging-and-mcp.md`
+- `/home/okhsunrog/code/rust/slint/ai-plugins/skills/slint/reference/polish.md`
+- `/home/okhsunrog/code/rust/slint/docs/development/mcp-server.md`
+- `/home/okhsunrog/code/rust/slint/docs/astro/src/content/docs/guide/tooling/ai-coding-assistants.mdx`
+
+Read the relevant file before doing non-trivial Slint work.

--- a/slint-ui/ui/popups/wifi-popup.slint
+++ b/slint-ui/ui/popups/wifi-popup.slint
@@ -221,6 +221,7 @@ export component WifiPopup inherits Rectangle {
                 horizontal-stretch: 1;
                 vertical-stretch: 1;
                 background: transparent;
+                clip: true;
 
                 // — scanning / idle — centered spinner —
                 if WifiState.phase == WifiPhase.scanning
@@ -228,13 +229,18 @@ export component WifiPopup inherits Rectangle {
                     alignment: center;
                     spacing: Theme.spacing-md;
 
-                    Icon {
-                        source: @image-url("../../assets/icons/refresh-cw.svg");
-                        size: 28px;
-                        tint: Theme.c.blue;
-                        // Drives the rotation off `animation-tick()` so the
-                        // icon spins continuously while this branch is live.
-                        transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
+                    HorizontalLayout {
+                        height: 28px;
+                        alignment: center;
+
+                        Icon {
+                            source: @image-url("../../assets/icons/refresh-cw.svg");
+                            size: 28px;
+                            tint: Theme.c.blue;
+                            // Drives the rotation off `animation-tick()` so the
+                            // icon spins continuously while this branch is live.
+                            transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
+                        }
                     }
 
                     Text {
@@ -249,7 +255,8 @@ export component WifiPopup inherits Rectangle {
 
                 // — picking — scrollable network list —
                 if WifiState.phase == WifiPhase.picking: ScrollView {
-                    preferred-height: networks-list.preferred-height;
+                    width: 100%;
+                    height: 100%;
                     vertical-stretch: 1;
 
                     networks-list := VerticalLayout {
@@ -500,11 +507,16 @@ export component WifiPopup inherits Rectangle {
                     alignment: center;
                     spacing: Theme.spacing-md;
 
-                    Icon {
-                        source: @image-url("../../assets/icons/refresh-cw.svg");
-                        size: 28px;
-                        tint: Theme.c.blue;
-                        transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
+                    HorizontalLayout {
+                        height: 28px;
+                        alignment: center;
+
+                        Icon {
+                            source: @image-url("../../assets/icons/refresh-cw.svg");
+                            size: 28px;
+                            tint: Theme.c.blue;
+                            transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
+                        }
                     }
 
                     Text {
@@ -524,10 +536,15 @@ export component WifiPopup inherits Rectangle {
                     alignment: center;
                     spacing: Theme.spacing-md;
 
-                    Icon {
-                        source: @image-url("../../assets/icons/check.svg");
-                        size: 36px;
-                        tint: Theme.c.green;
+                    HorizontalLayout {
+                        height: 36px;
+                        alignment: center;
+
+                        Icon {
+                            source: @image-url("../../assets/icons/check.svg");
+                            size: 36px;
+                            tint: Theme.c.green;
+                        }
                     }
 
                     Text {
@@ -551,10 +568,15 @@ export component WifiPopup inherits Rectangle {
                     alignment: center;
                     spacing: Theme.spacing-md;
 
-                    Icon {
-                        source: @image-url("../../assets/icons/x.svg");
-                        size: 36px;
-                        tint: Theme.c.red;
+                    HorizontalLayout {
+                        height: 36px;
+                        alignment: center;
+
+                        Icon {
+                            source: @image-url("../../assets/icons/x.svg");
+                            size: 36px;
+                            tint: Theme.c.red;
+                        }
                     }
 
                     Text {
@@ -577,9 +599,12 @@ export component WifiPopup inherits Rectangle {
             }
 
             // ───────────────── FOOTER (phase-driven buttons) ─────────────────
-            HorizontalLayout {
-                alignment: end;
-                spacing: Theme.spacing-sm;
+            if WifiState.phase == WifiPhase.auth
+                || WifiState.phase == WifiPhase.error
+                || WifiState.phase == WifiPhase.connected: HorizontalLayout {
+                    height: Theme.control-height;
+                    alignment: end;
+                    spacing: Theme.spacing-sm;
 
                 // Auth phase: Cancel + Connect
                 if WifiState.phase == WifiPhase.auth: StyledButton {
@@ -594,10 +619,15 @@ export component WifiPopup inherits Rectangle {
                     clicked => { WifiState.submit-password(); }
                 }
 
-                // Error phase: Back to list + Retry
+                // Error phase: Back to the last list, or run a fresh scan.
                 if WifiState.phase == WifiPhase.error: StyledButton {
                     label: "Back";
                     style: Theme.button-default;
+                    clicked => { WifiState.cancel-pick(); }
+                }
+                if WifiState.phase == WifiPhase.error: StyledButton {
+                    label: "Rescan";
+                    style: Theme.button-primary;
                     clicked => { WifiState.rescan(); }
                 }
 


### PR DESCRIPTION
## Summary
- fix WiFi popup body/footer sizing so the network list no longer draws over the header
- center status icons in scanning, connecting, connected, and error states
- split error actions into Back and Rescan
- add AGENTS.md with project guidance and a Slint MCP/headless screenshot workflow for agent-driven UI iteration

## Verification
- cargo fmt --all --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- Slint MCP headless mock UI flow with screenshots:
  - opened WiFi popup from welcome connectivity pill
  - waited for mock scan results
  - selected secured unknown network, entered password, connected successfully
  - verified connected state screenshot
  - verified known-network Forget does not trigger row connect
  - verified enterprise unsupported error state and Back/Rescan footer

Screenshots were inspected locally under /tmp/azfs-wifi-*.png.

- update: successful installs now show separate Quit and Reboot actions; Quit only closes the GUI, Reboot invokes systemctl reboot.
