### PR TITLE
Add ZFSBootMenu demo environment builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
 gen_iso/out/
 gen_iso/workdir/
+gen_iso/be-out/
+gen_iso/be-workdir/
 gen_iso/arch.qcow2
 gen_iso/my_vars.fd
 gen_iso/profile_rendered/

--- a/README.md
+++ b/README.md
@@ -302,8 +302,12 @@ The command uses `mkarchiso` to assemble the full package/profile environment,
 then copies its staging root into a new dataset with numeric ownership, ACLs,
 and xattrs preserved. It replaces the live-media initramfs with a normal ZFS
 root initramfs, configures `mountpoint=/`, `canmount=noauto`, and `overlay=off`,
-adds `archinstall_zfs.demo=1` to the ZFSBootMenu command line, and creates a
-`@fresh` snapshot. The pool's `bootfs` property is not changed.
+adds `archinstall_zfs.demo=1` (and `rw` when no read-write policy is
+inherited from the current root's command line) to the ZFSBootMenu command
+line, and creates a `@fresh` snapshot. The pool's `bootfs` property is not
+changed. The initramfs is built with mkinitcpio's `autodetect` hook, so build
+it on the machine that will boot it; a pool moved to different hardware may
+be missing drivers.
 
 The root-owned staging tree defaults to `/var/tmp/archinstall-zfs-be-workdir`
 so desktop file indexers cannot keep the temporary chroot mounts busy. Set
@@ -311,8 +315,8 @@ so desktop file indexers cannot keep the temporary chroot mounts busy. Set
 
 For safety, deployment refuses to reuse an existing dataset. It also refuses a
 staging tree after recursive `chown`, since that would lose root ownership.
-After booting the new environment, log in on tty1 and run `azfs` or
-`azfs-demo`.
+After booting the new environment, tty1 automatically logs in as root (the
+live profile's autologin is kept); run `azfs` or `azfs-demo`.
 
 ### Option 2 — Any other distro via podman
 

--- a/README.md
+++ b/README.md
@@ -277,9 +277,42 @@ just cargo-build          # native cargo build, produces target/release/{azfs,az
 just cargo-test
 just iso-test             # native mkarchiso (sudo)
 just iso-full
+just zfs-be-build         # writable bare-metal LinuxKMS demo BE on novafs
 just test-install         # QEMU regression test (requires cargo-build first)
 just qemu-install         # interactive boot of latest ISO
 ```
+
+### Bare-metal LinuxKMS demo boot environment
+
+The full ArchISO profile can also be deployed as a normal writable ZFSBootMenu
+boot environment. This is useful for testing LinuxKMS, libinput, touchpads,
+cursors, real GPUs, and iwd on physical hardware while keeping installation
+and destructive storage operations disabled.
+
+```bash
+# Defaults to novafs/archiso0/root, linux-lts, and the precompiled ZFS package.
+just zfs-be-build
+
+# All important choices can be overridden explicitly.
+just zfs-be-build --mode dkms --kernel linux \
+  --dataset tank/archiso0/root --mount-dir /mnt/archzfs-be
+```
+
+The command uses `mkarchiso` to assemble the full package/profile environment,
+then copies its staging root into a new dataset with numeric ownership, ACLs,
+and xattrs preserved. It replaces the live-media initramfs with a normal ZFS
+root initramfs, configures `mountpoint=/`, `canmount=noauto`, and `overlay=off`,
+adds `archinstall_zfs.demo=1` to the ZFSBootMenu command line, and creates a
+`@fresh` snapshot. The pool's `bootfs` property is not changed.
+
+The root-owned staging tree defaults to `/var/tmp/archinstall-zfs-be-workdir`
+so desktop file indexers cannot keep the temporary chroot mounts busy. Set
+`ARCHINSTALL_ZFS_BE_WORKDIR` to override it.
+
+For safety, deployment refuses to reuse an existing dataset. It also refuses a
+staging tree after recursive `chown`, since that would lose root ownership.
+After booting the new environment, log in on tty1 and run `azfs` or
+`azfs-demo`.
 
 ### Option 2 — Any other distro via podman
 

--- a/gen_iso/deploy-zfs-be.sh
+++ b/gen_iso/deploy-zfs-be.sh
@@ -202,15 +202,26 @@ fi
 if [[ " ${commandline} " != *" archinstall_zfs.demo=1 "* ]]; then
     commandline="${commandline:+${commandline} }archinstall_zfs.demo=1"
 fi
+# The zfs mkinitcpio hook mounts the root read-only unless rw is on the
+# kernel command line, and a host command line is not always inherited.
+if [[ " ${commandline} " != *" rw "* && " ${commandline} " != *" ro "* ]]; then
+    commandline="${commandline} rw"
+fi
 
-encryption="$(zfs get -H -o value encryption -- "${pool}")"
+# Encryption may start below the pool root, so inspect the nearest existing
+# ancestor, which is what the new datasets will inherit from.
+ancestor="${parent%/*}"
+zfs list -H -o name -- "${ancestor}" >/dev/null 2>&1 \
+    || die "ancestor dataset does not exist: ${ancestor}"
+encryption="$(zfs get -H -o value encryption -- "${ancestor}")"
 key_target=""
 if [[ "${encryption}" != "off" ]]; then
-    key_location="$(zfs get -H -o value keylocation -- "${pool}")"
+    encryption_root="$(zfs get -H -o value encryptionroot -- "${ancestor}")"
+    key_location="$(zfs get -H -o value keylocation -- "${encryption_root}")"
     case "${key_location}" in
         file:///*)
             [[ -f "${key_file}" ]] \
-                || die "encrypted pool requires readable --key-file: ${key_file}"
+                || die "encrypted target requires readable --key-file: ${key_file}"
             key_target="$(realpath -m -- "${key_location#file://}")"
             [[ "${key_target}" == /* && "${key_target}" != "/" ]] \
                 || die "unsafe ZFS keylocation: ${key_location}"
@@ -222,7 +233,7 @@ if [[ "${encryption}" != "off" ]]; then
             keysource=""
             ;;
         *)
-            die "unsupported encrypted-pool keylocation: ${key_location}"
+            die "unsupported keylocation on ${encryption_root}: ${key_location}"
             ;;
     esac
 else
@@ -256,7 +267,6 @@ zfs create -u \
     -o mountpoint=none \
     -o canmount=off \
     -o overlay=off \
-    -o compression=lz4 \
     -- "${parent}"
 created_parent=1
 
@@ -325,6 +335,12 @@ rm -f -- \
 rm -f -- \
     "${mount_dir}/etc/systemd/system/multi-user.target.wants/reflector.service" \
     "${mount_dir}/etc/systemd/system/multi-user.target.wants/sshd.service" \
+    "${mount_dir}/etc/systemd/system/multi-user.target.wants/choose-mirror.service" \
+    "${mount_dir}/etc/systemd/system/multi-user.target.wants/livecd-talk.service" \
+    "${mount_dir}/etc/systemd/system/sound.target.wants/livecd-alsa-unmuter.service" \
+    "${mount_dir}/etc/systemd/system/choose-mirror.service" \
+    "${mount_dir}/etc/systemd/system/livecd-talk.service" \
+    "${mount_dir}/etc/systemd/system/livecd-alsa-unmuter.service" \
     "${mount_dir}/etc/systemd/journald.conf.d/volatile-storage.conf"
 install -D -m 0644 /dev/null "${mount_dir}/etc/cloud/cloud-init.disabled"
 ln -sfn /dev/null "${mount_dir}/etc/systemd/system/zfs-mount.service"

--- a/gen_iso/deploy-zfs-be.sh
+++ b/gen_iso/deploy-zfs-be.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+app_name="${0##*/}"
+dataset=""
+source_root=""
+boot_source=""
+kernel="linux-lts"
+mount_dir="/mnt/archzfs-be"
+snapshot="fresh"
+key_file="/etc/zfs/zroot.key"
+dry_run=0
+mounted=0
+created_parent=0
+
+usage() {
+    cat <<EOF
+Usage: ${app_name} --dataset POOL/BE/root --source-root DIR [options]
+
+Deploy a completed mkarchiso airootfs staging tree as a writable
+ZFSBootMenu boot environment.
+
+Required:
+  --dataset DATASET      New root dataset, ending in /root
+  --source-root DIR      mkarchiso workdir/<arch>/airootfs directory
+
+Options:
+  --boot-source DIR      Directory containing vmlinuz-<kernel>
+                         (auto-detected from the mkarchiso workdir)
+  --kernel PACKAGE       Kernel package name (default: linux-lts)
+  --mount-dir DIR        Temporary deployment mount (default: /mnt/archzfs-be)
+  --snapshot NAME        Final snapshot name (default: fresh)
+  --key-file FILE        Key copied into encrypted-root initramfs
+                         (default: /etc/zfs/zroot.key)
+  --dry-run              Validate and print the plan without changing ZFS
+  -h, --help             Show this help
+
+The target dataset and its parent must not already exist. The pool bootfs
+property is never changed.
+EOF
+}
+
+die() {
+    printf '[%s] ERROR: %s\n' "${app_name}" "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '[%s] %s\n' "${app_name}" "$*"
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+cleanup() {
+    if (( mounted )) && mountpoint -q -- "${mount_dir}"; then
+        umount -- "${mount_dir}" || true
+    fi
+}
+
+on_error() {
+    local line="$1"
+    if (( created_parent )); then
+        printf '[%s] ERROR: deployment failed at line %s; partial dataset retained: %s\n' \
+            "${app_name}" "${line}" "${dataset%/root}" >&2
+        printf '[%s] Remove it explicitly before retrying: zfs destroy -r %q\n' \
+            "${app_name}" "${dataset%/root}" >&2
+    fi
+}
+
+trap cleanup EXIT
+trap 'on_error "$LINENO"' ERR
+
+while (( $# )); do
+    case "$1" in
+        --dataset)
+            (( $# >= 2 )) || die "--dataset requires a value"
+            dataset="$2"
+            shift 2
+            ;;
+        --source-root)
+            (( $# >= 2 )) || die "--source-root requires a value"
+            source_root="$2"
+            shift 2
+            ;;
+        --boot-source)
+            (( $# >= 2 )) || die "--boot-source requires a value"
+            boot_source="$2"
+            shift 2
+            ;;
+        --kernel)
+            (( $# >= 2 )) || die "--kernel requires a value"
+            kernel="$2"
+            shift 2
+            ;;
+        --mount-dir)
+            (( $# >= 2 )) || die "--mount-dir requires a value"
+            mount_dir="$2"
+            shift 2
+            ;;
+        --snapshot)
+            (( $# >= 2 )) || die "--snapshot requires a value"
+            snapshot="$2"
+            shift 2
+            ;;
+        --key-file)
+            (( $# >= 2 )) || die "--key-file requires a value"
+            key_file="$2"
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+(( EUID == 0 )) || die "run this script as root (for example, with sudo)"
+
+for command in arch-chroot cat chmod find findmnt grep install ln mount mountpoint \
+    realpath rm rsync stat sync umount zfs zpool; do
+    require_command "${command}"
+done
+
+[[ -n "${dataset}" ]] || die "--dataset is required"
+[[ -n "${source_root}" ]] || die "--source-root is required"
+[[ "${dataset}" =~ ^[A-Za-z0-9][A-Za-z0-9_.:-]*(/[A-Za-z0-9][A-Za-z0-9_.:-]*){2,}$ ]] \
+    || die "invalid dataset name: ${dataset}"
+[[ "${dataset##*/}" == "root" ]] || die "target dataset must end in /root"
+[[ "${kernel}" =~ ^[A-Za-z0-9][A-Za-z0-9@._+-]*$ ]] || die "invalid kernel package name"
+[[ "${snapshot}" =~ ^[A-Za-z0-9][A-Za-z0-9_.:-]*$ ]] || die "invalid snapshot name"
+
+source_root="$(realpath -e -- "${source_root}")"
+[[ -d "${source_root}" ]] || die "source root is not a directory: ${source_root}"
+[[ -x "${source_root}/usr/local/bin/azfs" ]] || die "source root does not contain executable azfs"
+[[ -x "${source_root}/usr/bin/mkinitcpio" ]] || die "source root does not contain mkinitcpio"
+[[ -x "${source_root}/usr/bin/pacman-key" ]] || die "source root does not contain pacman-key"
+[[ -x "${source_root}/usr/bin/zfs" ]] || die "source root does not contain ZFS tools"
+[[ -f /etc/hostid ]] || die "host has no /etc/hostid"
+[[ "$(stat -c '%s' -- /etc/hostid)" == "4" ]] || die "host /etc/hostid is not exactly four bytes"
+
+# A recursive chown of the mkarchiso workdir destroys the rootfs ownership
+# information. Refuse it instead of producing an unbootable or insecure BE.
+source_owner="$(stat -c '%u' -- "${source_root}/usr/bin/env")"
+[[ "${source_owner}" == "0" ]] \
+    || die "source root ownership is not preserved (usr/bin/env UID is ${source_owner}, expected 0)"
+
+work_dir="$(realpath -m -- "${source_root}/../..")"
+if [[ -z "${boot_source}" ]]; then
+    for candidate in \
+        "${work_dir}/x86_64/boot" \
+        "${work_dir}/iso/arch/boot/x86_64"; do
+        if [[ -f "${candidate}/vmlinuz-${kernel}" ]]; then
+            boot_source="${candidate}"
+            break
+        fi
+    done
+fi
+[[ -n "${boot_source}" ]] || die "could not auto-detect mkarchiso boot artifacts"
+boot_source="$(realpath -e -- "${boot_source}")"
+[[ -f "${boot_source}/vmlinuz-${kernel}" ]] \
+    || die "kernel not found: ${boot_source}/vmlinuz-${kernel}"
+
+mapfile -t module_dirs < <(find "${source_root}/usr/lib/modules" -mindepth 1 -maxdepth 1 -type d -print)
+(( ${#module_dirs[@]} == 1 )) \
+    || die "expected exactly one kernel module directory, found ${#module_dirs[@]}"
+kernel_release="${module_dirs[0]##*/}"
+[[ -f "${module_dirs[0]}/pkgbase" ]] || die "kernel module directory has no pkgbase marker"
+[[ "$(<"${module_dirs[0]}/pkgbase")" == "${kernel}" ]] \
+    || die "kernel module pkgbase does not match --kernel ${kernel}"
+find "${module_dirs[0]}" -type f -name 'zfs.ko*' -print -quit | grep -q . \
+    || die "ZFS kernel module is missing for ${kernel_release}"
+
+parent="${dataset%/root}"
+pool="${dataset%%/*}"
+zpool list -H -o name -- "${pool}" >/dev/null 2>&1 || die "pool is not imported: ${pool}"
+
+current_root="$(findmnt -n -o SOURCE /)"
+[[ "${current_root}" != "${dataset}" ]] || die "refusing to replace the running root dataset"
+[[ "${current_root}" != "${parent}"/* ]] || die "target parent contains the running root dataset"
+if zfs list -H -o name -- "${parent}" >/dev/null 2>&1; then
+    die "target parent already exists: ${parent}"
+fi
+if zfs list -H -o name -- "${dataset}" >/dev/null 2>&1; then
+    die "target dataset already exists: ${dataset}"
+fi
+
+commandline=""
+if [[ "${current_root}" == "${pool}/"* ]]; then
+    commandline="$(zfs get -H -o value org.zfsbootmenu:commandline -- "${current_root}")"
+    [[ "${commandline}" != "-" ]] || commandline=""
+fi
+if [[ " ${commandline} " != *" archinstall_zfs.demo=1 "* ]]; then
+    commandline="${commandline:+${commandline} }archinstall_zfs.demo=1"
+fi
+
+encryption="$(zfs get -H -o value encryption -- "${pool}")"
+key_target=""
+if [[ "${encryption}" != "off" ]]; then
+    key_location="$(zfs get -H -o value keylocation -- "${pool}")"
+    case "${key_location}" in
+        file:///*)
+            [[ -f "${key_file}" ]] \
+                || die "encrypted pool requires readable --key-file: ${key_file}"
+            key_target="$(realpath -m -- "${key_location#file://}")"
+            [[ "${key_target}" == /* && "${key_target}" != "/" ]] \
+                || die "unsafe ZFS keylocation: ${key_location}"
+            # The key is copied into this BE, so it must not depend on another
+            # BE remaining available as ZFSBootMenu's key source.
+            keysource="${dataset}"
+            ;;
+        prompt)
+            keysource=""
+            ;;
+        *)
+            die "unsupported encrypted-pool keylocation: ${key_location}"
+            ;;
+    esac
+else
+    keysource=""
+fi
+
+mount_dir="$(realpath -m -- "${mount_dir}")"
+[[ "${mount_dir}" != "/" ]] || die "refusing to use / as deployment mount"
+if mountpoint -q -- "${mount_dir}"; then
+    die "deployment mount is already in use: ${mount_dir}"
+fi
+if [[ -d "${mount_dir}" ]] && find "${mount_dir}" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    die "deployment mount is not empty: ${mount_dir}"
+fi
+
+info "source root: ${source_root}"
+info "kernel: ${kernel} (${kernel_release})"
+info "target dataset: ${dataset}"
+info "temporary mount: ${mount_dir}"
+info "ZFSBootMenu command line: ${commandline}"
+info "ZFSBootMenu key source: ${keysource:-not set}"
+
+if (( dry_run )); then
+    info "dry run completed; no changes made"
+    exit 0
+fi
+
+install -d -m 0755 -- "${mount_dir}"
+
+zfs create -u \
+    -o mountpoint=none \
+    -o canmount=off \
+    -o overlay=off \
+    -o compression=lz4 \
+    -- "${parent}"
+created_parent=1
+
+create_options=(
+    -u
+    -o mountpoint=/
+    -o canmount=noauto
+    -o overlay=off
+    -o "org.zfsbootmenu:commandline=${commandline}"
+)
+if [[ -n "${keysource}" ]]; then
+    create_options+=(-o "org.zfsbootmenu:keysource=${keysource}")
+fi
+zfs create "${create_options[@]}" -- "${dataset}"
+
+mount -t zfs -o zfsutil -- "${dataset}" "${mount_dir}"
+mounted=1
+
+info "copying mkarchiso rootfs into the dataset"
+rsync -aHAX --numeric-ids --delete -- "${source_root}/" "${mount_dir}/"
+
+install -D -m 0644 -- "${boot_source}/vmlinuz-${kernel}" "${mount_dir}/boot/vmlinuz-${kernel}"
+install -D -m 0644 -- /etc/hostid "${mount_dir}/etc/hostid"
+rm -f -- "${mount_dir}/etc/zfs/zpool.cache"
+
+initramfs_files=(/etc/hostid)
+if [[ -n "${key_target}" ]]; then
+    install -D -m 0000 -- "${key_file}" "${mount_dir}${key_target}"
+    initramfs_files+=("${key_target}")
+fi
+
+# Replace the live-media initramfs preset with a normal ZFS-root preset.
+rm -f -- "${mount_dir}/etc/mkinitcpio.conf.d/archiso.conf"
+if [[ "${kernel}" != "linux" ]]; then
+    rm -f -- "${mount_dir}/etc/mkinitcpio.d/linux.preset"
+fi
+install -d -m 0755 -- "${mount_dir}/etc/mkinitcpio.d" "${mount_dir}/etc/mkinitcpio.conf.d"
+cat >"${mount_dir}/etc/mkinitcpio.d/${kernel}.preset" <<EOF
+# Generated for the archinstall_zfs ZFSBootMenu demo environment.
+ALL_kver="/boot/vmlinuz-${kernel}"
+PRESETS=('default')
+default_image="/boot/initramfs-${kernel}.img"
+EOF
+
+{
+    printf 'FILES=('
+    printf '%q ' "${initramfs_files[@]}"
+    printf ')\n'
+    printf '%s\n' 'HOOKS=(base udev autodetect microcode modconf kms keyboard keymap consolefont block zfs filesystems)'
+} >"${mount_dir}/etc/mkinitcpio.conf.d/zfs-root.conf"
+chmod 0644 -- "${mount_dir}/etc/mkinitcpio.d/${kernel}.preset" \
+    "${mount_dir}/etc/mkinitcpio.conf.d/zfs-root.conf"
+
+# The live ISO keeps pacman's keyring in tmpfs. A normal writable BE needs a
+# persistent keyring of its own; do not copy the host's private local key.
+rm -rf -- "${mount_dir}/etc/pacman.d/gnupg"
+install -d -m 0755 -- "${mount_dir}/etc/pacman.d/gnupg"
+rm -f -- \
+    "${mount_dir}/etc/systemd/system/etc-pacman.d-gnupg.mount" \
+    "${mount_dir}/etc/systemd/system/pacman-init.service" \
+    "${mount_dir}/etc/systemd/system/zfs-dkms-autoinstall.service" \
+    "${mount_dir}/etc/systemd/system/multi-user.target.wants/pacman-init.service"
+
+# Keep the hardware-oriented live profile, but remove behavior that only
+# makes sense for an ephemeral installation medium.
+rm -f -- \
+    "${mount_dir}/etc/systemd/system/multi-user.target.wants/reflector.service" \
+    "${mount_dir}/etc/systemd/system/multi-user.target.wants/sshd.service" \
+    "${mount_dir}/etc/systemd/journald.conf.d/volatile-storage.conf"
+install -D -m 0644 /dev/null "${mount_dir}/etc/cloud/cloud-init.disabled"
+ln -sfn /dev/null "${mount_dir}/etc/systemd/system/zfs-mount.service"
+printf '%s\n' 'archzfs-demo' >"${mount_dir}/etc/hostname"
+
+cat >"${mount_dir}/usr/local/bin/azfs-demo" <<'EOF'
+#!/usr/bin/env bash
+exec /usr/local/bin/azfs --demo "$@"
+EOF
+chmod 0755 -- "${mount_dir}/usr/local/bin/azfs-demo"
+
+cat >>"${mount_dir}/etc/motd" <<'EOF'
+
+Safe bare-metal UI test environment:
+  azfs       LinuxKMS UI; safe mode is enforced by the kernel command line
+  azfs-demo  LinuxKMS UI with safe mode explicitly enabled
+EOF
+
+install -D -m 0644 /dev/stdin "${mount_dir}/etc/archinstall-zfs/demo-be" <<EOF
+dataset=${dataset}
+kernel=${kernel}
+kernel_release=${kernel_release}
+source_root=${source_root}
+EOF
+
+info "initializing a persistent pacman keyring"
+arch-chroot "${mount_dir}" /usr/bin/pacman-key --init
+arch-chroot "${mount_dir}" /usr/bin/pacman-key --populate archlinux
+
+info "generating normal ZFS-root initramfs"
+arch-chroot "${mount_dir}" /usr/bin/mkinitcpio -p "${kernel}"
+
+initramfs="${mount_dir}/boot/initramfs-${kernel}.img"
+[[ -s "${initramfs}" ]] || die "mkinitcpio did not create ${initramfs}"
+if find "${initramfs}" -perm /0077 -print -quit | grep -q .; then
+    die "initramfs is readable by non-root users"
+fi
+initramfs_listing="$(arch-chroot "${mount_dir}" /usr/bin/lsinitcpio "/boot/initramfs-${kernel}.img")"
+grep -Eq '/zfs\.ko(\.|$)' <<<"${initramfs_listing}" \
+    || die "generated initramfs does not contain zfs.ko"
+if [[ -n "${key_target}" ]]; then
+    grep -qx "${key_target#/}" <<<"${initramfs_listing}" \
+        || die "generated initramfs does not contain the pool key"
+fi
+
+[[ "$(stat -c '%u:%g' -- "${mount_dir}/usr/bin/env")" == "0:0" ]] \
+    || die "deployed rootfs ownership verification failed"
+[[ -x "${mount_dir}/usr/local/bin/azfs" ]] || die "deployed azfs binary is not executable"
+
+zfs snapshot -- "${dataset}@${snapshot}"
+sync -f -- "${mount_dir}"
+umount -- "${mount_dir}"
+mounted=0
+
+[[ "$(zfs get -H -o value mounted -- "${dataset}")" == "no" ]] \
+    || die "target dataset remained mounted"
+
+info "created ${dataset}@${snapshot}"
+info "ZFSBootMenu will discover the BE from its /boot kernel and mountpoint=/ property"
+info "pool bootfs was not changed"

--- a/gen_iso/reset-zfs-be-workdir.sh
+++ b/gen_iso/reset-zfs-be-workdir.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+marker_name=".archinstall-zfs-be-workdir"
+marker_text="archinstall_zfs ZFS BE staging workdir v1"
+
+die() {
+    printf '[reset-zfs-be-workdir.sh] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+(( EUID == 0 )) || die "run this script as root"
+(( $# == 1 )) || die "usage: $0 WORKDIR"
+
+work_dir="$(realpath -m -- "$1")"
+[[ "${work_dir}" == /* ]] || die "workdir must be an absolute path"
+
+case "${work_dir}" in
+    /|/home|/root|/tmp|/var|/var/tmp)
+        die "refusing unsafe workdir: ${work_dir}"
+        ;;
+esac
+
+marker="${work_dir}/${marker_name}"
+if [[ -e "${work_dir}" ]]; then
+    [[ -f "${marker}" ]] || die "existing path is not a managed BE workdir: ${work_dir}"
+    [[ "$(<"${marker}")" == "${marker_text}" ]] \
+        || die "managed-workdir marker is invalid: ${marker}"
+
+    mounts=()
+    while IFS= read -r mounted_path; do
+        if [[ "${mounted_path}" == "${work_dir}" || "${mounted_path}" == "${work_dir}/"* ]]; then
+            mounts+=("${mounted_path}")
+        fi
+    done < <(findmnt -rn -o TARGET)
+    if (( ${#mounts[@]} )); then
+        printf '[reset-zfs-be-workdir.sh] ERROR: refusing to delete a workdir with active mounts:\n' >&2
+        printf '  %s\n' "${mounts[@]}" >&2
+        exit 1
+    fi
+
+    rm -rf --one-file-system -- "${work_dir}"
+fi
+
+install -d -m 0755 -- "${work_dir}"
+printf '%s\n' "${marker_text}" >"${marker}"

--- a/justfile
+++ b/justfile
@@ -148,7 +148,7 @@ zfs-be-stage MODE="precompiled" KERNEL="linux-lts":
 zfs-be-deploy DATASET="novafs/archiso0/root" KERNEL="linux-lts" MOUNT_DIR="/mnt/archzfs-be":
     sudo bash gen_iso/deploy-zfs-be.sh \
         --dataset {{DATASET}} \
-        --source-root {{BE_WORKDIR}}/x86_64/airootfs \
+        --source-root "{{BE_WORKDIR}}/x86_64/airootfs" \
         --kernel {{KERNEL}} \
         --mount-dir {{MOUNT_DIR}}
 

--- a/justfile
+++ b/justfile
@@ -4,6 +4,8 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 PROFILE_DIR := "gen_iso/profile"
 PROFILE_OUT := "gen_iso/profile_rendered"
 ISO_OUT := "gen_iso/out"
+BE_WORKDIR := env_var_or_default("ARCHINSTALL_ZFS_BE_WORKDIR", "/var/tmp/archinstall-zfs-be-workdir")
+BE_ISO_OUT := "gen_iso/be-out"
 DISK_IMAGE := "gen_iso/arch.qcow2"
 UEFI_VARS := "gen_iso/my_vars.fd"
 QEMU_SCRIPT := "gen_iso/run-qemu.sh"
@@ -121,6 +123,43 @@ iso-full MODE="precompiled" KERNEL="linux-lts":
     sudo mkarchiso -v -w "gen_iso/workdir" -o {{ISO_OUT}} {{PROFILE_OUT}}
     sudo chown -R "$(id -u):$(id -g)" {{ISO_OUT}} gen_iso/workdir
     @echo "Full ISO built in {{ISO_OUT}}"
+
+# Build the full hardware profile into a dedicated mkarchiso workdir.
+# The workdir intentionally remains root-owned: changing its ownership would
+# corrupt the numeric ownership metadata needed by zfs-be-deploy.
+[arg("MODE", long="mode")]
+[arg("KERNEL", long="kernel")]
+zfs-be-stage MODE="precompiled" KERNEL="linux-lts":
+    @echo "Staging ZFSBootMenu demo BE (mode={{MODE}}, kernel={{KERNEL}})"
+    just cargo-build
+    just _render-profile {{MODE}} {{KERNEL}}
+    just _prepare-binary
+    sudo bash gen_iso/reset-zfs-be-workdir.sh "{{BE_WORKDIR}}"
+    mkdir -p {{BE_ISO_OUT}}
+    sudo mkarchiso -v -w "{{BE_WORKDIR}}" -o {{BE_ISO_OUT}} {{PROFILE_OUT}}
+    sudo chown -R "$(id -u):$(id -g)" {{BE_ISO_OUT}}
+    @echo "BE rootfs staged in {{BE_WORKDIR}}/x86_64/airootfs"
+
+# Deploy a staged rootfs into a brand-new ZFSBootMenu boot environment.
+# Refuses existing datasets and never changes the pool's bootfs property.
+[arg("DATASET", long="dataset")]
+[arg("KERNEL", long="kernel")]
+[arg("MOUNT_DIR", long="mount-dir")]
+zfs-be-deploy DATASET="novafs/archiso0/root" KERNEL="linux-lts" MOUNT_DIR="/mnt/archzfs-be":
+    sudo bash gen_iso/deploy-zfs-be.sh \
+        --dataset {{DATASET}} \
+        --source-root {{BE_WORKDIR}}/x86_64/airootfs \
+        --kernel {{KERNEL}} \
+        --mount-dir {{MOUNT_DIR}}
+
+# End-to-end bare-metal LinuxKMS demo BE build and deployment.
+[arg("MODE", long="mode")]
+[arg("KERNEL", long="kernel")]
+[arg("DATASET", long="dataset")]
+[arg("MOUNT_DIR", long="mount-dir")]
+zfs-be-build MODE="precompiled" KERNEL="linux-lts" DATASET="novafs/archiso0/root" MOUNT_DIR="/mnt/archzfs-be":
+    just zfs-be-stage --mode {{MODE}} --kernel {{KERNEL}}
+    just zfs-be-deploy --dataset {{DATASET}} --kernel {{KERNEL}} --mount-dir {{MOUNT_DIR}}
 
 # List available ISOs
 iso-list:


### PR DESCRIPTION
Adds a repeatable path from the existing full ArchISO profile to a writable ZFSBootMenu boot environment for testing the real Slint LinuxKMS, libinput, GPU, and iwd paths on physical hardware while installer safe-demo mode blocks destructive operations.

- stage the full mkarchiso profile in a root-owned workdir outside the repository
- deploy only into a brand-new `POOL/BE/root` dataset with `mountpoint=/`, `canmount=noauto`, and `overlay=off`
- generate a normal ZFS-root mkinitcpio image with hostid and encrypted-pool key handling
- keep `bootfs` unchanged, mask automatic ZFS mounts, disable live-media-only services, and create `@fresh`
- refuse reused datasets, damaged rootfs ownership, unsafe workdir cleanup, and workdirs with active mounts
- document the end-to-end `just zfs-be-build` workflow

Testing

- built the full `linux-lts`/precompiled profile twice with `just zfs-be-stage`; the second build completed from the external managed workdir without leaked chroot mounts
- deployed and inspected `novafs/archiso0/root@fresh`; verified ZFS properties, 0600 initramfs, embedded `zfs.ko`, hostid and key, independent keysource, unchanged `bootfs`, and unchanged live mounts
- verified refusal of existing datasets, unsafe cleanup roots, and managed workdirs with active nested mounts
- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `shellcheck gen_iso/deploy-zfs-be.sh gen_iso/reset-zfs-be-workdir.sh`
- physical boot and LinuxKMS input testing are still pending