### PR TITLE
Fix encrypted boot and protect saved config secrets

### DIFF
--- a/.github/docker/ci/Dockerfile
+++ b/.github/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux@sha256:345a872f6c95e082d4b8c050af637eebb57402c6e2177b411c3acf7df84eb33b
+FROM archlinux@sha256:b0deabeb3d283da2c7f7dbf0eea051b7b2cd0554e0b737cc457fd21683bdcdd1
 
 # Rust build deps: base-devel, pkgconf, clang for C-FFI crates.
 # UI libs: libxkbcommon/libinput/libdrm/freetype2/fontconfig/ttf-dejavu for the slint UI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -285,7 +285,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -563,7 +563,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "v_frame",
  "y4m",
 ]
@@ -3269,7 +3269,7 @@ dependencies = [
  "async-lock",
  "futures-lite",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "uuid",
  "zbus",
  "zvariant",
@@ -3287,7 +3287,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -3362,7 +3362,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3582,7 +3582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7755f08423275157ad1680aaecc9ccb7e0cc633da3240fea2d1522935cc15c72"
 dependencies = [
  "lyon_path",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3689,9 +3689,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minijinja"
-version = "2.22.0"
+version = "2.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef84a52be188a1d4124bd717903fdde96ca4705f2b56adfe2d91fcc57fcb6987"
+checksum = "86886cf6dbf4e614b19c9a1eec9775f021869d7eadde0fc73921a81b90c9b4c9"
 dependencies = [
  "memo-map",
  "serde",
@@ -3750,7 +3750,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "once_cell",
  "png",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -3834,7 +3834,7 @@ dependencies = [
  "futures-timer",
  "log",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "uuid",
  "zbus",
@@ -4960,7 +4960,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -4983,7 +4983,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5126,7 +5126,7 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -5238,7 +5238,7 @@ dependencies = [
  "rand 0.9.5",
  "rand_chacha",
  "simd_helpers",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -6508,11 +6508,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -6528,9 +6528,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6862,7 +6862,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -8012,7 +8012,7 @@ dependencies = [
  "log",
  "os_pipe",
  "rustix 1.1.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -8186,9 +8186,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -8222,14 +8222,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -8244,6 +8244,15 @@ dependencies = [
  "serde",
  "winnow",
  "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8344,7 +8353,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "zeroize",
 ]
@@ -8381,41 +8390,42 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.13.1"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.13.1"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.119",
+ "syn 3.0.3",
  "winnow",
 ]
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ pacman -Sy libxkbcommon libinput freetype2 fontconfig ttf-dejavu
 ### Silent mode (for automation)
 ```bash
 azfs-tui --config config.json --silent
+# If the exported config needs passwords:
+azfs-tui --config config.json --secrets config.secrets.json --silent
 ```
+
+Saved configurations omit the ZFS encryption password, root password, and user
+passwords. The TUI can optionally save those values to a separate JSON file
+with mode `0600`; pass that file with `--secrets` for unattended installs.
+Legacy configuration files containing inline passwords remain supported.
 
 ---
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,12 +28,12 @@ sha2 = "0.11.0"
 sublime_fuzzy.workspace = true
 sysinfo = "0.39.6"
 tar = "0.4.46"
-thiserror = "2.0.19"
+thiserror = "2.0.20"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "io-util", "fs", "sync", "time", "process"] }
 tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-zbus = { version = "5.18.0", default-features = false, features = ["tokio"] }
+zbus = { version = "5.19.0", default-features = false, features = ["tokio"] }
 
 [features]
 # Exactly one wifi backend must be enabled. Consumers (slint-ui, tui)

--- a/core/src/config/io.rs
+++ b/core/src/config/io.rs
@@ -1,11 +1,30 @@
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 
 use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
 
 use super::types::GlobalConfig;
 
 const ZFS_CONFIG_KEY: &str = "archinstall_zfs";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigSecrets {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zfs_encryption_password: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_password: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub users: Vec<UserSecrets>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UserSecrets {
+    pub username: String,
+    pub password: String,
+}
 
 impl GlobalConfig {
     pub fn load_from_file(path: &Path) -> Result<Self> {
@@ -29,14 +48,85 @@ impl GlobalConfig {
     }
 
     pub fn save_to_file(&self, path: &Path) -> Result<()> {
-        let json = self.to_json_string()?;
-        fs::write(path, json)
-            .wrap_err_with(|| format!("failed to write config: {}", path.display()))?;
+        let json = self.to_redacted_json_string()?;
+        write_private_file(path, &json, "config")
+    }
+
+    pub fn save_secrets_to_file(&self, path: &Path) -> Result<()> {
+        let json = serde_json::to_string_pretty(&self.secrets())
+            .wrap_err("failed to serialize config secrets")?;
+        write_private_file(path, &json, "config secrets")
+    }
+
+    pub fn apply_secrets_from_file(&mut self, path: &Path) -> Result<()> {
+        let content = fs::read_to_string(path)
+            .wrap_err_with(|| format!("failed to read config secrets: {}", path.display()))?;
+        let secrets: ConfigSecrets =
+            serde_json::from_str(&content).wrap_err("failed to parse config secrets JSON")?;
+        self.apply_secrets(secrets);
         Ok(())
     }
 
     pub fn to_json_string(&self) -> Result<String> {
         serde_json::to_string_pretty(self).wrap_err("failed to serialize config")
+    }
+
+    pub fn to_redacted_json_string(&self) -> Result<String> {
+        let mut redacted = self.clone();
+        redacted.zfs_encryption_password = None;
+        redacted.root_password = None;
+        if let Some(users) = redacted.users.as_mut() {
+            for user in users {
+                user.password = None;
+            }
+        }
+        redacted.to_json_string()
+    }
+
+    pub fn has_secrets(&self) -> bool {
+        self.zfs_encryption_password.is_some()
+            || self.root_password.is_some()
+            || self
+                .users
+                .as_ref()
+                .is_some_and(|users| users.iter().any(|user| user.password.is_some()))
+    }
+
+    pub fn secrets(&self) -> ConfigSecrets {
+        ConfigSecrets {
+            zfs_encryption_password: self.zfs_encryption_password.clone(),
+            root_password: self.root_password.clone(),
+            users: self
+                .users
+                .iter()
+                .flatten()
+                .filter_map(|user| {
+                    user.password.as_ref().map(|password| UserSecrets {
+                        username: user.username.clone(),
+                        password: password.clone(),
+                    })
+                })
+                .collect(),
+        }
+    }
+
+    pub fn apply_secrets(&mut self, secrets: ConfigSecrets) {
+        if secrets.zfs_encryption_password.is_some() {
+            self.zfs_encryption_password = secrets.zfs_encryption_password;
+        }
+        if secrets.root_password.is_some() {
+            self.root_password = secrets.root_password;
+        }
+        if let Some(users) = self.users.as_mut() {
+            for user_secret in secrets.users {
+                if let Some(user) = users
+                    .iter_mut()
+                    .find(|user| user.username == user_secret.username)
+                {
+                    user.password = Some(user_secret.password);
+                }
+            }
+        }
     }
 
     pub fn to_combined_json(&self) -> Result<String> {
@@ -48,9 +138,32 @@ impl GlobalConfig {
     }
 }
 
+fn write_private_file(path: &Path, contents: &str, description: &str) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(path)
+        .wrap_err_with(|| format!("failed to open {description}: {}", path.display()))?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+        .wrap_err_with(|| format!("failed to secure {description}: {}", path.display()))?;
+    file.set_len(0)
+        .wrap_err_with(|| format!("failed to truncate {description}: {}", path.display()))?;
+    file.write_all(contents.as_bytes())
+        .wrap_err_with(|| format!("failed to write {description}: {}", path.display()))?;
+    file.sync_all()
+        .wrap_err_with(|| format!("failed to sync {description}: {}", path.display()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::config::types::{GlobalConfig, InstallationMode};
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use crate::config::types::{GlobalConfig, InstallationMode, UserConfig};
 
     #[test]
     fn test_load_direct_format() {
@@ -116,5 +229,94 @@ mod tests {
         );
         assert_eq!(loaded.pool_name.as_deref(), Some("roundtrip"));
         assert_eq!(loaded.hostname.as_deref(), Some("testhost"));
+    }
+
+    #[test]
+    fn saved_config_omits_all_passwords_and_is_private() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let cfg = GlobalConfig {
+            zfs_encryption_password: Some("pool-secret".into()),
+            root_password: Some("root-secret".into()),
+            users: Some(vec![UserConfig {
+                username: "alice".into(),
+                password: Some("user-secret".into()),
+                sudo: true,
+                shell: None,
+                groups: None,
+                ssh_authorized_keys: Vec::new(),
+                autologin: false,
+            }]),
+            ..Default::default()
+        };
+
+        fs::write(&path, "old-secret-that-must-be-removed").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        cfg.save_to_file(&path).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(!content.contains("old-secret-that-must-be-removed"));
+        assert!(!content.contains("pool-secret"));
+        assert!(!content.contains("root-secret"));
+        assert!(!content.contains("user-secret"));
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn secrets_file_roundtrip_restores_passwords() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secrets.json");
+        let cfg = GlobalConfig {
+            zfs_encryption_password: Some("pool-secret".into()),
+            root_password: Some("root-secret".into()),
+            users: Some(vec![UserConfig {
+                username: "alice".into(),
+                password: Some("user-secret".into()),
+                sudo: true,
+                shell: None,
+                groups: None,
+                ssh_authorized_keys: Vec::new(),
+                autologin: false,
+            }]),
+            ..Default::default()
+        };
+
+        cfg.save_secrets_to_file(&path).unwrap();
+        let mut redacted = cfg.clone();
+        redacted.zfs_encryption_password = None;
+        redacted.root_password = None;
+        redacted.users.as_mut().unwrap()[0].password = None;
+        redacted.apply_secrets_from_file(&path).unwrap();
+
+        assert_eq!(
+            redacted.zfs_encryption_password.as_deref(),
+            Some("pool-secret")
+        );
+        assert_eq!(redacted.root_password.as_deref(), Some("root-secret"));
+        assert_eq!(
+            redacted.users.unwrap()[0].password.as_deref(),
+            Some("user-secret")
+        );
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn save_refuses_to_follow_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let victim = dir.path().join("victim.json");
+        let link = dir.path().join("config.json");
+        fs::write(&victim, "do not overwrite").unwrap();
+        std::os::unix::fs::symlink(&victim, &link).unwrap();
+
+        let result = GlobalConfig::default().save_to_file(&link);
+
+        assert!(result.is_err());
+        assert_eq!(fs::read_to_string(victim).unwrap(), "do not overwrite");
     }
 }

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -103,6 +103,10 @@ impl Installer {
         tracing::info!(target: "metrics", event = "phase_start", num = 6u32, name = "Installing ZFS packages");
         self.install_zfs_on_target()?;
 
+        // The encrypted pool key must exist in the target before either
+        // initramfs backend tries to embed it in the image.
+        self.prepare_encryption_key()?;
+
         // Phase 7: Initramfs
         tracing::info!("Phase 7: Generating initramfs...");
         tracing::info!(target: "metrics", event = "phase_start", num = 7u32, name = "Generating initramfs");
@@ -220,6 +224,19 @@ impl Installer {
         }
 
         Ok(())
+    }
+
+    fn prepare_encryption_key(&self) -> Result<()> {
+        if !self.config.encryption_enabled() {
+            return Ok(());
+        }
+
+        let password = self
+            .config
+            .zfs_encryption_password
+            .as_deref()
+            .ok_or_else(|| color_eyre::eyre::eyre!("encryption enabled but password missing"))?;
+        crate::zfs_keyfile::write_key_file(&self.target, password)
     }
 
     fn configure_users(&self) -> Result<()> {
@@ -574,18 +591,6 @@ impl Installer {
             Path::new("/mnt"),
         )?;
 
-        // Copy encryption key if needed
-        if self.config.encryption_enabled() {
-            let key_src = crate::zfs_keyfile::key_file_path(Path::new("/"));
-            let key_dst = crate::zfs_keyfile::key_file_path(&self.target);
-            if key_src.exists() {
-                if let Some(parent) = key_dst.parent() {
-                    std::fs::create_dir_all(parent)?;
-                }
-                std::fs::copy(&key_src, &key_dst)?;
-            }
-        }
-
         // zrepl
         if self.config.zrepl_enabled {
             crate::zrepl::setup_zrepl(&self.target, pool_name, prefix)?;
@@ -598,8 +603,9 @@ impl Installer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::types::GlobalConfig;
+    use crate::config::types::{GlobalConfig, ZfsEncryptionMode};
     use crate::system::cmd::tests::RecordingRunner;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn test_installer_validates_config() {
@@ -620,5 +626,51 @@ mod tests {
                 .to_string()
                 .contains("validation failed")
         );
+    }
+
+    #[test]
+    fn prepare_encryption_key_writes_target_key_before_initramfs() {
+        let target = tempfile::tempdir().unwrap();
+        let runner: Arc<dyn CommandRunner> = Arc::new(RecordingRunner::new(vec![]));
+        let config = GlobalConfig {
+            zfs_encryption_mode: ZfsEncryptionMode::Pool,
+            zfs_encryption_password: Some("correct horse battery staple".into()),
+            ..Default::default()
+        };
+        let installer = Installer::new(
+            runner,
+            config,
+            target.path(),
+            CancellationToken::new(),
+            None,
+        );
+
+        installer.prepare_encryption_key().unwrap();
+
+        let key_path = crate::zfs_keyfile::key_file_path(target.path());
+        assert!(key_path.exists());
+        assert_eq!(key_path.metadata().unwrap().permissions().mode() & 0o777, 0);
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o400)).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(key_path).unwrap(),
+            "correct horse battery staple"
+        );
+    }
+
+    #[test]
+    fn prepare_encryption_key_is_noop_without_encryption() {
+        let target = tempfile::tempdir().unwrap();
+        let runner: Arc<dyn CommandRunner> = Arc::new(RecordingRunner::new(vec![]));
+        let installer = Installer::new(
+            runner,
+            GlobalConfig::default(),
+            target.path(),
+            CancellationToken::new(),
+            None,
+        );
+
+        installer.prepare_encryption_key().unwrap();
+
+        assert!(!crate::zfs_keyfile::key_file_path(target.path()).exists());
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -33,6 +33,10 @@ struct Cli {
     #[arg(long, global = true)]
     config: Option<PathBuf>,
 
+    /// Path to a JSON secrets file merged into the configuration
+    #[arg(long, global = true)]
+    secrets: Option<PathBuf>,
+
     #[arg(long, global = true)]
     silent: bool,
 
@@ -58,11 +62,14 @@ async fn main() -> Result<()> {
         }
     }
 
-    let config = if let Some(ref path) = cli.config {
+    let mut config = if let Some(ref path) = cli.config {
         GlobalConfig::load_from_file(path)?
     } else {
         GlobalConfig::default()
     };
+    if let Some(ref path) = cli.secrets {
+        config.apply_secrets_from_file(path)?;
+    }
 
     if cli.silent {
         use color_eyre::eyre::bail;

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -13,12 +13,16 @@ pub async fn run(
     cli: Cli,
     ui_log_rx: tokio::sync::mpsc::UnboundedReceiver<(String, i32)>,
 ) -> Result<()> {
-    let config = if let Some(ref path) = cli.config {
+    let mut config = if let Some(ref path) = cli.config {
         tracing::info!(path = %path.display(), "loading config from file");
         GlobalConfig::load_from_file(path)?
     } else {
         GlobalConfig::default()
     };
+    if let Some(ref path) = cli.secrets {
+        tracing::info!(path = %path.display(), "loading config secrets from file");
+        config.apply_secrets_from_file(path)?;
+    }
 
     if cli.silent {
         if cli.config.is_none() {

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -14,6 +14,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub config: Option<std::path::PathBuf>,
 
+    /// Path to a JSON secrets file merged into the configuration
+    #[arg(long, global = true)]
+    pub secrets: Option<std::path::PathBuf>,
+
     /// Run installation without interactive prompts (requires --config)
     #[arg(long, global = true)]
     pub silent: bool,

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -206,14 +206,60 @@ impl Wizard {
                     if let Some(path) = result.value
                         && !path.is_empty()
                     {
-                        match self.config.save_to_file(std::path::Path::new(&path)) {
-                            Ok(()) => {
-                                let _ =
-                                    run_select(terminal, &format!("Saved to {path}"), &["OK"], 0);
-                            }
-                            Err(e) => {
-                                let msg = format!("Save failed: {e}");
-                                let _ = run_select(terminal, &msg, &["OK"], 0);
+                        let save_secrets = if self.config.has_secrets() {
+                            run_select(
+                                terminal,
+                                "Passwords are omitted from the main config",
+                                &[
+                                    "Save config only",
+                                    "Save passwords to a separate 0600 secrets file",
+                                    "Cancel",
+                                ],
+                                0,
+                            )?
+                            .selected
+                        } else {
+                            Some(0)
+                        };
+
+                        if !matches!(save_secrets, None | Some(2)) {
+                            match self.config.save_to_file(std::path::Path::new(&path)) {
+                                Ok(()) => {
+                                    let mut message =
+                                        format!("Saved config without passwords to {path}");
+                                    if save_secrets == Some(1) {
+                                        let default_secrets_path = format!("{path}.secrets.json");
+                                        let secret_result = run_edit(
+                                            terminal,
+                                            "Save secrets to file (mode 0600)",
+                                            &default_secrets_path,
+                                            false,
+                                        )?;
+                                        if let Some(secret_path) = secret_result.value
+                                            && !secret_path.is_empty()
+                                        {
+                                            match self.config.save_secrets_to_file(
+                                                std::path::Path::new(&secret_path),
+                                            ) {
+                                                Ok(()) => {
+                                                    message.push_str(&format!(
+                                                        "; saved passwords to {secret_path}"
+                                                    ));
+                                                }
+                                                Err(e) => {
+                                                    message.push_str(&format!(
+                                                        "; secrets save failed: {e}"
+                                                    ));
+                                                }
+                                            }
+                                        }
+                                    }
+                                    let _ = run_select(terminal, &message, &["OK"], 0);
+                                }
+                                Err(e) => {
+                                    let msg = format!("Save failed: {e}");
+                                    let _ = run_select(terminal, &msg, &["OK"], 0);
+                                }
                             }
                         }
                     }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 clap.workspace = true
-minijinja = { version = "2.22.0", features = ["builtins"] }
+minijinja = { version = "2.24.0", features = ["builtins"] }
 serde_json.workspace = true


### PR DESCRIPTION
Encrypted installs generated the target initramfs before provisioning the ZFS key, while saved installer configurations serialized every password in plaintext. This fixes both paths, keeps legacy inline-secret configs readable, and refreshes the dependency stack used by the installer and CI.

- Provision the target ZFS key before dracut or mkinitcpio builds the initramfs.
- Export the main configuration without ZFS, root, or user passwords.
- Add a separate mode-0600 secrets file and `--secrets` support for unattended installs.
- Refuse symlink targets when saving configuration or secrets files.
- Prompt explicitly in the TUI before writing a separate secrets file.
- Update thiserror, zbus, minijinja, nixpkgs, and the pinned Arch Linux CI image digest.

Testing

- Encrypted pool installation and boot in QEMU; verified the pool online and SSH active.

Closes #61
Closes #49