### PR TITLE
Add safe LinuxKMS demo and installer cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "zfskit",
  "zxcvbn",
 ]
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Key improvements over the Python version:
 - **No external package manager binaries** needed at runtime (no `pacman`, `pacstrap`, `yay`)
 - **Proper AUR dependency resolution** via `raur` + `aur-depends` crates
 - **Cancellable installation** with graceful cleanup
+- **Safe LinuxKMS demo** for real input, cursor, Wi-Fi, disk, and read-only ZFS testing
 - **Trace-level file logging** (`/tmp/archinstall-zfs.log`) for post-mortem analysis
 
 ### Screenshots
@@ -59,6 +60,21 @@ azfs-tui
 ```
 
 > Why recommended: the ISO already contains ZFS components and both installers, so startup is faster and avoids on-the-fly package installation.
+
+### Safe LinuxKMS UI demo
+
+The ISO boot menu also offers **Arch Linux installer — safe LinuxKMS demo**.
+It runs the same Linux KMS, software Skia, libinput, cursor, touchpad, and iwd
+paths as the real graphical installer, while disabling installation and every
+destructive storage operation. Disks and partitions remain visible and every
+configuration step can be exercised.
+
+The demo can discover ZFS pools and explicitly import one for inspection with
+`zpool import -N -o readonly=on -o cachefile=none`. It never mounts datasets,
+verifies the pool's `readonly` property after import, and exports only pools
+that were imported by the current demo session. Those pools are exported when
+the user requests it and again during normal application shutdown. The same
+mode can be selected manually with `azfs --demo`.
 
 ### Option B: Official Arch ISO
 ```bash

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -125,6 +125,9 @@ pub async fn install_and_generate_zbm(
         download_config,
     )
     .await?;
+    if cancel.is_cancelled() {
+        color_eyre::eyre::bail!("installation cancelled");
+    }
 
     // 2-5. Sync operations: config, hooks, generate-zbm, copy EFI
     let r = runner;

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -66,6 +66,7 @@ impl Installer {
         if !errors.is_empty() {
             bail!("Config validation failed:\n  {}", errors.join("\n  "));
         }
+        self.ensure_not_cancelled()?;
 
         // Phase 4: install base system via libalpm
         tracing::info!("Phase 4: Installing base system...");
@@ -78,6 +79,7 @@ impl Installer {
             self.download_progress_tx.clone(),
         )?;
         self._target_mounts = Some(target_mounts);
+        self.ensure_not_cancelled()?;
 
         // Create a reusable AlpmContext for all subsequent package installs.
         // The target now has pacman.conf, keyring, and mirrorlist from finalize_target().
@@ -92,16 +94,19 @@ impl Installer {
         )?;
         ctx.sync_databases(false)?;
         self.alpm_ctx = Some(ctx);
+        self.ensure_not_cancelled()?;
 
         // Phase 5: System config
         tracing::info!("Phase 5: Configuring system...");
         tracing::info!(target: "metrics", event = "phase_start", num = 5u32, name = "Configuring system");
         self.configure_system()?;
+        self.ensure_not_cancelled()?;
 
         // Phase 6: archzfs repo on target + ZFS packages
         tracing::info!("Phase 6: Installing ZFS packages on target...");
         tracing::info!(target: "metrics", event = "phase_start", num = 6u32, name = "Installing ZFS packages");
         self.install_zfs_on_target()?;
+        self.ensure_not_cancelled()?;
 
         // The encrypted pool key must exist in the target before either
         // initramfs backend tries to embed it in the image.
@@ -111,32 +116,44 @@ impl Installer {
         tracing::info!("Phase 7: Generating initramfs...");
         tracing::info!(target: "metrics", event = "phase_start", num = 7u32, name = "Generating initramfs");
         self.generate_initramfs()?;
+        self.ensure_not_cancelled()?;
 
         // Phase 8: Users + authentication
         tracing::info!("Phase 8: Configuring users...");
         tracing::info!(target: "metrics", event = "phase_start", num = 8u32, name = "Configuring users");
         self.configure_users()?;
+        self.ensure_not_cancelled()?;
 
         // Phase 9: Profile packages + services
         tracing::info!("Phase 9: Installing profile packages...");
         tracing::info!(target: "metrics", event = "phase_start", num = 9u32, name = "Installing profile packages");
         self.install_profile()?;
+        self.ensure_not_cancelled()?;
 
         // Phase 10: Additional packages + AUR
         tracing::info!("Phase 10: Installing additional packages...");
         tracing::info!(target: "metrics", event = "phase_start", num = 10u32, name = "Installing additional packages");
         self.install_additional_packages()?;
+        self.ensure_not_cancelled()?;
 
         // Phase 11: Swap configuration
         tracing::info!("Phase 11: Configuring swap...");
         tracing::info!(target: "metrics", event = "phase_start", num = 11u32, name = "Configuring swap");
         self.configure_swap()?;
+        self.ensure_not_cancelled()?;
 
         // Phase 12: ZFS services + genfstab + misc files
         tracing::info!("Phase 12: Finalizing ZFS configuration...");
         tracing::info!(target: "metrics", event = "phase_start", num = 12u32, name = "Finalizing ZFS configuration");
         self.finalize_zfs()?;
 
+        Ok(())
+    }
+
+    fn ensure_not_cancelled(&self) -> Result<()> {
+        if self.cancel.is_cancelled() {
+            bail!("installation cancelled");
+        }
         Ok(())
     }
 
@@ -626,6 +643,22 @@ mod tests {
                 .to_string()
                 .contains("validation failed")
         );
+    }
+
+    #[test]
+    fn cancelled_installer_stops_before_first_operation() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let runner: Arc<dyn CommandRunner> = Arc::new(RecordingRunner::new(vec![]));
+        let installer = Installer::new(
+            runner,
+            GlobalConfig::default(),
+            Path::new("/mnt"),
+            cancel,
+            None,
+        );
+
+        assert!(installer.ensure_not_cancelled().is_err());
     }
 
     #[test]

--- a/core/src/zfs_cleanup.rs
+++ b/core/src/zfs_cleanup.rs
@@ -7,6 +7,15 @@
 
 use color_eyre::eyre::Result;
 
+/// Whether `pool_name` is currently imported. Used to avoid exporting a pool
+/// that was already owned by the live environment before the installer ran.
+pub async fn pool_is_imported(pool_name: &str) -> Result<bool> {
+    let pools = zfskit::Zfs::new()
+        .list_pools(&zfskit::pool::ListOptions::default())
+        .await?;
+    Ok(pools.iter().any(|pool| pool.name == pool_name))
+}
+
 /// Sequence used by both the TUI and Slint install pipelines: try to unmount
 /// everything, then export the pool. Each unmount attempt is best-effort and
 /// followed by a `sync(2)` and a 1-second sleep — old behavior carried from
@@ -22,9 +31,9 @@ use color_eyre::eyre::Result;
 /// After unmount attempts, `zpool export` with a `-f` retry on failure.
 ///
 /// Errors from individual ZFS commands are intentionally swallowed; only the
-/// final export's failure mode is retried with force, and even that's
-/// best-effort. The function returns `Ok` regardless of pool state at the end
-/// — the kernel sync calls themselves do error-bubble.
+/// final export's failure mode is retried with force. Failure of the forced
+/// export is returned to the caller: reporting successful cleanup while the
+/// installer-owned pool remains imported would be unsafe.
 pub async fn cleanup_pool_after_install(pool_name: &str, root_dataset: &str) -> Result<()> {
     let zfs = zfskit::Zfs::new();
     let root_handle = zfs.dataset(root_dataset)?;
@@ -56,9 +65,8 @@ pub async fn cleanup_pool_after_install(pool_name: &str, root_dataset: &str) -> 
         .is_err()
     {
         tracing::warn!("zpool export failed, trying force");
-        let _ = pool
-            .export(&zfskit::pool::ExportOptions { force: true })
-            .await;
+        pool.export(&zfskit::pool::ExportOptions { force: true })
+            .await?;
     }
 
     Ok(())

--- a/gen_iso/profile/efiboot/loader/entries/02-archiso-linux-safe-demo.conf.j2
+++ b/gen_iso/profile/efiboot/loader/entries/02-archiso-linux-safe-demo.conf.j2
@@ -1,0 +1,5 @@
+title    Arch Linux installer — safe LinuxKMS demo (%ARCH%, UEFI)
+sort-key 02
+linux    /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-{{ kernel }}
+initrd   /%INSTALL_DIR%/boot/%ARCH%/initramfs-{{ kernel }}.img
+options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% archinstall_zfs.demo=1{% if fast_build %} console=tty0 console=ttyS0,115200{% endif %}

--- a/gen_iso/profile/grub/grub.cfg.j2
+++ b/gen_iso/profile/grub/grub.cfg.j2
@@ -50,6 +50,12 @@ menuentry "Arch Linux install medium (%ARCH%, ${archiso_platform})" --class arch
 initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-{{ kernel }}.img
 }
 
+menuentry "Arch Linux installer — safe LinuxKMS demo (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe-demo' {
+    set gfxpayload=keep
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-{{ kernel }} archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% archinstall_zfs.demo=1{% if fast_build %} console=tty0 console=ttyS0,115200{% endif %}
+initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-{{ kernel }}.img
+}
+
 menuentry "Arch Linux install medium with speakup screen reader (%ARCH%, ${archiso_platform})" --hotkey s --class arch --class gnu-linux --class gnu --class os --id 'archlinux-accessibility' {
     set gfxpayload=keep
     linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-{{ kernel }} archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on{% if fast_build %} console=tty0 console=ttyS0,115200{% endif %}

--- a/gen_iso/profile/syslinux/archiso_sys-linux.cfg.j2
+++ b/gen_iso/profile/syslinux/archiso_sys-linux.cfg.j2
@@ -8,6 +8,15 @@ LINUX /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-{{ kernel }}
 INITRD /%INSTALL_DIR%/boot/%ARCH%/initramfs-{{ kernel }}.img
 APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID%{% if fast_build %} console=tty0 console=ttyS0,115200{% endif %}
 
+LABEL arch-demo
+TEXT HELP
+Boot the real LinuxKMS installer UI with destructive storage operations disabled.
+ENDTEXT
+MENU LABEL Arch Linux installer - safe LinuxKMS ^demo (%ARCH%, BIOS)
+LINUX /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-{{ kernel }}
+INITRD /%INSTALL_DIR%/boot/%ARCH%/initramfs-{{ kernel }}.img
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% archinstall_zfs.demo=1{% if fast_build %} console=tty0 console=ttyS0,115200{% endif %}
+
 # Accessibility boot option
 LABEL archspeech
 TEXT HELP

--- a/slint-ui/Cargo.toml
+++ b/slint-ui/Cargo.toml
@@ -54,6 +54,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
+zfskit = "0.2.0"
 zxcvbn.workspace = true
 
 [build-dependencies]

--- a/slint-ui/src/controllers/demo.rs
+++ b/slint-ui/src/controllers/demo.rs
@@ -1,0 +1,269 @@
+//! Safe LinuxKMS demo session: read-only ZFS inventory and explicitly
+//! read-only imports. The session owns only pools it imported itself and
+//! exports those pools on request and on every process exit path.
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::process::Command;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use color_eyre::eyre::{Result, bail};
+use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
+use zfskit::dataset::ListOptions as DatasetListOptions;
+use zfskit::pool::ListOptions as PoolListOptions;
+
+use archinstall_zfs_core::config::types::GlobalConfig;
+
+use crate::refresh::refresh_items;
+use crate::ui::{App, DemoDataset, DemoPool, DemoState};
+
+#[derive(Default)]
+pub struct DemoSession {
+    owned_pools: Mutex<HashSet<String>>,
+}
+
+impl DemoSession {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    async fn inventory(&self) -> Result<(Vec<DemoPool>, Vec<DemoDataset>)> {
+        let zfs = zfskit::Zfs::new();
+        let imported = zfs.list_pools(&PoolListOptions::default()).await?;
+        let discovered = zfs.discover_importable_pools().await?;
+        let owned = self.owned_pools.lock().unwrap().clone();
+
+        let mut seen = HashSet::new();
+        let mut pools = Vec::new();
+        for pool in imported {
+            seen.insert(pool.name.clone());
+            pools.push(DemoPool {
+                owned: owned.contains(&pool.name),
+                name: pool.name.into(),
+                state: pool.state.into(),
+                imported: true,
+            });
+        }
+        for pool in discovered {
+            if seen.insert(pool.name.clone()) {
+                pools.push(DemoPool {
+                    name: pool.name.into(),
+                    state: pool.state.into(),
+                    imported: false,
+                    owned: false,
+                });
+            }
+        }
+        pools.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+
+        let datasets = zfs
+            .list_datasets(&DatasetListOptions {
+                recursive: true,
+                ..Default::default()
+            })
+            .await?
+            .into_iter()
+            .map(|dataset| DemoDataset {
+                name: dataset.name.into(),
+                kind: format!("{:?}", dataset.kind).to_lowercase().into(),
+            })
+            .collect();
+
+        Ok((pools, datasets))
+    }
+
+    async fn import_readonly(&self, pool_name: &str) -> Result<()> {
+        // Parse and validate before handing the name to a subprocess. No shell
+        // is involved, but accepting only a valid ZFS pool name also keeps the
+        // owned-pool cleanup set trustworthy.
+        let zfs = zfskit::Zfs::new();
+        let _ = zfs.pool(pool_name)?;
+        let name = pool_name.to_string();
+        let output = tokio::task::spawn_blocking(move || {
+            Command::new("zpool")
+                .args(readonly_import_args(&name))
+                .output()
+        })
+        .await??;
+        if !output.status.success() {
+            bail!(
+                "read-only import failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        self.owned_pools
+            .lock()
+            .unwrap()
+            .insert(pool_name.to_string());
+
+        let name = pool_name.to_string();
+        let verification = tokio::task::spawn_blocking(move || {
+            Command::new("zpool")
+                .args(["get", "-H", "-o", "value", "readonly", &name])
+                .output()
+        })
+        .await??;
+        if !verification.status.success()
+            || String::from_utf8_lossy(&verification.stdout).trim() != "on"
+        {
+            let _ = self.export_owned(pool_name).await;
+            bail!("pool did not report readonly=on after import");
+        }
+        Ok(())
+    }
+
+    async fn export_owned(&self, pool_name: &str) -> Result<()> {
+        let is_owned = self.owned_pools.lock().unwrap().contains(pool_name);
+        if !is_owned {
+            bail!("refusing to export a pool not imported by this demo session");
+        }
+        zfskit::Zfs::new()
+            .pool(pool_name)?
+            .export(&zfskit::pool::ExportOptions::default())
+            .await?;
+        self.owned_pools.lock().unwrap().remove(pool_name);
+        Ok(())
+    }
+
+    pub fn export_all_blocking(&self) {
+        let pools: Vec<String> = self.owned_pools.lock().unwrap().iter().cloned().collect();
+        for pool in pools {
+            let output = Command::new("zpool").args(["export", &pool]).output();
+            match output {
+                Ok(output) if output.status.success() => {
+                    self.owned_pools.lock().unwrap().remove(&pool);
+                }
+                Ok(output) => tracing::error!(
+                    pool,
+                    stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                    "failed to export demo-owned pool"
+                ),
+                Err(error) => tracing::error!(pool, %error, "failed to run zpool export"),
+            }
+        }
+    }
+}
+
+fn readonly_import_args(pool_name: &str) -> [&str; 7] {
+    [
+        "import",
+        "-N",
+        "-o",
+        "readonly=on",
+        "-o",
+        "cachefile=none",
+        pool_name,
+    ]
+}
+
+impl Drop for DemoSession {
+    fn drop(&mut self) {
+        self.export_all_blocking();
+    }
+}
+
+pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, session: &Arc<DemoSession>) {
+    app.global::<DemoState>().set_enabled(true);
+
+    let weak = app.as_weak();
+    let session_for_refresh = session.clone();
+    app.global::<DemoState>().on_refresh(move || {
+        refresh_async(&weak, session_for_refresh.clone(), None);
+    });
+
+    let weak = app.as_weak();
+    let session_for_import = session.clone();
+    app.global::<DemoState>()
+        .on_import_readonly(move |pool_name| {
+            refresh_async(
+                &weak,
+                session_for_import.clone(),
+                Some(DemoAction::Import(pool_name.to_string())),
+            );
+        });
+
+    let weak = app.as_weak();
+    let session_for_export = session.clone();
+    app.global::<DemoState>().on_export_pool(move |pool_name| {
+        refresh_async(
+            &weak,
+            session_for_export.clone(),
+            Some(DemoAction::Export(pool_name.to_string())),
+        );
+    });
+
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    app.global::<DemoState>().on_select_pool(move |pool_name| {
+        let Some(app) = weak.upgrade() else { return };
+        cfg.borrow_mut().pool_name = Some(pool_name.to_string());
+        refresh_items(&app, &cfg.borrow());
+        app.global::<DemoState>()
+            .set_status(SharedString::from(format!(
+                "Selected pool {pool_name} for configuration"
+            )));
+    });
+}
+
+enum DemoAction {
+    Import(String),
+    Export(String),
+}
+
+fn refresh_async(weak: &slint::Weak<App>, session: Arc<DemoSession>, action: Option<DemoAction>) {
+    let weak = weak.clone();
+    if let Some(app) = weak.upgrade() {
+        app.global::<DemoState>().set_busy(true);
+        app.global::<DemoState>()
+            .set_status("Refreshing ZFS inventory...".into());
+    }
+    tokio::spawn(async move {
+        let action_result = match action {
+            Some(DemoAction::Import(pool)) => session.import_readonly(&pool).await,
+            Some(DemoAction::Export(pool)) => session.export_owned(&pool).await,
+            None => Ok(()),
+        };
+        let inventory = match action_result {
+            Ok(()) => session.inventory().await,
+            Err(error) => Err(error),
+        };
+        let _ = weak.upgrade_in_event_loop(move |app| {
+            let state = app.global::<DemoState>();
+            state.set_busy(false);
+            match inventory {
+                Ok((pools, datasets)) => {
+                    let pool_count = pools.len();
+                    let dataset_count = datasets.len();
+                    state.set_pools(ModelRc::new(VecModel::from(pools)));
+                    state.set_datasets(ModelRc::new(VecModel::from(datasets)));
+                    state.set_status(
+                        format!("{pool_count} pool(s), {dataset_count} dataset(s)").into(),
+                    );
+                }
+                Err(error) => state.set_status(format!("ZFS inventory failed: {error}").into()),
+            }
+        });
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::readonly_import_args;
+
+    #[test]
+    fn readonly_import_arguments_are_explicit() {
+        assert_eq!(
+            readonly_import_args("tank"),
+            [
+                "import",
+                "-N",
+                "-o",
+                "readonly=on",
+                "-o",
+                "cachefile=none",
+                "tank",
+            ]
+        );
+    }
+}

--- a/slint-ui/src/controllers/install.rs
+++ b/slint-ui/src/controllers/install.rs
@@ -4,12 +4,14 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::thread;
 
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use archinstall_zfs_core::config::types::GlobalConfig;
 use archinstall_zfs_core::system::async_download::{PackageProgress, PackageState};
+use tokio_util::sync::CancellationToken;
 
 use crate::format::{format_duration, format_speed, truncate_str};
 use crate::install;
@@ -18,11 +20,29 @@ use crate::ui::{App, DownloadInfo, InstallState, LogMessage, WizardState};
 
 const MAX_LOG_LINES: usize = 2000;
 
-pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
+pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, demo: bool) {
+    let active_cancel = Arc::new(Mutex::new(None::<CancellationToken>));
+
+    let weak = app.as_weak();
+    let cancel_slot = active_cancel.clone();
+    app.on_cancel_requested(move || {
+        let Some(app) = weak.upgrade() else { return };
+        if let Some(token) = cancel_slot.lock().unwrap().as_ref() {
+            token.cancel();
+            app.global::<InstallState>().set_state(4);
+        }
+    });
+
     let weak = app.as_weak();
     let cfg = config.clone();
+    let cancel_slot = active_cancel;
     app.on_install_requested(move || {
         let Some(app) = weak.upgrade() else { return };
+        if !installation_allowed(demo) {
+            app.global::<WizardState>()
+                .set_status_text("Installation is disabled in safe demo mode".into());
+            return;
+        }
         let c = cfg.borrow().clone();
 
         let errors = c.validate_for_install();
@@ -44,8 +64,14 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
         let download_tx = Arc::new(download_tx);
         spawn_download_pump(&app, download_rx);
 
-        spawn_install_thread(&app, c, log_tx, download_tx);
+        let cancel = CancellationToken::new();
+        *cancel_slot.lock().unwrap() = Some(cancel.clone());
+        spawn_install_thread(&app, c, log_tx, download_tx, cancel, cancel_slot.clone());
     });
+}
+
+fn installation_allowed(demo: bool) -> bool {
+    !demo
 }
 
 fn spawn_log_pump(app: &App, log_rx: crossbeam_channel::Receiver<(String, i32)>) {
@@ -226,6 +252,8 @@ fn spawn_install_thread(
     config: GlobalConfig,
     log_tx: crossbeam_channel::Sender<(String, i32)>,
     download_tx: Arc<tokio::sync::watch::Sender<PackageProgress>>,
+    cancel: CancellationToken,
+    cancel_slot: Arc<Mutex<Option<CancellationToken>>>,
 ) {
     let weak = app.as_weak();
     tokio::task::spawn_blocking(move || {
@@ -258,11 +286,29 @@ fn spawn_install_thread(
 
         let runner: Arc<dyn archinstall_zfs_core::system::cmd::CommandRunner> =
             Arc::new(archinstall_zfs_core::system::cmd::RealRunner);
-        let result = install::run_install(runner, &config, Some(download_tx));
+        let result = install::run_install(runner, &config, cancel.clone(), Some(download_tx));
 
-        let state = if result.is_ok() { 2 } else { 3 };
+        let state = if result.is_ok() {
+            2
+        } else if cancel.is_cancelled() {
+            5
+        } else {
+            3
+        };
+        *cancel_slot.lock().unwrap() = None;
         let _ = weak.upgrade_in_event_loop(move |app| {
             app.global::<InstallState>().set_state(state);
         });
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::installation_allowed;
+
+    #[test]
+    fn safe_demo_cannot_start_installation() {
+        assert!(!installation_allowed(true));
+        assert!(installation_allowed(false));
+    }
 }

--- a/slint-ui/src/controllers/mod.rs
+++ b/slint-ui/src/controllers/mod.rs
@@ -1,3 +1,4 @@
+pub mod demo;
 pub mod install;
 pub mod lists;
 pub mod quit;

--- a/slint-ui/src/controllers/quit.rs
+++ b/slint-ui/src/controllers/quit.rs
@@ -1,20 +1,46 @@
-//! Quit / reboot handler. If the install completed successfully (state == 2)
-//! and the user clicks Reboot, exec `systemctl reboot` after hiding the window.
+//! Separate quit and reboot handlers. Quitting after a successful install must
+//! leave the live environment running so the user can inspect or copy files.
 
 use slint::ComponentHandle;
 
-use crate::ui::{App, InstallState};
+use crate::ui::{App, DemoState, InstallState};
 
 pub fn setup(app: &App) {
     let weak = app.as_weak();
+    app.window().on_close_requested(move || {
+        let Some(app) = weak.upgrade() else {
+            return slint::CloseRequestResponse::HideWindow;
+        };
+        if app.global::<DemoState>().get_busy() {
+            app.global::<DemoState>()
+                .set_status("Wait for the current ZFS operation before quitting".into());
+            return slint::CloseRequestResponse::KeepWindowShown;
+        }
+        if matches!(app.global::<InstallState>().get_state(), 1 | 4) {
+            app.invoke_cancel_requested();
+            slint::CloseRequestResponse::KeepWindowShown
+        } else {
+            slint::CloseRequestResponse::HideWindow
+        }
+    });
+
+    let weak = app.as_weak();
     app.on_quit_requested(move || {
         let Some(app) = weak.upgrade() else { return };
-        let should_reboot = app.global::<InstallState>().get_state() == 2;
-        let _ = app.window().hide();
-        if should_reboot {
-            let _ = std::process::Command::new("systemctl")
-                .arg("reboot")
-                .spawn();
+        if app.global::<DemoState>().get_busy() {
+            app.global::<DemoState>()
+                .set_status("Wait for the current ZFS operation before quitting".into());
+            return;
         }
+        let _ = app.window().hide();
+    });
+
+    let weak = app.as_weak();
+    app.on_reboot_requested(move || {
+        let Some(app) = weak.upgrade() else { return };
+        let _ = app.window().hide();
+        let _ = std::process::Command::new("systemctl")
+            .arg("reboot")
+            .spawn();
     });
 }

--- a/slint-ui/src/controllers/welcome.rs
+++ b/slint-ui/src/controllers/welcome.rs
@@ -41,8 +41,8 @@ impl KernelScan {
     }
 }
 
-pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &KernelScan) {
-    run_initial_checks(app, config, kernel_scan);
+pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &KernelScan, demo: bool) {
+    run_initial_checks(app, config, kernel_scan, demo);
 
     let weak = app.as_weak();
     let cfg = config.clone();
@@ -52,7 +52,8 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &Kernel
         let net = archinstall_zfs_core::system::net::check_internet();
         app.global::<WelcomeState>().set_net_ok(net);
         if net {
-            if !app.global::<WelcomeState>().get_zfs_ok()
+            if !demo
+                && !app.global::<WelcomeState>().get_zfs_ok()
                 && !app.global::<WelcomeState>().get_zfs_installing()
             {
                 start_zfs_init(&app, &cfg.borrow());
@@ -64,13 +65,24 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &Kernel
     });
 }
 
-fn run_initial_checks(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &KernelScan) {
+fn run_initial_checks(
+    app: &App,
+    config: &Rc<RefCell<GlobalConfig>>,
+    kernel_scan: &KernelScan,
+    demo: bool,
+) {
     let net = archinstall_zfs_core::system::net::check_internet();
     let uefi = archinstall_zfs_core::system::sysinfo::has_uefi();
-    let zfs_mod = archinstall_zfs_core::zfs_setup::check_zfs_module(
+    let mut zfs_mod = archinstall_zfs_core::zfs_setup::check_zfs_module(
         &archinstall_zfs_core::system::cmd::RealRunner,
     )
     .unwrap_or(false);
+    if demo && !zfs_mod {
+        zfs_mod = archinstall_zfs_core::zfs_setup::load_zfs_module(
+            &archinstall_zfs_core::system::cmd::RealRunner,
+        )
+        .unwrap_or(false);
+    }
     let zfs_utils = archinstall_zfs_core::zfs_setup::check_zfs_utils(
         &archinstall_zfs_core::system::cmd::RealRunner,
     )
@@ -83,7 +95,7 @@ fn run_initial_checks(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan
     welcome.set_zfs_ok(zfs_mod && zfs_utils);
 
     if net {
-        if !(zfs_mod && zfs_utils) {
+        if !demo && !(zfs_mod && zfs_utils) {
             start_zfs_init(app, &config.borrow());
         }
         start_kernel_scan(kernel_scan);

--- a/slint-ui/src/install.rs
+++ b/slint-ui/src/install.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use color_eyre::eyre::{Result, eyre};
+use color_eyre::eyre::{Result, bail, eyre};
 use tokio_util::sync::CancellationToken;
 
 use archinstall_zfs_core::config::types::{GlobalConfig, SwapMode};
@@ -13,9 +13,9 @@ use archinstall_zfs_core::system::cmd::CommandRunner;
 pub fn run_install(
     runner: Arc<dyn CommandRunner>,
     config: &GlobalConfig,
+    cancel: CancellationToken,
     download_progress_tx: Option<Arc<tokio::sync::watch::Sender<DownloadProgress>>>,
 ) -> Result<()> {
-    let cancel = CancellationToken::new();
     let rt = tokio::runtime::Handle::current();
     let mountpoint = PathBuf::from("/mnt");
     let pool_name = config
@@ -23,85 +23,120 @@ pub fn run_install(
         .as_deref()
         .ok_or_else(|| eyre!("pool name not set"))?;
     let prefix = &config.dataset_prefix;
-
-    // Phase 0 checks (internet, UEFI, ZFS) are done on the welcome screen.
-
-    tracing::info!("Phase 1: Disk preparation");
-    tracing::info!(target: "metrics", event = "phase_start", num = 1u32, name = "Disk preparation");
-    let parts = archinstall_zfs_core::prepare::prepare_disk(&*runner, config)?;
-    let efi_partition = parts.efi;
-    let zfs_partition = parts.zfs;
-    let swap_partition = parts.swap;
-
-    tracing::info!("Phase 2: ZFS pool and datasets");
-    tracing::info!(target: "metrics", event = "phase_start", num = 2u32, name = "ZFS pool and datasets");
-    rt.block_on(archinstall_zfs_core::prepare::prepare_zfs(
-        &*runner,
-        config,
-        zfs_partition.as_deref(),
-        &mountpoint,
-    ))?;
-
-    tracing::info!("Phase 3: Mounting EFI partition");
-    tracing::info!(target: "metrics", event = "phase_start", num = 3u32, name = "Mounting EFI partition");
-    archinstall_zfs_core::disk::partition::mount_efi(&*runner, &efi_partition, &mountpoint)?;
-
-    tracing::info!("Phase 4-12: Running installer pipeline");
-    let mut installer = archinstall_zfs_core::installer::Installer::new(
-        runner.clone(),
-        config.clone(),
-        &mountpoint,
-        cancel.clone(),
-        download_progress_tx,
-    );
-    if let Some(swap) = swap_partition {
-        installer.set_swap_partition(swap);
-    }
-    installer.perform_installation()?;
-
-    // TRIM strategy: post-install ZFS-side configuration (no Alpm involved).
-    rt.block_on(archinstall_zfs_core::zfs_trim::configure_zfs_trim(
-        &*runner,
-        &mountpoint,
-        pool_name,
-        config,
-    ))?;
-
-    tracing::info!("Phase 13: Setting up ZFSBootMenu");
-    tracing::info!(target: "metrics", event = "phase_start", num = 13u32, name = "Setting up ZFSBootMenu");
-    let zswap_on = matches!(
-        config.swap_mode,
-        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-    );
-    rt.block_on(archinstall_zfs_core::bootmenu::set_zbm_properties(
-        pool_name,
-        prefix,
-        config.init_system,
-        zswap_on,
-        config.set_bootfs,
-    ))?;
-    rt.block_on(archinstall_zfs_core::bootmenu::install_and_generate_zbm(
-        runner.clone(),
-        &mountpoint,
-        config.init_system,
-        &cancel,
-        archinstall_zfs_core::system::async_download::DownloadConfig {
-            concurrency: config.parallel_downloads as usize,
-            ..Default::default()
-        },
-    ))?;
-    archinstall_zfs_core::bootmenu::create_efi_entries(&*runner, &efi_partition)?;
-
-    tracing::info!("Phase 14: Cleanup");
-    tracing::info!(target: "metrics", event = "phase_start", num = 14u32, name = "Cleanup");
-    nix::unistd::sync();
     let root_ds_full = format!("{pool_name}/{prefix}/root");
-    archinstall_zfs_core::disk::partition::umount_efi(&*runner, &mountpoint)?;
+    let pool_was_imported = rt
+        .block_on(archinstall_zfs_core::zfs_cleanup::pool_is_imported(
+            pool_name,
+        ))
+        .unwrap_or(true);
+    let mut pool_setup_started = false;
+    let mut efi_mounted = false;
 
-    rt.block_on(
-        archinstall_zfs_core::zfs_cleanup::cleanup_pool_after_install(pool_name, &root_ds_full),
-    )?;
+    let result = (|| -> Result<()> {
+        ensure_not_cancelled(&cancel)?;
 
+        // Phase 0 checks (internet, UEFI, ZFS) are done on the welcome screen.
+
+        tracing::info!("Phase 1: Disk preparation");
+        tracing::info!(target: "metrics", event = "phase_start", num = 1u32, name = "Disk preparation");
+        let parts = archinstall_zfs_core::prepare::prepare_disk(&*runner, config)?;
+        let efi_partition = parts.efi;
+        let zfs_partition = parts.zfs;
+        let swap_partition = parts.swap;
+
+        ensure_not_cancelled(&cancel)?;
+        tracing::info!("Phase 2: ZFS pool and datasets");
+        tracing::info!(target: "metrics", event = "phase_start", num = 2u32, name = "ZFS pool and datasets");
+        pool_setup_started = true;
+        rt.block_on(archinstall_zfs_core::prepare::prepare_zfs(
+            &*runner,
+            config,
+            zfs_partition.as_deref(),
+            &mountpoint,
+        ))?;
+
+        ensure_not_cancelled(&cancel)?;
+        tracing::info!("Phase 3: Mounting EFI partition");
+        tracing::info!(target: "metrics", event = "phase_start", num = 3u32, name = "Mounting EFI partition");
+        archinstall_zfs_core::disk::partition::mount_efi(&*runner, &efi_partition, &mountpoint)?;
+        efi_mounted = true;
+
+        tracing::info!("Phase 4-12: Running installer pipeline");
+        let mut installer = archinstall_zfs_core::installer::Installer::new(
+            runner.clone(),
+            config.clone(),
+            &mountpoint,
+            cancel.clone(),
+            download_progress_tx,
+        );
+        if let Some(swap) = swap_partition {
+            installer.set_swap_partition(swap);
+        }
+        installer.perform_installation()?;
+
+        ensure_not_cancelled(&cancel)?;
+        // TRIM strategy: post-install ZFS-side configuration (no Alpm involved).
+        rt.block_on(archinstall_zfs_core::zfs_trim::configure_zfs_trim(
+            &*runner,
+            &mountpoint,
+            pool_name,
+            config,
+        ))?;
+
+        ensure_not_cancelled(&cancel)?;
+        tracing::info!("Phase 13: Setting up ZFSBootMenu");
+        tracing::info!(target: "metrics", event = "phase_start", num = 13u32, name = "Setting up ZFSBootMenu");
+        let zswap_on = matches!(
+            config.swap_mode,
+            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+        );
+        rt.block_on(archinstall_zfs_core::bootmenu::set_zbm_properties(
+            pool_name,
+            prefix,
+            config.init_system,
+            zswap_on,
+            config.set_bootfs,
+        ))?;
+        rt.block_on(archinstall_zfs_core::bootmenu::install_and_generate_zbm(
+            runner.clone(),
+            &mountpoint,
+            config.init_system,
+            &cancel,
+            archinstall_zfs_core::system::async_download::DownloadConfig {
+                concurrency: config.parallel_downloads as usize,
+                ..Default::default()
+            },
+        ))?;
+        archinstall_zfs_core::bootmenu::create_efi_entries(&*runner, &efi_partition)?;
+
+        Ok(())
+    })();
+
+    if pool_setup_started && !pool_was_imported {
+        tracing::info!("Phase 14: Cleanup");
+        tracing::info!(target: "metrics", event = "phase_start", num = 14u32, name = "Cleanup");
+        nix::unistd::sync();
+        if efi_mounted {
+            let _ = archinstall_zfs_core::disk::partition::umount_efi(&*runner, &mountpoint);
+        }
+        let cleanup_result = rt.block_on(
+            archinstall_zfs_core::zfs_cleanup::cleanup_pool_after_install(pool_name, &root_ds_full),
+        );
+        if result.is_ok() {
+            cleanup_result?;
+        } else if let Err(error) = cleanup_result {
+            tracing::error!(%error, "cleanup after failed or cancelled installation failed");
+        }
+    }
+
+    result?;
     tracing::info!("Installation complete!");
+    Ok(())
+}
+
+fn ensure_not_cancelled(cancel: &CancellationToken) -> Result<()> {
+    if cancel.is_cancelled() {
+        bail!("installation cancelled");
+    }
     Ok(())
 }

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -45,12 +45,18 @@ struct Cli {
     /// physical DPI; on desktop builds the OS value is used unless overridden.
     #[arg(long, global = true)]
     ui_scale: Option<f32>,
+
+    /// Run the full UI and hardware backends while disabling installation and
+    /// destructive storage operations.
+    #[arg(long, global = true)]
+    demo: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
     let cli = Cli::parse();
+    let demo = cli.demo || kernel_cmdline_enables_demo();
 
     if let Some(scale) = cli.ui_scale
         && scale > 0.0
@@ -73,6 +79,9 @@ async fn main() -> Result<()> {
 
     if cli.silent {
         use color_eyre::eyre::bail;
+        if demo {
+            bail!("--silent is unavailable in safe demo mode");
+        }
         if cli.config.is_none() {
             bail!("--silent requires --config");
         }
@@ -82,13 +91,18 @@ async fn main() -> Result<()> {
         }
         let runner: Arc<dyn archinstall_zfs_core::system::cmd::CommandRunner> =
             Arc::new(archinstall_zfs_core::system::cmd::RealRunner);
-        install::run_install(runner, &config, None)
+        install::run_install(
+            runner,
+            &config,
+            tokio_util::sync::CancellationToken::new(),
+            None,
+        )
     } else {
-        run_gui(config)
+        run_gui(config, demo)
     }
 }
 
-fn run_gui(config: GlobalConfig) -> Result<()> {
+fn run_gui(config: GlobalConfig, demo: bool) -> Result<()> {
     let app = App::new()?;
     let config = Rc::new(RefCell::new(config));
     let kernel_scan = controllers::welcome::KernelScan::new();
@@ -99,13 +113,45 @@ fn run_gui(config: GlobalConfig) -> Result<()> {
 
     refresh_items(&app, &config.borrow());
 
-    controllers::welcome::setup(&app, &config, &kernel_scan);
+    controllers::welcome::setup(&app, &config, &kernel_scan, demo);
     controllers::lists::setup(&app, &config, &models);
     controllers::wizard::setup(&app, &config, &kernel_scan);
-    controllers::install::setup(&app, &config);
+    controllers::install::setup(&app, &config, demo);
     controllers::wifi::setup(&app);
     controllers::quit::setup(&app);
 
+    let demo_session = demo.then(controllers::demo::DemoSession::new);
+    if let Some(session) = &demo_session {
+        controllers::demo::setup(&app, &config, session);
+    }
+
     app.run()?;
+    if let Some(session) = demo_session {
+        session.export_all_blocking();
+    }
     Ok(())
+}
+
+fn kernel_cmdline_enables_demo() -> bool {
+    cmdline_enables_demo(&std::fs::read_to_string("/proc/cmdline").unwrap_or_default())
+}
+
+fn cmdline_enables_demo(cmdline: &str) -> bool {
+    cmdline
+        .split_whitespace()
+        .any(|arg| matches!(arg, "archinstall_zfs.demo" | "archinstall_zfs.demo=1"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cmdline_enables_demo;
+
+    #[test]
+    fn demo_kernel_argument_is_detected() {
+        assert!(cmdline_enables_demo(
+            "quiet archinstall_zfs.demo=1 console=tty1"
+        ));
+        assert!(cmdline_enables_demo("archinstall_zfs.demo"));
+        assert!(!cmdline_enables_demo("archinstall_zfs.demo=0"));
+    }
 }

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -18,11 +18,14 @@ export { WelcomeState }
 import { InstallState } from "state/install-state.slint";
 export { InstallState }
 
+import { DemoState } from "state/demo-state.slint";
+export { DemoState }
+
 import { WifiState } from "state/wifi-state.slint";
 export { WifiState }
 
-import { ItemType, ConfigItem, SelectOption, UserEntry, PackageEntry, PackageSearchResult, LogMessage, DownloadInfo, WifiSecurity, WifiPhase, WifiNetworkUi } from "types.slint";
-export { ItemType, ConfigItem, SelectOption, UserEntry, PackageEntry, PackageSearchResult, LogMessage, DownloadInfo, WifiSecurity, WifiPhase, WifiNetworkUi }
+import { ItemType, ConfigItem, SelectOption, UserEntry, PackageEntry, PackageSearchResult, LogMessage, DownloadInfo, DemoPool, DemoDataset, WifiSecurity, WifiPhase, WifiNetworkUi } from "types.slint";
+export { ItemType, ConfigItem, SelectOption, UserEntry, PackageEntry, PackageSearchResult, LogMessage, DownloadInfo, DemoPool, DemoDataset, WifiSecurity, WifiPhase, WifiNetworkUi }
 
 import { TextInputPopup } from "popups/text-input-popup.slint";
 import { SelectPopup } from "popups/select-popup.slint";
@@ -31,6 +34,7 @@ import { StringListPopup } from "popups/string-list-popup.slint";
 import { PackageSearchPopup } from "popups/package-search-popup.slint";
 import { MultiSelectPopup } from "popups/multi-select-popup.slint";
 import { WifiPopup } from "popups/wifi-popup.slint";
+import { ZfsInspectPopup } from "popups/zfs-inspect-popup.slint";
 
 import { WelcomeView } from "views/welcome-view.slint";
 import { WizardView } from "views/wizard-view.slint";
@@ -68,6 +72,8 @@ export component App inherits Window {
     callback toggle-activated(string);
     callback install-requested();
     callback quit-requested();
+    callback reboot-requested();
+    callback cancel-requested();
     callback user-added(string, string, bool); // username, password, sudo
     callback user-removed(int);
     callback user-sudo-toggled(int);
@@ -114,10 +120,16 @@ export component App inherits Window {
     }
 
     // ── Welcome screen (step 0, no sidebar) ───────────
-    if InstallState.state == 0 && WizardState.current-step == 0: WelcomeView { }
+    if InstallState.state == 0 && WizardState.current-step == 0: WelcomeView {
+        y: DemoState.enabled ? 32px : 0px;
+        height: root.height - self.y;
+        quit-requested() => { quit-requested(); }
+    }
 
     // ── Wizard config screen (steps 1+, with sidebar) ──
     if InstallState.state == 0 && WizardState.current-step > 0: WizardView {
+        y: DemoState.enabled ? 32px : 0px;
+        height: root.height - self.y;
         item-activated(key) => { item-activated(key); }
         toggle-activated(key) => { toggle-activated(key); }
         install-requested() => { install-requested(); }
@@ -129,7 +141,11 @@ export component App inherits Window {
 
     // ── Install progress screen ──────────────────────
     if InstallState.state >= 1: InstallView {
+        y: DemoState.enabled ? 32px : 0px;
+        height: root.height - self.y;
         quit-requested() => { quit-requested(); }
+        reboot-requested() => { reboot-requested(); }
+        cancel-requested() => { cancel-requested(); }
     }
 
     // ── Popup overlays ──────────────────────────────────
@@ -233,5 +249,25 @@ export component App inherits Window {
         // All callbacks already go through WifiState as globals, so
         // the mount site has no per-callback plumbing.
         popup-visible: PopupState.wifi-visible;
+    }
+
+    ZfsInspectPopup {
+        closed() => { DemoState.popup-visible = false; }
+    }
+
+    if DemoState.enabled: Rectangle {
+        x: 0;
+        y: 0;
+        width: root.width;
+        height: 32px;
+        background: Theme.c.yellow;
+        Text {
+            text: "SAFE LINUXKMS DEMO — configuration only; installation and destructive storage changes are disabled";
+            color: Theme.c.base;
+            font-size: Theme.font-sm;
+            font-weight: FontWeight.semi-bold;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+        }
     }
 }

--- a/slint-ui/ui/popups/zfs-inspect-popup.slint
+++ b/slint-ui/ui/popups/zfs-inspect-popup.slint
@@ -1,0 +1,146 @@
+import { ListView } from "std-widgets.slint";
+import { Theme } from "../styling.slint";
+import { DemoState } from "../state/demo-state.slint";
+import { StyledButton } from "../components/styled-button.slint";
+
+export component ZfsInspectPopup inherits Rectangle {
+    callback closed();
+
+    if DemoState.popup-visible: Rectangle {
+        width: 100%;
+        height: 100%;
+        background: #00000080;
+
+        TouchArea { clicked => { root.closed(); } }
+
+        focus-scope := FocusScope {
+            key-pressed(event) => {
+                if event.text == Key.Escape {
+                    root.closed();
+                    return accept;
+                }
+                return reject;
+            }
+        }
+
+        Rectangle {
+            width: 0px;
+            height: 0px;
+            init => { focus-scope.focus(); }
+        }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: min(680px, parent.width - 40px);
+            height: min(540px, parent.height - 40px);
+            background: Theme.c.mantle;
+            border-radius: Theme.radius-md;
+            border-color: Theme.c.surface1;
+            border-width: 1px;
+            clip: true;
+
+            VerticalLayout {
+                padding: Theme.spacing-lg;
+                spacing: Theme.spacing-sm;
+
+                HorizontalLayout {
+                    height: 36px;
+                    spacing: Theme.spacing-sm;
+                    Text {
+                        text: "ZFS pools and datasets";
+                        color: Theme.c.blue;
+                        font-size: Theme.font-lg;
+                        font-weight: FontWeight.semi-bold;
+                        vertical-alignment: center;
+                        horizontal-stretch: 1;
+                    }
+                    StyledButton {
+                        label: "Refresh";
+                        enabled: !DemoState.busy;
+                        clicked => { DemoState.refresh(); }
+                    }
+                    StyledButton { label: "Close"; clicked => { root.closed(); } }
+                }
+
+                Text {
+                    text: DemoState.status;
+                    color: DemoState.busy ? Theme.c.blue : Theme.c.subtext0;
+                    font-size: Theme.font-sm;
+                    wrap: word-wrap;
+                }
+
+                Text { text: "POOLS"; color: Theme.c.mauve; font-size: Theme.font-sm; }
+                ListView {
+                    height: 180px;
+                    for pool[index] in DemoState.pools: Rectangle {
+                        height: 48px;
+                        background: Math.mod(index, 2) == 0 ? Theme.c.surface0 : Theme.c.base;
+                        border-radius: Theme.radius-sm;
+                        HorizontalLayout {
+                            padding-left: Theme.spacing-md;
+                            padding-right: Theme.spacing-sm;
+                            spacing: Theme.spacing-sm;
+                            Text {
+                                text: pool.name;
+                                color: Theme.c.text;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                horizontal-stretch: 1;
+                            }
+                            Text {
+                                text: pool.imported
+                                    ? (pool.owned ? "read-only demo import" : "already imported")
+                                    : "available · " + pool.state;
+                                color: pool.owned ? Theme.c.green : Theme.c.overlay0;
+                                font-size: Theme.font-sm;
+                                vertical-alignment: center;
+                            }
+                            StyledButton {
+                                label: "Use";
+                                enabled: !DemoState.busy;
+                                clicked => { DemoState.select-pool(pool.name); }
+                            }
+                            if !pool.imported: StyledButton {
+                                label: "Import read-only";
+                                enabled: !DemoState.busy;
+                                clicked => { DemoState.import-readonly(pool.name); }
+                            }
+                            if pool.owned: StyledButton {
+                                label: "Export";
+                                enabled: !DemoState.busy;
+                                clicked => { DemoState.export-pool(pool.name); }
+                            }
+                        }
+                    }
+                }
+
+                Text { text: "DATASETS"; color: Theme.c.mauve; font-size: Theme.font-sm; }
+                ListView {
+                    for dataset[index] in DemoState.datasets: Rectangle {
+                        height: 30px;
+                        background: Math.mod(index, 2) == 0 ? Theme.c.surface0 : transparent;
+                        HorizontalLayout {
+                            padding-left: Theme.spacing-md;
+                            padding-right: Theme.spacing-md;
+                            Text {
+                                text: dataset.name;
+                                color: Theme.c.text;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                horizontal-stretch: 1;
+                                overflow: elide;
+                            }
+                            Text {
+                                text: dataset.kind;
+                                color: Theme.c.overlay0;
+                                font-size: Theme.font-sm;
+                                vertical-alignment: center;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/slint-ui/ui/state/demo-state.slint
+++ b/slint-ui/ui/state/demo-state.slint
@@ -1,0 +1,15 @@
+import { DemoPool, DemoDataset } from "../types.slint";
+
+export global DemoState {
+    in property <bool> enabled: false;
+    in-out property <bool> popup-visible: false;
+    in property <bool> busy: false;
+    in property <string> status: "";
+    in property <[DemoPool]> pools;
+    in property <[DemoDataset]> datasets;
+
+    callback refresh();
+    callback import-readonly(string);
+    callback export-pool(string);
+    callback select-pool(string);
+}

--- a/slint-ui/ui/state/install-state.slint
+++ b/slint-ui/ui/state/install-state.slint
@@ -1,11 +1,12 @@
 // Install-progress state. `state` is the high-level mode (0=config, 1=running,
-// 2=done, 3=failed); the rest is driven by the install pipeline running in a
+// 2=done, 3=failed, 4=cancelling, 5=cancelled); the rest is driven by the install pipeline running in a
 // background thread.
 
 import { LogMessage, DownloadInfo } from "../types.slint";
 
 export global InstallState {
-    // 0 = config screen, 1 = installing, 2 = done, 3 = failed
+    // 0 = config, 1 = installing, 2 = done, 3 = failed,
+    // 4 = cancellation requested, 5 = cancelled and cleaned up
     in-out property <int> state: 0;
 
     in property <[LogMessage]> log-messages;

--- a/slint-ui/ui/types.slint
+++ b/slint-ui/ui/types.slint
@@ -100,6 +100,18 @@ export struct DownloadInfo {
     state: int,
 }
 
+export struct DemoPool {
+    name: string,
+    state: string,
+    imported: bool,
+    owned: bool,
+}
+
+export struct DemoDataset {
+    name: string,
+    kind: string,
+}
+
 // ── WiFi types ──────────────────────────────────────────────────────────────
 
 // Security mode of a discovered or known network. Mirrors the Rust

--- a/slint-ui/ui/views/install-view.slint
+++ b/slint-ui/ui/views/install-view.slint
@@ -1,13 +1,16 @@
 // Install progress screen — scrolling log + a progress card with the current
-// phase, optional package-download details, and an Exit/Reboot button when
-// done.
+// phase, optional package-download details, cancellation while running, and
+// separate Quit/Reboot actions after success.
 
 import { ListView } from "std-widgets.slint";
 import { Theme } from "../styling.slint";
 import { InstallState } from "../state/install-state.slint";
+import { StyledButton } from "../components/styled-button.slint";
 
 export component InstallView inherits VerticalLayout {
     callback quit-requested();
+    callback reboot-requested();
+    callback cancel-requested();
 
     padding: 12px;
     spacing: 8px;
@@ -45,7 +48,9 @@ export component InstallView inherits VerticalLayout {
 
     // Progress card (always visible during install)
     Rectangle {
-        height: InstallState.download-active ? 180px : 80px;
+        height: InstallState.download-active ? 232px
+            : (InstallState.state == 1 || InstallState.state == 4) ? 132px
+            : 80px;
         background: Theme.c.surface0;
         border-radius: 10px;
 
@@ -60,9 +65,12 @@ export component InstallView inherits VerticalLayout {
                 Text {
                     text: InstallState.state == 2 ? "\u{2713} Complete"
                         : InstallState.state == 3 ? "\u{2717} Failed"
+                        : InstallState.state == 4 ? "Cancelling..."
+                        : InstallState.state == 5 ? "Cancelled"
                         : InstallState.phase-label;
                     color: InstallState.state == 2 ? Theme.c.green
                         : InstallState.state == 3 ? Theme.c.red
+                        : InstallState.state >= 4 ? Theme.c.yellow
                         : Theme.c.text;
                     font-size: 14px;
                     font-weight: FontWeight.semi-bold;
@@ -167,23 +175,41 @@ export component InstallView inherits VerticalLayout {
                 }
             }
 
-            // Exit button
-            if InstallState.state >= 2: Rectangle {
-                height: 36px;
-                background: exit-ta.has-hover ? Theme.c.blue : Theme.c.surface1;
-                border-radius: 8px;
+            if InstallState.state == 1 || InstallState.state == 4: HorizontalLayout {
+                alignment: end;
 
-                exit-ta := TouchArea {
+                StyledButton {
+                    label: InstallState.state == 4 ? "Cancelling..." : "Cancel installation";
+                    style: Theme.button-default;
+                    enabled: InstallState.state == 1;
+                    clicked => { root.cancel-requested(); }
+                }
+            }
+
+            if InstallState.state == 2: HorizontalLayout {
+                alignment: end;
+                spacing: Theme.spacing-sm;
+
+                StyledButton {
+                    label: "Quit";
+                    style: Theme.button-default;
                     clicked => { root.quit-requested(); }
                 }
 
-                Text {
-                    text: InstallState.state == 2 ? "Reboot" : "Exit";
-                    color: exit-ta.has-hover ? Theme.c.base : Theme.c.text;
-                    font-size: 14px;
-                    font-weight: FontWeight.semi-bold;
-                    horizontal-alignment: center;
-                    vertical-alignment: center;
+                StyledButton {
+                    label: "Reboot";
+                    style: Theme.button-primary;
+                    clicked => { root.reboot-requested(); }
+                }
+            }
+
+            if InstallState.state == 3 || InstallState.state == 5: HorizontalLayout {
+                alignment: end;
+
+                StyledButton {
+                    label: "Quit";
+                    style: Theme.button-default;
+                    clicked => { root.quit-requested(); }
                 }
             }
         }

--- a/slint-ui/ui/views/welcome-view.slint
+++ b/slint-ui/ui/views/welcome-view.slint
@@ -11,7 +11,27 @@ import { Icon } from "../components/icon.slint";
 import { SignalBars } from "../components/signal-bars.slint";
 
 export component WelcomeView inherits Rectangle {
+    callback quit-requested();
     background: Theme.c.base;
+
+    Rectangle {
+        x: 16px;
+        y: root.height - self.height - 16px;
+        width: 88px;
+        height: 36px;
+        background: quit-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
+        border-radius: Theme.radius-sm;
+        quit-ta := TouchArea {
+            clicked => { root.quit-requested(); }
+            mouse-cursor: pointer;
+        }
+        Text {
+            text: "Quit";
+            color: Theme.c.text;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+        }
+    }
 
     // ── Bottom-right connectivity widget ───────────────────────────────
     // Absolutely-positioned pill in the corner — canonical spot for a

--- a/slint-ui/ui/views/wizard-view.slint
+++ b/slint-ui/ui/views/wizard-view.slint
@@ -5,6 +5,7 @@ import { ScrollView } from "std-widgets.slint";
 import { Theme } from "../styling.slint";
 import { WizardState } from "../state/wizard-state.slint";
 import { PopupState } from "../state/popup-state.slint";
+import { DemoState } from "../state/demo-state.slint";
 import { SidebarItem } from "../components/sidebar-item.slint";
 import { ConfigItemRow } from "../components/config-item.slint";
 import { StyledButton } from "../components/styled-button.slint";
@@ -185,6 +186,15 @@ export component WizardView inherits Rectangle {
                 clicked => { root.quit-requested(); }
             }
 
+            if DemoState.enabled: StyledButton {
+                label: "Inspect ZFS";
+                style: Theme.button-default;
+                clicked => {
+                    DemoState.popup-visible = true;
+                    DemoState.refresh();
+                }
+            }
+
             // Back button (not on first wizard step)
             if WizardState.current-step > 1: StyledButton {
                 label: "\u{25c2} Back";
@@ -212,8 +222,9 @@ export component WizardView inherits Rectangle {
             // Install button (Review step only) — takes the Next slot so the
             // user never needs to scroll the content card to start the install.
             if WizardState.current-step == WizardState.total-steps - 1: StyledButton {
-                label: "Install \u{25b8}";
+                label: DemoState.enabled ? "Installation disabled" : "Install \u{25b8}";
                 style: Theme.button-primary;
+                enabled: !DemoState.enabled;
                 clicked => { root.install-requested(); }
             }
         }

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use color_eyre::eyre::{Result, bail, eyre};
 use tokio_util::sync::CancellationToken;
@@ -59,6 +60,84 @@ pub async fn run_install(
         >,
     >,
 ) -> Result<()> {
+    let pool_name = config
+        .pool_name
+        .as_deref()
+        .ok_or_else(|| eyre!("pool name not set"))?
+        .to_string();
+    let root_ds_full = format!("{pool_name}/{}/root", config.dataset_prefix);
+    let mountpoint = PathBuf::from("/mnt");
+    let cleanup_state = Arc::new(InstallCleanupState::default());
+    let result = run_install_inner(
+        runner.clone(),
+        config,
+        cancel,
+        download_progress_tx,
+        cleanup_state.clone(),
+    )
+    .await;
+
+    if cleanup_state.pool_setup_started.load(Ordering::Acquire)
+        && !cleanup_state.pool_preexisting.load(Ordering::Acquire)
+    {
+        tracing::info!("Phase 14: Cleanup");
+        if cleanup_state.efi_mounted.load(Ordering::Acquire) {
+            let r = runner.clone();
+            let mp = mountpoint.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                nix::unistd::sync();
+                archinstall_zfs_core::disk::partition::umount_efi(&*r, &mp)
+            })
+            .await;
+        }
+        let cleanup_result = archinstall_zfs_core::zfs_cleanup::cleanup_pool_after_install(
+            &pool_name,
+            &root_ds_full,
+        )
+        .await;
+        if result.is_ok() {
+            cleanup_result?;
+        } else if let Err(error) = cleanup_result {
+            tracing::error!(%error, "cleanup after failed or cancelled installation failed");
+        }
+    }
+
+    result?;
+    tracing::info!("Installation complete!");
+    Ok(())
+}
+
+struct InstallCleanupState {
+    pool_setup_started: AtomicBool,
+    efi_mounted: AtomicBool,
+    // Conservative default: never export a pool when its initial ownership
+    // could not be established.
+    pool_preexisting: AtomicBool,
+}
+
+impl Default for InstallCleanupState {
+    fn default() -> Self {
+        Self {
+            pool_setup_started: AtomicBool::new(false),
+            efi_mounted: AtomicBool::new(false),
+            pool_preexisting: AtomicBool::new(true),
+        }
+    }
+}
+
+async fn run_install_inner(
+    runner: Arc<dyn CommandRunner>,
+    config: GlobalConfig,
+    cancel: CancellationToken,
+    download_progress_tx: Option<
+        Arc<
+            tokio::sync::watch::Sender<
+                archinstall_zfs_core::system::async_download::DownloadProgress,
+            >,
+        >,
+    >,
+    cleanup_state: Arc<InstallCleanupState>,
+) -> Result<()> {
     let mountpoint = PathBuf::from("/mnt");
     let pool_name = config
         .pool_name
@@ -68,6 +147,8 @@ pub async fn run_install(
     let prefix = config.dataset_prefix.clone();
     let kernel = config.primary_kernel().to_string();
     let config = Arc::new(config);
+
+    ensure_not_cancelled(&cancel)?;
 
     // ── Phase 0: Pre-installation checks ───────────────────────
     tracing::info!("Phase 0: Pre-installation checks");
@@ -108,6 +189,13 @@ pub async fn run_install(
         .await??;
     }
     tracing::info!("ZFS initialized on host");
+    cleanup_state.pool_preexisting.store(
+        archinstall_zfs_core::zfs_cleanup::pool_is_imported(&pool_name)
+            .await
+            .unwrap_or(true),
+        Ordering::Release,
+    );
+    ensure_not_cancelled(&cancel)?;
 
     // ── Phase 1: Disk preparation (sync) ──────────────────────
     tracing::info!("Phase 1: Disk preparation");
@@ -125,6 +213,10 @@ pub async fn run_install(
     // ZFS ops are async (via zfskit), so they run directly on the
     // current task. mount_efi is sync (subprocess) and stays in spawn_blocking.
     tracing::info!("Phase 2: ZFS pool and datasets");
+    ensure_not_cancelled(&cancel)?;
+    cleanup_state
+        .pool_setup_started
+        .store(true, Ordering::Release);
     archinstall_zfs_core::prepare::prepare_zfs(
         &*runner,
         &config,
@@ -134,6 +226,7 @@ pub async fn run_install(
     .await?;
 
     tracing::info!("Phase 3: Mounting EFI partition");
+    ensure_not_cancelled(&cancel)?;
     {
         let r = runner.clone();
         let efi = efi_partition.clone();
@@ -143,6 +236,7 @@ pub async fn run_install(
         })
         .await??;
     }
+    cleanup_state.efi_mounted.store(true, Ordering::Release);
 
     // ── Phases 4-12: Installer pipeline (sync — AlpmContext is !Send) ──
     tracing::info!("Phase 4-12: Running installer pipeline");
@@ -168,6 +262,7 @@ pub async fn run_install(
         })
         .await??;
     }
+    ensure_not_cancelled(&cancel)?;
 
     // TRIM strategy: post-install ZFS-side configuration (no Alpm involved).
     // Called outside Installer so the zfskit setter can be a regular
@@ -177,6 +272,7 @@ pub async fn run_install(
 
     // ── Phase 13: ZFSBootMenu ──────────────────────────────────
     tracing::info!("Phase 13: Setting up ZFSBootMenu");
+    ensure_not_cancelled(&cancel)?;
 
     let zswap_on = matches!(
         config.swap_mode,
@@ -213,26 +309,12 @@ pub async fn run_install(
         .await??;
     }
 
-    // ── Phase 14: Cleanup ──────────────────────────────────────
-    tracing::info!("Phase 14: Cleanup");
-    let root_ds_full = format!("{pool_name}/{prefix}/root");
+    Ok(())
+}
 
-    // sync(2) + umount_efi are sync but quick. Wrap in spawn_blocking so we
-    // don't block the tokio worker on the FFI/subprocess.
-    {
-        let r = runner.clone();
-        let mp = mountpoint.clone();
-        tokio::task::spawn_blocking(move || -> Result<()> {
-            nix::unistd::sync();
-            archinstall_zfs_core::disk::partition::umount_efi(&*r, &mp)?;
-            Ok(())
-        })
-        .await??;
+fn ensure_not_cancelled(cancel: &CancellationToken) -> Result<()> {
+    if cancel.is_cancelled() {
+        bail!("installation cancelled");
     }
-
-    archinstall_zfs_core::zfs_cleanup::cleanup_pool_after_install(&pool_name, &root_ds_full)
-        .await?;
-
-    tracing::info!("Installation complete!");
     Ok(())
 }


### PR DESCRIPTION
Adds an ISO-selectable safe LinuxKMS session for exercising the real Slint KMS, libinput, cursor, touchpad, iwd, disk, partition, and ZFS discovery paths without allowing installation or destructive storage changes. It also makes cancellation and shutdown cleanup explicit so installer-owned pools are exported on success, failure, or cancellation.

- Add a safe LinuxKMS demo boot entry and an equivalent `azfs --demo` switch.
- Keep real hardware discovery and Wi-Fi management available while blocking both UI and CLI installation entry points.
- Discover pools and datasets, import selected pools with `readonly=on`, `cachefile=none`, and no mounts, verify the read-only property, and export only pools owned by the demo session.
- Add Quit controls during configuration and Cancel during installation, with cleanup shared by the Slint and TUI installers.
- Split the completed-install action into Quit and Reboot so the live environment can remain available after installation.

Testing

- Exercised the welcome, configuration, review, ZFS inspection, running-install, and completed-install states with Slint MCP and inspected rendered screenshots.
- Rendered the ISO profile and verified the safe demo entries for systemd-boot, GRUB, and Syslinux.
- Bare-metal LinuxKMS input and read-only ZFS import still need hardware validation; the PR remains a draft for that test.
