### PR TITLE
Harden boot environment dataset mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8345,9 +8345,9 @@ dependencies = [
 
 [[package]]
 name = "zfskit"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c151d75d62ac48d7efddc512d1670ab821acea68335f2c86eab3747be81b2d9"
+checksum = "bf812774e40b666bd61d87f326f7a160ea4be2727b74bc28bbcd50fdd7b4cb83"
 dependencies = [
  "async-trait",
  "regex",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ lzma-rs = "0.3.0"
 nix = { workspace = true, features = ["fs", "mount", "process", "signal"] }
 nmrs = { workspace = true, optional = true }
 pacmanconf = "3.1.0"
-zfskit = "0.2.0"
+zfskit = "0.2.1"
 raur = { version = "8.0.0", default-features = false, features = ["async", "reqwest", "rusttls-tls"] }
 regex = "1.13.1"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }

--- a/core/src/dataset_layout.rs
+++ b/core/src/dataset_layout.rs
@@ -31,7 +31,9 @@ pub fn default_datasets() -> Vec<DatasetConfig> {
 }
 
 fn properties_to_opts(props: &[(&str, &str)]) -> CreateOptions {
-    CreateOptions::new().properties(props.iter().map(|(k, v)| (k.to_string(), v.to_string())))
+    CreateOptions::new()
+        .no_mount()
+        .properties(props.iter().map(|(k, v)| (k.to_string(), v.to_string())))
 }
 
 pub async fn create_dataset(
@@ -105,7 +107,7 @@ pub async fn mount_datasets_ordered(
     zfs: &zfskit::Zfs,
     pool_name: &str,
     prefix: &str,
-    _datasets: &[DatasetConfig],
+    datasets: &[DatasetConfig],
 ) -> Result<()> {
     // Mount root dataset first (canmount=noauto)
     let root_ds = format!("{pool_name}/{prefix}/root");
@@ -113,12 +115,17 @@ pub async fn mount_datasets_ordered(
         .mount(&MountOptions::default())
         .await?;
 
-    // Recursively mount all child datasets; fall back to mount -a if -R fails
-    // (older or stripped-down ZFS builds occasionally lack -R).
-    let base_ds = format!("{pool_name}/{prefix}");
-    let recursive = MountOptions { recursive: true };
-    if zfs.dataset(&base_ds)?.mount(&recursive).await.is_err() {
-        let _ = zfs.mount_all().await;
+    let mut children: Vec<&DatasetConfig> = datasets
+        .iter()
+        .filter(|dataset| dataset.name != "root")
+        .collect();
+    children.sort_by_key(|dataset| dataset.name.matches('/').count());
+
+    for dataset in children {
+        let full_name = format!("{pool_name}/{prefix}/{}", dataset.name);
+        zfs.dataset(&full_name)?
+            .mount(&MountOptions::default())
+            .await?;
     }
 
     Ok(())
@@ -166,6 +173,7 @@ mod tests {
             .record(
                 Cmd::new("zfs").args([
                     "create",
+                    "-u",
                     "-o",
                     "mountpoint=/",
                     "-o",
@@ -177,19 +185,31 @@ mod tests {
                 0,
             )
             .record(
-                Cmd::new("zfs").args(["create", "-o", "mountpoint=none", "pool/arch0/data"]),
+                Cmd::new("zfs").args(["create", "-u", "-o", "mountpoint=none", "pool/arch0/data"]),
                 vec![],
                 vec![],
                 0,
             )
             .record(
-                Cmd::new("zfs").args(["create", "-o", "mountpoint=/home", "pool/arch0/data/home"]),
+                Cmd::new("zfs").args([
+                    "create",
+                    "-u",
+                    "-o",
+                    "mountpoint=/home",
+                    "pool/arch0/data/home",
+                ]),
                 vec![],
                 vec![],
                 0,
             )
             .record(
-                Cmd::new("zfs").args(["create", "-o", "mountpoint=/root", "pool/arch0/data/root"]),
+                Cmd::new("zfs").args([
+                    "create",
+                    "-u",
+                    "-o",
+                    "mountpoint=/root",
+                    "pool/arch0/data/root",
+                ]),
                 vec![],
                 vec![],
                 0,
@@ -199,5 +219,76 @@ mod tests {
         create_child_datasets(&zfs, "pool", "arch0", &datasets)
             .await
             .expect("create_child_datasets succeeds");
+    }
+
+    #[tokio::test]
+    async fn test_mount_datasets_mounts_only_selected_be() {
+        let datasets = default_datasets();
+        let runner = RecordingRunner::new()
+            .record(
+                Cmd::new("zfs").args(["mount", "pool/arch0/root"]),
+                vec![],
+                vec![],
+                0,
+            )
+            .record(
+                Cmd::new("zfs").args(["mount", "pool/arch0/vm"]),
+                vec![],
+                vec![],
+                0,
+            )
+            .record(
+                Cmd::new("zfs").args(["mount", "pool/arch0/data/home"]),
+                vec![],
+                vec![],
+                0,
+            )
+            .record(
+                Cmd::new("zfs").args(["mount", "pool/arch0/data/root"]),
+                vec![],
+                vec![],
+                0,
+            );
+
+        let zfs = Zfs::with_runner(runner);
+        mount_datasets_ordered(&zfs, "pool", "arch0", &datasets)
+            .await
+            .expect("selected boot environment mounts");
+    }
+
+    #[tokio::test]
+    async fn test_mount_datasets_propagates_nonempty_mountpoint_error() {
+        let datasets = vec![
+            DatasetConfig {
+                name: "root".to_string(),
+                properties: vec![
+                    ("mountpoint".to_string(), "/".to_string()),
+                    ("canmount".to_string(), "noauto".to_string()),
+                ],
+            },
+            DatasetConfig {
+                name: "data/root".to_string(),
+                properties: vec![("mountpoint".to_string(), "/root".to_string())],
+            },
+        ];
+        let runner = RecordingRunner::new()
+            .record(
+                Cmd::new("zfs").args(["mount", "pool/arch0/root"]),
+                vec![],
+                vec![],
+                0,
+            )
+            .record(
+                Cmd::new("zfs").args(["mount", "pool/arch0/data/root"]),
+                vec![],
+                b"cannot mount '/root': directory is not empty\n".to_vec(),
+                1,
+            );
+
+        let zfs = Zfs::with_runner(runner);
+        let error = mount_datasets_ordered(&zfs, "pool", "arch0", &datasets)
+            .await
+            .expect_err("non-empty mountpoint must stop installation");
+        assert!(error.to_string().contains("directory is not empty"));
     }
 }

--- a/core/src/prepare.rs
+++ b/core/src/prepare.rs
@@ -218,11 +218,13 @@ fn base_dataset_props(
             let mut p = crate::zfs_keyfile::dataset_encryption_properties(key_path);
             p.push(("mountpoint", "none".to_string()));
             p.push(("compression", compression.to_string()));
+            p.push(("overlay", "off".to_string()));
             p
         }
         _ => vec![
             ("mountpoint", "none".to_string()),
             ("compression", compression.to_string()),
+            ("overlay", "off".to_string()),
         ],
     }
 }
@@ -313,6 +315,18 @@ mod tests {
     use zfskit::{Cmd, RecordingRunner, Zfs};
 
     use super::*;
+
+    #[test]
+    fn base_dataset_disables_overlay_mounts() {
+        for encryption in [
+            ZfsEncryptionMode::None,
+            ZfsEncryptionMode::Pool,
+            ZfsEncryptionMode::Dataset,
+        ] {
+            let props = base_dataset_props(encryption, Path::new("/etc/zfs/zroot.key"), "zstd");
+            assert!(props.contains(&("overlay", "off".to_string())));
+        }
+    }
 
     #[tokio::test]
     async fn pool_encryption_loads_pool_key_before_mount() {


### PR DESCRIPTION
Prevents installer-created boot environments from silently mounting over non-empty paths, so stale files or an unexpected mount layout stop installation instead of being hidden.

- Set `overlay=off` on each boot-environment base dataset so descendants inherit the protection.
- Create datasets with `zfs create -u` and mount them only after the complete layout exists.
- Mount only the selected boot environment datasets in deterministic order and propagate mount failures.
- Remove the global `zfs mount -a` fallback that could affect unrelated pools.
- Update to `zfskit 0.2.1` for safe no-mount dataset creation.