### PR TITLE
Replace stringly-typed wizard plumbing with enums

### DIFF
--- a/core/src/boot_environment.rs
+++ b/core/src/boot_environment.rs
@@ -1,0 +1,94 @@
+//! Naming the datasets of a boot environment.
+//!
+//! A boot environment is a pool plus a prefix — `zroot` and `arch0` give
+//! `zroot/arch0`, whose `root` child is what the system boots from. That
+//! layout was spelled out with `format!` in six modules, each threading the
+//! pool and the prefix through its own arguments, and each free to get the
+//! order or the separator wrong on its own.
+//!
+//! One type carries the pair and answers what the datasets are called.
+
+use std::fmt;
+
+/// The datasets belonging to one boot environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootEnvironment {
+    pool: String,
+    prefix: String,
+}
+
+impl BootEnvironment {
+    pub fn new(pool: impl Into<String>, prefix: impl Into<String>) -> Self {
+        Self {
+            pool: pool.into(),
+            prefix: prefix.into(),
+        }
+    }
+
+    /// The pool the environment lives in.
+    pub fn pool(&self) -> &str {
+        &self.pool
+    }
+
+    /// The name distinguishing this environment from others in the pool.
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    /// The environment's own dataset, parent of everything below.
+    pub fn base(&self) -> String {
+        format!("{}/{}", self.pool, self.prefix)
+    }
+
+    /// The dataset mounted at `/` when this environment is booted.
+    pub fn root(&self) -> String {
+        self.child("root")
+    }
+
+    /// A dataset within the environment, named relative to its base.
+    pub fn child(&self, relative: &str) -> String {
+        format!("{}/{relative}", self.base())
+    }
+}
+
+impl fmt::Display for BootEnvironment {
+    /// Prints the base dataset, which is how a boot environment is named
+    /// everywhere it is shown or logged.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.base())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_are_built_from_the_pool_and_the_prefix() {
+        let be = BootEnvironment::new("zroot", "arch0");
+
+        assert_eq!(be.base(), "zroot/arch0");
+        assert_eq!(be.root(), "zroot/arch0/root");
+        assert_eq!(be.child("data/home"), "zroot/arch0/data/home");
+        assert_eq!(be.to_string(), "zroot/arch0");
+    }
+
+    #[test]
+    fn the_pool_and_prefix_stay_available_for_the_commands_that_need_them() {
+        // zpool operations take the pool alone; the prefix appears in
+        // messages about which environment is being built.
+        let be = BootEnvironment::new("tank", "arch1");
+
+        assert_eq!(be.pool(), "tank");
+        assert_eq!(be.prefix(), "arch1");
+    }
+
+    #[test]
+    fn environments_in_one_pool_are_distinct() {
+        let first = BootEnvironment::new("zroot", "arch0");
+        let second = BootEnvironment::new("zroot", "arch1");
+
+        assert_ne!(first, second);
+        assert_ne!(first.root(), second.root());
+    }
+}

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use color_eyre::eyre::{Context, Result};
 use serde::Serialize;
 
+use crate::boot_environment::BootEnvironment;
 use crate::config::types::InitSystem;
 use crate::system::cmd::{CommandRunner, check_exit, chroot_cmd};
 
@@ -259,14 +260,13 @@ fn rootprefix_for(init_system: InitSystem) -> &'static str {
 }
 
 pub async fn set_zbm_properties(
-    pool_name: &str,
-    prefix: &str,
+    be: &BootEnvironment,
     init_system: InitSystem,
     zswap_enabled: bool,
     set_bootfs: bool,
 ) -> Result<()> {
     let zfs = zfskit::Zfs::new();
-    let root_ds = format!("{pool_name}/{prefix}/root");
+    let root_ds = be.root();
     let cmdline = build_zbm_cmdline(zswap_enabled);
     let rootprefix = rootprefix_for(init_system);
 
@@ -284,7 +284,7 @@ pub async fn set_zbm_properties(
         // 10-second countdown then boots the bootfs dataset. Users can press
         // any key during the countdown to browse/select other BEs.
         // Without bootfs, ZBM ignores zbm.timeout and always waits for input.
-        zfs.pool(pool_name)?
+        zfs.pool(be.pool())?
             .set_property("bootfs", &root_ds)
             .await?;
         tracing::info!(

--- a/core/src/config/choices.rs
+++ b/core/src/config/choices.rs
@@ -1,0 +1,235 @@
+//! Ordered choice lists for the configuration enums the wizards present as
+//! radio groups.
+//!
+//! Both interfaces used to encode each enum four times over: the order and
+//! labels when building the list, and the inverse mapping when applying the
+//! selection — once per interface. Nothing tied the four together, so adding a
+//! variant meant four correct edits with no compiler help, and the two
+//! interfaces had already drifted apart on what an out-of-range index means.
+//!
+//! The order and the labels live here, beside the enums. A test pins the
+//! labels to each enum's `Display`, so the text the wizard shows and the text
+//! the enum prints cannot drift apart. An index is now only ever produced and
+//! consumed through this trait.
+
+use super::types::{
+    AudioServer, CompressionAlgo, InitSystem, InstallationMode, SeatAccess, SwapMode,
+    ZfsEncryptionMode,
+};
+
+/// A configuration value offered as an ordered list of alternatives.
+///
+/// `CHOICES` is the single source of truth for what the list contains and what
+/// position each value occupies. Implementations must list every variant; the
+/// `choice_roundtrip` test helper checks that for each one.
+pub trait Choice: Copy + PartialEq + Sized + 'static {
+    /// The alternatives in presentation order, each with the text shown for
+    /// it. Borrowed rather than owned so both interfaces can use these
+    /// directly: the terminal one holds `&'static str` in its menu rows.
+    const CHOICES: &'static [(Self, &'static str)];
+
+    /// Position in the presented list.
+    ///
+    /// A value missing from `ORDER` is a bug in the implementation rather than
+    /// something a caller can act on, so this falls back to the first entry
+    /// instead of forcing every call site into error handling. The round-trip
+    /// tests exist to keep that from happening.
+    fn index(self) -> usize {
+        Self::CHOICES
+            .iter()
+            .position(|(value, _)| *value == self)
+            .unwrap_or(0)
+    }
+
+    /// The alternative at `index`, or `None` if the index is out of range.
+    fn from_index(index: usize) -> Option<Self> {
+        Self::CHOICES.get(index).map(|(value, _)| *value)
+    }
+
+    /// The text shown for this alternative.
+    fn label(self) -> &'static str {
+        Self::CHOICES
+            .iter()
+            .find(|(value, _)| *value == self)
+            .map(|(_, label)| *label)
+            .unwrap_or_default()
+    }
+
+    /// Labels for the whole list, in order.
+    fn labels() -> Vec<&'static str> {
+        Self::CHOICES.iter().map(|(_, label)| *label).collect()
+    }
+}
+
+impl Choice for InstallationMode {
+    const CHOICES: &'static [(Self, &'static str)] = &[
+        (Self::FullDisk, "Full Disk"),
+        (Self::NewPool, "New Pool"),
+        (Self::ExistingPool, "Existing Pool"),
+    ];
+}
+
+impl Choice for CompressionAlgo {
+    // `off` last: it is the opt-out, and the interfaces render the final row
+    // of this group as the "disabled" state.
+    const CHOICES: &'static [(Self, &'static str)] = &[
+        (Self::Lz4, "lz4"),
+        (Self::Zstd, "zstd"),
+        (Self::Zstd5, "zstd-5"),
+        (Self::Zstd10, "zstd-10"),
+        (Self::Off, "off"),
+    ];
+}
+
+impl Choice for ZfsEncryptionMode {
+    const CHOICES: &'static [(Self, &'static str)] = &[
+        (Self::None, "No encryption"),
+        (Self::Pool, "Encrypt entire pool"),
+        (Self::Dataset, "Encrypt base dataset only"),
+    ];
+}
+
+impl Choice for SwapMode {
+    const CHOICES: &'static [(Self, &'static str)] = &[
+        (Self::None, "None"),
+        (Self::Zram, "ZRAM"),
+        (Self::ZswapPartition, "Swap partition"),
+        (Self::ZswapPartitionEncrypted, "Swap partition (encrypted)"),
+    ];
+}
+
+impl Choice for InitSystem {
+    const CHOICES: &'static [(Self, &'static str)] =
+        &[(Self::Dracut, "dracut"), (Self::Mkinitcpio, "mkinitcpio")];
+}
+
+/// Optional settings are presented with an explicit "None" row first, so the
+/// `Option` itself is the choice rather than something the interfaces have to
+/// offset their indices around.
+impl Choice for Option<AudioServer> {
+    const CHOICES: &'static [(Self, &'static str)] = &[
+        (None, "None"),
+        (Some(AudioServer::Pipewire), "pipewire"),
+        (Some(AudioServer::Pulseaudio), "pulseaudio"),
+    ];
+}
+
+impl Choice for Option<SeatAccess> {
+    const CHOICES: &'static [(Self, &'static str)] = &[
+        (None, "None"),
+        (Some(SeatAccess::Seatd), "seatd"),
+        (Some(SeatAccess::Polkit), "polkit"),
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every listed choice maps to its own index and back.
+    fn roundtrip<T: Choice + std::fmt::Debug>() {
+        for (position, (choice, _)) in T::CHOICES.iter().enumerate() {
+            assert_eq!(choice.index(), position, "index of {choice:?}");
+            assert_eq!(
+                T::from_index(position),
+                Some(*choice),
+                "value at index {position}"
+            );
+        }
+        assert_eq!(T::labels().len(), T::CHOICES.len());
+        assert!(T::from_index(T::CHOICES.len()).is_none(), "out of range");
+    }
+
+    #[test]
+    fn every_choice_list_round_trips() {
+        roundtrip::<InstallationMode>();
+        roundtrip::<CompressionAlgo>();
+        roundtrip::<ZfsEncryptionMode>();
+        roundtrip::<SwapMode>();
+        roundtrip::<InitSystem>();
+        roundtrip::<Option<AudioServer>>();
+        roundtrip::<Option<SeatAccess>>();
+    }
+
+    /// Exhaustiveness: a new variant must be added to `CHOICES`, and these
+    /// matches stop compiling until it is listed here too.
+    #[test]
+    fn every_variant_is_listed() {
+        fn assert_listed<T: Choice + std::fmt::Debug>(variants: &[T]) {
+            for variant in variants {
+                assert!(
+                    T::CHOICES.iter().any(|(value, _)| value == variant),
+                    "{variant:?} is missing from CHOICES, so no interface can offer it"
+                );
+            }
+        }
+
+        assert_listed(&[
+            InstallationMode::FullDisk,
+            InstallationMode::NewPool,
+            InstallationMode::ExistingPool,
+        ]);
+        assert_listed(&[
+            CompressionAlgo::Off,
+            CompressionAlgo::Lz4,
+            CompressionAlgo::Zstd,
+            CompressionAlgo::Zstd5,
+            CompressionAlgo::Zstd10,
+        ]);
+        assert_listed(&[
+            ZfsEncryptionMode::None,
+            ZfsEncryptionMode::Pool,
+            ZfsEncryptionMode::Dataset,
+        ]);
+        assert_listed(&[
+            SwapMode::None,
+            SwapMode::Zram,
+            SwapMode::ZswapPartition,
+            SwapMode::ZswapPartitionEncrypted,
+        ]);
+        assert_listed(&[InitSystem::Dracut, InitSystem::Mkinitcpio]);
+        assert_listed(&[
+            None,
+            Some(AudioServer::Pipewire),
+            Some(AudioServer::Pulseaudio),
+        ]);
+        assert_listed(&[None, Some(SeatAccess::Seatd), Some(SeatAccess::Polkit)]);
+    }
+
+    /// The wizard's labels are the enums' own `Display` output. Keeping them
+    /// as literals in the table lets both interfaces borrow them, and this is
+    /// what stops the two representations drifting apart.
+    #[test]
+    fn labels_match_the_display_impls() {
+        fn assert_display_matches<T: Choice + std::fmt::Display + std::fmt::Debug>() {
+            for (value, label) in T::CHOICES {
+                assert_eq!(
+                    &value.to_string(),
+                    label,
+                    "{value:?} prints differently from the label the wizard shows"
+                );
+            }
+        }
+
+        assert_display_matches::<InstallationMode>();
+        assert_display_matches::<CompressionAlgo>();
+        assert_display_matches::<ZfsEncryptionMode>();
+        assert_display_matches::<SwapMode>();
+        assert_display_matches::<InitSystem>();
+
+        // Option has no Display of its own; check the inner values and the
+        // spelling of the empty row.
+        for (value, label) in <Option<AudioServer>>::CHOICES {
+            match value {
+                Some(server) => assert_eq!(&server.to_string(), label),
+                None => assert_eq!(*label, "None"),
+            }
+        }
+        for (value, label) in <Option<SeatAccess>>::CHOICES {
+            match value {
+                Some(access) => assert_eq!(&access.to_string(), label),
+                None => assert_eq!(*label, "None"),
+            }
+        }
+    }
+}

--- a/core/src/config/edit.rs
+++ b/core/src/config/edit.rs
@@ -92,8 +92,6 @@ settings! {
         PoolName => "pool_name",
         DatasetPrefix => "dataset_prefix",
         Hostname => "hostname",
-        Locale => "locale",
-        Timezone => "timezone",
         RootPassword => "root_password",
         EncryptionPassword => "encryption_password",
         SwapPartitionSize => "swap_partition_size",
@@ -101,6 +99,49 @@ settings! {
         AdditionalPackages => "additional_packages",
         AurPackages => "aur_packages",
         ExtraServices => "extra_services",
+    }
+}
+
+settings! {
+    /// A setting turned on and off in place.
+    ToggleSetting {
+        Ntp => "ntp",
+        Bluetooth => "bluetooth",
+        Zrepl => "zrepl",
+    }
+}
+
+settings! {
+    /// A setting edited through a dedicated picker rather than in the row.
+    ///
+    /// Identity only: what the picker looks like, and whether an interface
+    /// offers one at all, is that interface's business. Naming them here is
+    /// what lets both dispatch on a value the compiler checks instead of on a
+    /// string literal repeated in two crates.
+    EditorSetting {
+        Kernel => "kernel",
+        Profile => "profile",
+        OptionalPackages => "optional_packages",
+        GpuDriver => "gpu_driver",
+        DisplayManager => "display_manager",
+        Timezone => "timezone",
+        Locale => "locale",
+        Keyboard => "keyboard",
+        Users => "users",
+        Packages => "packages",
+        // Also a text row: in the mode that installs into an existing pool the
+        // terminal interface offers a picker instead of free text, and the row
+        // keeps its key either way.
+        PoolName => "pool_name",
+    }
+}
+
+/// Flip a setting that is on or off.
+pub fn apply_toggle(config: &mut GlobalConfig, setting: ToggleSetting) {
+    match setting {
+        ToggleSetting::Ntp => config.ntp = !config.ntp,
+        ToggleSetting::Bluetooth => config.bluetooth = !config.bluetooth,
+        ToggleSetting::Zrepl => config.zrepl_enabled = !config.zrepl_enabled,
     }
 }
 
@@ -199,8 +240,6 @@ pub fn apply_text(config: &mut GlobalConfig, setting: TextSetting, value: &str) 
     match setting {
         TextSetting::PoolName => config.pool_name = text,
         TextSetting::Hostname => config.hostname = text,
-        TextSetting::Locale => config.locale = text,
-        TextSetting::Timezone => config.timezone = text,
         TextSetting::RootPassword => config.root_password = text,
         TextSetting::EncryptionPassword => config.zfs_encryption_password = text,
         TextSetting::SwapPartitionSize => config.swap_partition_size = text,
@@ -373,6 +412,28 @@ mod tests {
         apply_text(&mut c, TextSetting::AdditionalPackages, "vim, git  htop,");
 
         assert_eq!(c.additional_packages, vec!["vim", "git", "htop"]);
+    }
+
+    #[test]
+    fn toggles_flip() {
+        let mut c = cfg();
+        let was = c.ntp;
+
+        apply_toggle(&mut c, ToggleSetting::Ntp);
+        assert_eq!(c.ntp, !was);
+
+        apply_toggle(&mut c, ToggleSetting::Ntp);
+        assert_eq!(c.ntp, was);
+    }
+
+    #[test]
+    fn each_toggle_moves_only_its_own_setting() {
+        let mut c = cfg();
+        apply_toggle(&mut c, ToggleSetting::Bluetooth);
+
+        assert!(c.bluetooth);
+        assert!(!c.zrepl_enabled);
+        assert!(c.ntp, "ntp defaults on and was not touched");
     }
 
     #[test]

--- a/core/src/config/edit.rs
+++ b/core/src/config/edit.rs
@@ -1,0 +1,388 @@
+//! Applying wizard edits to the configuration.
+//!
+//! Both interfaces present the same settings and used to carry their own copy
+//! of what each one does — two `apply_text` functions that had already drifted
+//! apart, two `apply_radio`s, and a string key matched in each with a
+//! catch-all arm that silently swallowed anything unrecognised. A typo in a
+//! key produced a control that did nothing, with no compile error and no
+//! runtime complaint.
+//!
+//! The settings are named by enum here, and the edits are applied here. The
+//! key strings still exist because the row identity has to survive a trip
+//! through the interface toolkit, but they are parsed back into an enum at the
+//! boundary, so every match below is exhaustive and a key that does not parse
+//! is reported rather than ignored.
+//!
+//! Settings are grouped by how they are edited — a value chosen from a list, a
+//! block device, or free text — because that is what determines the shape of
+//! the edit. Rows that open a dedicated editor, and rows that are actions
+//! rather than settings, stay with the interface that renders them.
+
+use std::path::Path;
+
+use super::choices::Choice;
+use super::types::{
+    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
+    SeatAccess, SwapMode, ZfsEncryptionMode,
+};
+
+/// Define a settings enum alongside the wire keys the interfaces use for it.
+///
+/// One table per enum, so the name and the key cannot drift apart, and
+/// `parse` is the inverse of `as_str` by construction.
+macro_rules! settings {
+    ($(#[$meta:meta])* $name:ident { $($variant:ident => $key:literal),+ $(,)? }) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum $name {
+            $($variant),+
+        }
+
+        impl $name {
+            /// Every setting in this group, for tests and for interfaces that
+            /// want to enumerate them.
+            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
+
+            /// The key this setting travels under.
+            pub const fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $key),+
+                }
+            }
+
+            /// Recover the setting from a key, or `None` if it names none.
+            pub fn parse(key: &str) -> Option<Self> {
+                match key {
+                    $($key => Some(Self::$variant),)+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+settings! {
+    /// A setting picked from a list of alternatives.
+    ChoiceSetting {
+        InstallationMode => "installation_mode",
+        Compression => "compression",
+        Encryption => "encryption",
+        SwapMode => "swap_mode",
+        InitSystem => "init_system",
+        Audio => "audio",
+        SeatAccess => "seat_access",
+        Profile => "profile",
+        NetworkCopyIso => "network",
+    }
+}
+
+settings! {
+    /// A setting naming a block device.
+    DeviceSetting {
+        Disk => "disk",
+        EfiPartition => "efi_partition",
+        ZfsPartition => "zfs_partition",
+        SwapPartition => "swap_partition",
+    }
+}
+
+settings! {
+    /// A setting edited as free text.
+    TextSetting {
+        PoolName => "pool_name",
+        DatasetPrefix => "dataset_prefix",
+        Hostname => "hostname",
+        Locale => "locale",
+        Timezone => "timezone",
+        RootPassword => "root_password",
+        EncryptionPassword => "encryption_password",
+        SwapPartitionSize => "swap_partition_size",
+        ParallelDownloads => "parallel_downloads",
+        AdditionalPackages => "additional_packages",
+        AurPackages => "aur_packages",
+        ExtraServices => "extra_services",
+    }
+}
+
+/// Apply a choice made at position `index` of the setting's list.
+///
+/// An index outside the list leaves the configuration untouched: the lists are
+/// built from the same tables this resolves against, so it can only mean the
+/// two got out of step, and guessing a variant would be worse than doing
+/// nothing.
+pub fn apply_choice(config: &mut GlobalConfig, setting: ChoiceSetting, index: usize) {
+    match setting {
+        ChoiceSetting::InstallationMode => {
+            let Some(mode) = InstallationMode::from_index(index) else {
+                return;
+            };
+            // Devices chosen under one mode mean nothing under another.
+            if config.installation_mode != Some(mode) {
+                config.disk = None;
+                config.efi_partition = None;
+                config.zfs_partition = None;
+                config.swap_partition = None;
+            }
+            config.installation_mode = Some(mode);
+        }
+        ChoiceSetting::Compression => {
+            if let Some(algo) = CompressionAlgo::from_index(index) {
+                config.compression = algo;
+            }
+        }
+        ChoiceSetting::Encryption => {
+            let Some(mode) = ZfsEncryptionMode::from_index(index) else {
+                return;
+            };
+            config.zfs_encryption_mode = mode;
+            if mode == ZfsEncryptionMode::None {
+                config.zfs_encryption_password = None;
+            }
+        }
+        ChoiceSetting::SwapMode => {
+            if let Some(mode) = SwapMode::from_index(index) {
+                config.swap_mode = mode;
+            }
+        }
+        ChoiceSetting::InitSystem => {
+            if let Some(init) = InitSystem::from_index(index) {
+                config.init_system = init;
+            }
+        }
+        ChoiceSetting::Audio => {
+            if let Some(server) = <Option<AudioServer>>::from_index(index) {
+                config.audio = server;
+            }
+        }
+        ChoiceSetting::SeatAccess => {
+            if let (Some(selection), Some(access)) = (
+                config.profile_selection.as_mut(),
+                <Option<SeatAccess>>::from_index(index),
+            ) {
+                selection.seat_access = access;
+            }
+        }
+        ChoiceSetting::Profile => {
+            // Position 0 is "no profile"; the registry follows.
+            config.profile_selection = index
+                .checked_sub(1)
+                .and_then(|i| crate::profile::all_profiles().get(i).map(|p| p.name))
+                .and_then(ProfileSelection::new);
+        }
+        ChoiceSetting::NetworkCopyIso => config.network_copy_iso = index == 0,
+    }
+}
+
+/// Apply a block device selection.
+pub fn apply_device(config: &mut GlobalConfig, setting: DeviceSetting, path: &Path) {
+    let path = path.to_path_buf();
+    match setting {
+        DeviceSetting::Disk => {
+            // Choosing a disk is what puts the wizard in full-disk mode.
+            config.installation_mode = Some(InstallationMode::FullDisk);
+            config.disk = Some(path);
+        }
+        DeviceSetting::EfiPartition => config.efi_partition = Some(path),
+        DeviceSetting::ZfsPartition => config.zfs_partition = Some(path),
+        DeviceSetting::SwapPartition => config.swap_partition = Some(path),
+    }
+}
+
+/// Apply text typed into a setting.
+///
+/// Empty clears the optional settings, which is how a user removes a value
+/// they have already entered. The two that cannot be empty — the dataset
+/// prefix and the download count — keep their previous value instead.
+pub fn apply_text(config: &mut GlobalConfig, setting: TextSetting, value: &str) {
+    let text = (!value.is_empty()).then(|| value.to_string());
+
+    match setting {
+        TextSetting::PoolName => config.pool_name = text,
+        TextSetting::Hostname => config.hostname = text,
+        TextSetting::Locale => config.locale = text,
+        TextSetting::Timezone => config.timezone = text,
+        TextSetting::RootPassword => config.root_password = text,
+        TextSetting::EncryptionPassword => config.zfs_encryption_password = text,
+        TextSetting::SwapPartitionSize => config.swap_partition_size = text,
+        TextSetting::DatasetPrefix => {
+            if let Some(prefix) = text {
+                config.dataset_prefix = prefix;
+            }
+        }
+        TextSetting::ParallelDownloads => {
+            if let Ok(count) = value.parse::<u32>() {
+                config.parallel_downloads = count.clamp(1, 20);
+            }
+        }
+        TextSetting::AdditionalPackages => config.additional_packages = package_list(value),
+        TextSetting::AurPackages => config.aur_packages = package_list(value),
+        TextSetting::ExtraServices => config.extra_services = package_list(value),
+    }
+}
+
+/// Split a whitespace- or comma-separated list of names.
+fn package_list(value: &str) -> Vec<String> {
+    value
+        .split_whitespace()
+        .map(|name| name.trim_matches(',').to_string())
+        .filter(|name| !name.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> GlobalConfig {
+        GlobalConfig::default()
+    }
+
+    /// Keys round-trip, and no two settings share one.
+    #[test]
+    fn keys_are_unique_and_reversible() {
+        fn check<T: std::fmt::Debug + Copy + PartialEq>(
+            all: &[T],
+            as_str: impl Fn(T) -> &'static str,
+            parse: impl Fn(&str) -> Option<T>,
+        ) {
+            let mut seen: Vec<&str> = Vec::new();
+            for setting in all {
+                let key = as_str(*setting);
+                assert_eq!(
+                    parse(key),
+                    Some(*setting),
+                    "{setting:?} does not round-trip"
+                );
+                assert!(!seen.contains(&key), "{key} is used by two settings");
+                seen.push(key);
+            }
+            assert_eq!(parse("no-such-key"), None);
+        }
+
+        check(
+            ChoiceSetting::ALL,
+            ChoiceSetting::as_str,
+            ChoiceSetting::parse,
+        );
+        check(
+            DeviceSetting::ALL,
+            DeviceSetting::as_str,
+            DeviceSetting::parse,
+        );
+        check(TextSetting::ALL, TextSetting::as_str, TextSetting::parse);
+    }
+
+    #[test]
+    fn changing_installation_mode_clears_devices_chosen_for_the_old_one() {
+        let mut c = cfg();
+        apply_device(&mut c, DeviceSetting::Disk, Path::new("/dev/sda"));
+        apply_device(&mut c, DeviceSetting::EfiPartition, Path::new("/dev/sda1"));
+
+        apply_choice(&mut c, ChoiceSetting::InstallationMode, 1);
+
+        assert_eq!(c.installation_mode, Some(InstallationMode::NewPool));
+        assert!(c.disk.is_none());
+        assert!(c.efi_partition.is_none());
+    }
+
+    #[test]
+    fn reselecting_the_same_mode_keeps_the_devices() {
+        let mut c = cfg();
+        apply_choice(&mut c, ChoiceSetting::InstallationMode, 0);
+        apply_device(&mut c, DeviceSetting::Disk, Path::new("/dev/sda"));
+
+        apply_choice(&mut c, ChoiceSetting::InstallationMode, 0);
+
+        assert_eq!(c.disk.as_deref(), Some(Path::new("/dev/sda")));
+    }
+
+    #[test]
+    fn turning_encryption_off_discards_the_passphrase() {
+        let mut c = cfg();
+        apply_choice(&mut c, ChoiceSetting::Encryption, 1);
+        apply_text(&mut c, TextSetting::EncryptionPassword, "hunter2hunter2");
+        assert!(c.zfs_encryption_password.is_some());
+
+        apply_choice(&mut c, ChoiceSetting::Encryption, 0);
+
+        assert_eq!(c.zfs_encryption_mode, ZfsEncryptionMode::None);
+        assert!(
+            c.zfs_encryption_password.is_none(),
+            "a passphrase must not outlive the encryption it was for"
+        );
+    }
+
+    #[test]
+    fn an_index_outside_the_list_changes_nothing() {
+        let mut c = cfg();
+        let before = c.compression;
+
+        apply_choice(&mut c, ChoiceSetting::Compression, 99);
+
+        assert_eq!(c.compression, before);
+    }
+
+    #[test]
+    fn choosing_a_disk_selects_full_disk_mode() {
+        let mut c = cfg();
+        apply_device(&mut c, DeviceSetting::Disk, Path::new("/dev/disk/by-id/x"));
+
+        assert_eq!(c.installation_mode, Some(InstallationMode::FullDisk));
+        assert_eq!(c.disk.as_deref(), Some(Path::new("/dev/disk/by-id/x")));
+    }
+
+    #[test]
+    fn empty_text_clears_optional_settings() {
+        let mut c = cfg();
+        apply_text(&mut c, TextSetting::Hostname, "box");
+        assert_eq!(c.hostname.as_deref(), Some("box"));
+
+        apply_text(&mut c, TextSetting::Hostname, "");
+
+        assert!(c.hostname.is_none());
+    }
+
+    #[test]
+    fn settings_that_cannot_be_empty_keep_their_value() {
+        let mut c = cfg();
+        apply_text(&mut c, TextSetting::DatasetPrefix, "arch1");
+
+        apply_text(&mut c, TextSetting::DatasetPrefix, "");
+
+        assert_eq!(c.dataset_prefix, "arch1");
+    }
+
+    #[test]
+    fn the_download_count_is_clamped_and_garbage_is_ignored() {
+        let mut c = cfg();
+
+        apply_text(&mut c, TextSetting::ParallelDownloads, "999");
+        assert_eq!(c.parallel_downloads, 20);
+
+        apply_text(&mut c, TextSetting::ParallelDownloads, "0");
+        assert_eq!(c.parallel_downloads, 1);
+
+        apply_text(&mut c, TextSetting::ParallelDownloads, "eight");
+        assert_eq!(c.parallel_downloads, 1, "unparsable input is not a change");
+    }
+
+    #[test]
+    fn package_lists_accept_spaces_and_commas() {
+        let mut c = cfg();
+
+        apply_text(&mut c, TextSetting::AdditionalPackages, "vim, git  htop,");
+
+        assert_eq!(c.additional_packages, vec!["vim", "git", "htop"]);
+    }
+
+    #[test]
+    fn profile_position_zero_means_no_profile() {
+        let mut c = cfg();
+        apply_choice(&mut c, ChoiceSetting::Profile, 1);
+        assert!(c.profile_selection.is_some());
+
+        apply_choice(&mut c, ChoiceSetting::Profile, 0);
+
+        assert!(c.profile_selection.is_none());
+    }
+}

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -1,3 +1,4 @@
+pub mod choices;
 pub mod io;
 pub mod types;
 pub mod validation;

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod choices;
+pub mod edit;
 pub mod io;
 pub mod types;
 pub mod validation;

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use super::validation::ValidationError;
+
 use crate::profile::DisplayManager;
 use crate::system::gpu::GfxDriver;
 
@@ -447,67 +449,44 @@ fn is_supported_device_path(path: &std::path::Path) -> bool {
             || name.starts_with("mmcblk"))
 }
 
-/// Validates the config and returns a list of error messages.
-/// Empty list means the config is valid for installation.
+/// Field-level checks, shared by `validate_for_install` and by interfaces
+/// that want to flag a single field as it is edited.
 impl GlobalConfig {
-    pub fn validate_pool_name(&self) -> Vec<String> {
-        let mut errors = Vec::new();
-        if let Some(ref name) = self.pool_name
-            && !is_valid_pool_name(name)
-        {
-            errors.push(format!(
-                "Pool name '{name}' is invalid: must be alphanumeric, underscores, or hyphens"
-            ));
+    pub fn validate_pool_name(&self) -> Vec<ValidationError> {
+        match &self.pool_name {
+            Some(name) if !is_valid_pool_name(name) => {
+                vec![ValidationError::PoolNameInvalid(name.clone())]
+            }
+            _ => Vec::new(),
         }
-        errors
     }
 
-    pub fn validate_dataset_prefix(&self) -> Vec<String> {
-        let mut errors = Vec::new();
-        if !is_valid_dataset_prefix(&self.dataset_prefix) {
-            errors.push(format!(
-                "Dataset prefix '{}' is invalid: must be alphanumeric, underscores, or hyphens",
-                self.dataset_prefix
-            ));
+    pub fn validate_dataset_prefix(&self) -> Vec<ValidationError> {
+        if is_valid_dataset_prefix(&self.dataset_prefix) {
+            Vec::new()
+        } else {
+            vec![ValidationError::DatasetPrefixInvalid(
+                self.dataset_prefix.clone(),
+            )]
         }
-        errors
     }
 
-    pub fn validate_device_paths(&self) -> Vec<String> {
-        let mut errors = Vec::new();
-        if let Some(ref p) = self.disk
-            && !is_supported_device_path(p)
-        {
-            errors.push(format!(
-                "disk must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
-                p.display()
-            ));
-        }
-        if let Some(ref p) = self.efi_partition
-            && !is_supported_device_path(p)
-        {
-            errors.push(format!(
-                "efi_partition must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
-                p.display()
-            ));
-        }
-        if let Some(ref p) = self.zfs_partition
-            && !is_supported_device_path(p)
-        {
-            errors.push(format!(
-                "zfs_partition must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
-                p.display()
-            ));
-        }
-        if let Some(ref p) = self.swap_partition
-            && !is_supported_device_path(p)
-        {
-            errors.push(format!(
-                "swap_partition must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node path, got: {}",
-                p.display()
-            ));
-        }
-        errors
+    pub fn validate_device_paths(&self) -> Vec<ValidationError> {
+        [
+            ("disk", self.disk.as_ref()),
+            ("efi_partition", self.efi_partition.as_ref()),
+            ("zfs_partition", self.zfs_partition.as_ref()),
+            ("swap_partition", self.swap_partition.as_ref()),
+        ]
+        .into_iter()
+        .filter_map(|(setting, path)| {
+            let path = path?;
+            (!is_supported_device_path(path)).then(|| ValidationError::DevicePathUnsupported {
+                setting,
+                path: path.clone(),
+            })
+        })
+        .collect()
     }
 }
 

--- a/core/src/config/validation.rs
+++ b/core/src/config/validation.rs
@@ -1,6 +1,43 @@
+use std::fmt;
+use std::path::PathBuf;
+
 use super::types::{
     GlobalConfig, InstallationMode, SwapMode, ZFS_PASSPHRASE_MIN_LENGTH, ZfsEncryptionMode,
 };
+
+/// Something about the configuration that stops the installation.
+///
+/// A value rather than a sentence: the sentence is one rendering of it, and
+/// an interface that wants to point at the offending field needs the parts,
+/// not the prose. Rendering lives in the `Display` implementation below, so
+/// every interface words a given problem the same way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    InstallationModeNotSelected,
+    PoolNameMissing,
+    PoolNameInvalid(String),
+    DatasetPrefixInvalid(String),
+    /// A device path the installer will not accept, and the setting it was
+    /// given for.
+    DevicePathUnsupported {
+        setting: &'static str,
+        path: PathBuf,
+    },
+    DiskRequired,
+    EfiPartitionRequired(InstallationMode),
+    ZfsPartitionRequired,
+    /// Full-disk mode carves the swap partition itself and needs its size.
+    SwapSizeRequired,
+    /// The other modes need an existing partition to use.
+    SwapPartitionRequired(InstallationMode),
+    EncryptionPasswordMissing,
+    EncryptionPasswordTooShort {
+        minimum: usize,
+    },
+    HostnameInvalid(String),
+    UnknownKernel(String),
+    UsernameInvalid(String),
+}
 
 /// Valid Linux hostname: 1-63 chars, alphanumeric + hyphens, no leading/trailing hyphen.
 fn is_valid_hostname(name: &str) -> bool {
@@ -22,134 +59,149 @@ pub fn is_valid_username(name: &str) -> bool {
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
 }
 
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InstallationModeNotSelected => write!(f, "Installation mode not selected"),
+            Self::PoolNameMissing => write!(f, "Pool name is required"),
+            Self::PoolNameInvalid(name) => write!(
+                f,
+                "Pool name '{name}' is invalid: must be alphanumeric, underscores, or hyphens"
+            ),
+            Self::DatasetPrefixInvalid(prefix) => write!(
+                f,
+                "Dataset prefix '{prefix}' is invalid: must be alphanumeric, underscores, or hyphens"
+            ),
+            Self::DevicePathUnsupported { setting, path } => write!(
+                f,
+                "{setting} must be a /dev/disk/by-id/, /dev/disk/by-path/, or supported /dev node \
+                 path, got: {}",
+                path.display()
+            ),
+            Self::DiskRequired => write!(f, "Full disk mode requires a disk selection (disk)"),
+            Self::EfiPartitionRequired(mode) => {
+                write!(f, "{} mode requires an EFI partition (efi_partition)", mode)
+            }
+            Self::ZfsPartitionRequired => {
+                write!(f, "New pool mode requires a ZFS partition (zfs_partition)")
+            }
+            Self::SwapSizeRequired => write!(
+                f,
+                "Swap partition mode requires swap_partition_size in full disk mode"
+            ),
+            Self::SwapPartitionRequired(mode) => write!(
+                f,
+                "Swap partition mode requires swap_partition in {} mode",
+                mode.to_string().to_lowercase()
+            ),
+            Self::EncryptionPasswordMissing => {
+                write!(f, "Encryption enabled but no password provided")
+            }
+            Self::EncryptionPasswordTooShort { minimum } => {
+                write!(
+                    f,
+                    "Encryption password must be at least {minimum} characters"
+                )
+            }
+            Self::HostnameInvalid(name) => write!(
+                f,
+                "Hostname '{name}' is invalid: must be 1-63 chars, alphanumeric and hyphens, no \
+                 leading/trailing hyphen"
+            ),
+            Self::UnknownKernel(name) => {
+                let known: Vec<&str> = crate::kernel::AVAILABLE_KERNELS
+                    .iter()
+                    .map(|k| k.name)
+                    .collect();
+                write!(
+                    f,
+                    "Unknown kernel '{name}'. Available: {}",
+                    known.join(", ")
+                )
+            }
+            Self::UsernameInvalid(name) => write!(
+                f,
+                "Username '{name}' is invalid: must be 1-32 chars, start with lowercase letter or \
+                 underscore, contain only lowercase, digits, underscore, hyphen"
+            ),
+        }
+    }
+}
+
 impl GlobalConfig {
-    /// Validate configuration for installation.
-    /// Returns a list of error messages. Empty means valid.
-    pub fn validate_for_install(&self) -> Vec<String> {
+    /// Everything about this configuration that stops the installation.
+    /// Empty means it can proceed.
+    pub fn validate_for_install(&self) -> Vec<ValidationError> {
         let mut errors = Vec::new();
 
-        // Must have an installation mode
-        let mode = match self.installation_mode {
-            Some(m) => m,
-            None => {
-                errors.push("Installation mode not selected".to_string());
-                return errors;
-            }
+        // Without a mode there is nothing to check the rest against.
+        let Some(mode) = self.installation_mode else {
+            return vec![ValidationError::InstallationModeNotSelected];
         };
 
-        // Pool name required for all modes
         if self.pool_name.is_none() {
-            errors.push("Pool name is required".to_string());
+            errors.push(ValidationError::PoolNameMissing);
         }
         errors.extend(self.validate_pool_name());
         errors.extend(self.validate_dataset_prefix());
         errors.extend(self.validate_device_paths());
 
-        // Mode-dependent validation
+        let wants_swap_partition = matches!(
+            self.swap_mode,
+            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+        );
+
         match mode {
             InstallationMode::FullDisk => {
                 if self.disk.is_none() {
-                    errors.push("Full disk mode requires a disk selection (disk)".to_string());
+                    errors.push(ValidationError::DiskRequired);
                 }
-                if matches!(
-                    self.swap_mode,
-                    SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-                ) && self.swap_partition_size.is_none()
-                {
-                    errors.push(
-                        "Swap partition mode requires swap_partition_size in full disk mode"
-                            .to_string(),
-                    );
+                // Full-disk mode creates the partition, so it needs a size
+                // rather than an existing one.
+                if wants_swap_partition && self.swap_partition_size.is_none() {
+                    errors.push(ValidationError::SwapSizeRequired);
                 }
             }
-            InstallationMode::NewPool => {
+            InstallationMode::NewPool | InstallationMode::ExistingPool => {
                 if self.efi_partition.is_none() {
-                    errors.push(
-                        "New pool mode requires an EFI partition (efi_partition)".to_string(),
-                    );
+                    errors.push(ValidationError::EfiPartitionRequired(mode));
                 }
-                if self.zfs_partition.is_none() {
-                    errors
-                        .push("New pool mode requires a ZFS partition (zfs_partition)".to_string());
+                if mode == InstallationMode::NewPool && self.zfs_partition.is_none() {
+                    errors.push(ValidationError::ZfsPartitionRequired);
                 }
-                if matches!(
-                    self.swap_mode,
-                    SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-                ) && self.swap_partition.is_none()
-                {
-                    errors.push(
-                        "Swap partition mode requires swap_partition in new pool mode".to_string(),
-                    );
-                }
-            }
-            InstallationMode::ExistingPool => {
-                if self.efi_partition.is_none() {
-                    errors.push(
-                        "Existing pool mode requires an EFI partition (efi_partition)".to_string(),
-                    );
-                }
-                if matches!(
-                    self.swap_mode,
-                    SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-                ) && self.swap_partition.is_none()
-                {
-                    errors.push(
-                        "Swap partition mode requires swap_partition in existing pool mode"
-                            .to_string(),
-                    );
+                if wants_swap_partition && self.swap_partition.is_none() {
+                    errors.push(ValidationError::SwapPartitionRequired(mode));
                 }
             }
         }
 
-        // Encryption validation
         if self.zfs_encryption_mode != ZfsEncryptionMode::None {
             match &self.zfs_encryption_password {
-                None => {
-                    errors.push("Encryption enabled but no password provided".to_string());
+                None => errors.push(ValidationError::EncryptionPasswordMissing),
+                Some(password) if password.len() < ZFS_PASSPHRASE_MIN_LENGTH => {
+                    errors.push(ValidationError::EncryptionPasswordTooShort {
+                        minimum: ZFS_PASSPHRASE_MIN_LENGTH,
+                    });
                 }
-                Some(pw) if pw.len() < ZFS_PASSPHRASE_MIN_LENGTH => {
-                    errors.push(format!(
-                        "Encryption password must be at least {ZFS_PASSPHRASE_MIN_LENGTH} characters"
-                    ));
-                }
-                _ => {}
+                Some(_) => {}
             }
         }
 
-        // Hostname validation
-        if let Some(ref hostname) = self.hostname
+        if let Some(hostname) = &self.hostname
             && !is_valid_hostname(hostname)
         {
-            errors.push(format!(
-                    "Hostname '{hostname}' is invalid: must be 1-63 chars, alphanumeric and hyphens, no leading/trailing hyphen"
-                ));
+            errors.push(ValidationError::HostnameInvalid(hostname.clone()));
         }
 
-        // Kernel validation
-        if let Some(ref kernels) = self.kernels {
-            for kernel in kernels {
-                if crate::kernel::get_kernel_info(kernel).is_none() {
-                    let known: Vec<&str> = crate::kernel::AVAILABLE_KERNELS
-                        .iter()
-                        .map(|k| k.name)
-                        .collect();
-                    errors.push(format!(
-                        "Unknown kernel '{kernel}'. Available: {}",
-                        known.join(", ")
-                    ));
-                }
+        for kernel in self.kernels.iter().flatten() {
+            if crate::kernel::get_kernel_info(kernel).is_none() {
+                errors.push(ValidationError::UnknownKernel(kernel.clone()));
             }
         }
 
-        // User validation
-        if let Some(ref users) = self.users {
-            for user in users {
-                if !is_valid_username(&user.username) {
-                    errors.push(format!(
-                        "Username '{}' is invalid: must be 1-32 chars, start with lowercase letter or underscore, contain only lowercase, digits, underscore, hyphen",
-                        user.username
-                    ));
-                }
+        for user in self.users.iter().flatten() {
+            if !is_valid_username(&user.username) {
+                errors.push(ValidationError::UsernameInvalid(user.username.clone()));
             }
         }
 
@@ -159,6 +211,7 @@ impl GlobalConfig {
 
 #[cfg(test)]
 mod tests {
+    use super::ValidationError;
     use std::path::PathBuf;
 
     use super::*;
@@ -200,6 +253,32 @@ mod tests {
         }
     }
 
+    /// Every problem renders as something a user can act on, and the ones
+    /// carrying a value mention it.
+    #[test]
+    fn errors_render_with_their_details() {
+        assert_eq!(
+            ValidationError::PoolNameInvalid("bad name".into()).to_string(),
+            "Pool name 'bad name' is invalid: must be alphanumeric, underscores, or hyphens"
+        );
+        assert_eq!(
+            ValidationError::EncryptionPasswordTooShort { minimum: 8 }.to_string(),
+            "Encryption password must be at least 8 characters"
+        );
+        assert!(
+            ValidationError::EfiPartitionRequired(InstallationMode::ExistingPool)
+                .to_string()
+                .starts_with("Existing Pool mode"),
+            "the mode belongs in the message"
+        );
+        assert!(
+            ValidationError::UnknownKernel("linux-custom".into())
+                .to_string()
+                .contains("linux-lts"),
+            "an unknown kernel should list the known ones"
+        );
+    }
+
     #[test]
     fn test_valid_full_disk() {
         let cfg = valid_full_disk_config();
@@ -225,7 +304,11 @@ mod tests {
     fn test_no_installation_mode() {
         let cfg = GlobalConfig::default();
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Installation mode")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::InstallationModeNotSelected))
+        );
     }
 
     #[test]
@@ -233,7 +316,11 @@ mod tests {
         let mut cfg = valid_full_disk_config();
         cfg.disk = None;
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("disk selection")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::DiskRequired))
+        );
     }
 
     #[test]
@@ -242,8 +329,16 @@ mod tests {
         cfg.efi_partition = None;
         cfg.zfs_partition = None;
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("EFI partition")));
-        assert!(errors.iter().any(|e| e.contains("ZFS partition")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::EfiPartitionRequired(_)))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::ZfsPartitionRequired))
+        );
     }
 
     #[test]
@@ -251,7 +346,11 @@ mod tests {
         let mut cfg = valid_existing_pool_config();
         cfg.efi_partition = None;
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("EFI partition")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::EfiPartitionRequired(_)))
+        );
     }
 
     #[test]
@@ -259,7 +358,11 @@ mod tests {
         let mut cfg = valid_full_disk_config();
         cfg.pool_name = None;
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Pool name")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::PoolNameMissing))
+        );
     }
 
     #[test]
@@ -268,7 +371,11 @@ mod tests {
         cfg.zfs_encryption_mode = ZfsEncryptionMode::Pool;
         cfg.zfs_encryption_password = None;
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("no password")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::EncryptionPasswordMissing))
+        );
     }
 
     #[test]
@@ -277,7 +384,11 @@ mod tests {
         cfg.zfs_encryption_mode = ZfsEncryptionMode::Dataset;
         cfg.zfs_encryption_password = Some("short".to_string());
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("at least")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::EncryptionPasswordTooShort { .. }))
+        );
     }
 
     #[test]
@@ -295,7 +406,11 @@ mod tests {
         cfg.swap_mode = SwapMode::ZswapPartition;
         cfg.swap_partition_size = None;
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("swap_partition_size")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::SwapSizeRequired))
+        );
     }
 
     #[test]
@@ -313,7 +428,11 @@ mod tests {
         cfg.swap_mode = SwapMode::ZswapPartitionEncrypted;
         cfg.swap_partition = None;
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("swap_partition")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::SwapPartitionRequired(_)))
+        );
     }
 
     #[test]
@@ -345,7 +464,11 @@ mod tests {
         let mut cfg = valid_full_disk_config();
         cfg.disk = Some(PathBuf::from("/tmp/not-a-disk"));
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("supported /dev node")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::DevicePathUnsupported { .. }))
+        );
     }
 
     #[test]
@@ -361,7 +484,11 @@ mod tests {
         let mut cfg = valid_full_disk_config();
         cfg.hostname = Some("-badhost".to_string());
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Hostname")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::HostnameInvalid(_)))
+        );
     }
 
     #[test]
@@ -369,7 +496,11 @@ mod tests {
         let mut cfg = valid_full_disk_config();
         cfg.hostname = Some("host.name".to_string());
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Hostname")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::HostnameInvalid(_)))
+        );
     }
 
     #[test]
@@ -377,7 +508,11 @@ mod tests {
         let mut cfg = valid_full_disk_config();
         cfg.hostname = Some("a".repeat(64));
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Hostname")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::HostnameInvalid(_)))
+        );
     }
 
     #[test]
@@ -385,7 +520,11 @@ mod tests {
         let mut cfg = valid_full_disk_config();
         cfg.kernels = Some(vec!["linux-custom".to_string()]);
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Unknown kernel")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::UnknownKernel(_)))
+        );
     }
 
     #[test]
@@ -425,7 +564,11 @@ mod tests {
             autologin: false,
         }]);
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Username")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::UsernameInvalid(_)))
+        );
     }
 
     #[test]
@@ -441,7 +584,11 @@ mod tests {
             autologin: false,
         }]);
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Username")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::UsernameInvalid(_)))
+        );
     }
 
     #[test]
@@ -457,7 +604,11 @@ mod tests {
             autologin: false,
         }]);
         let errors = cfg.validate_for_install();
-        assert!(errors.iter().any(|e| e.contains("Username")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::UsernameInvalid(_)))
+        );
     }
 
     #[test]

--- a/core/src/dataset_layout.rs
+++ b/core/src/dataset_layout.rs
@@ -1,4 +1,6 @@
 use color_eyre::eyre::{Result, bail};
+
+use crate::boot_environment::BootEnvironment;
 use zfskit::dataset::{CreateOptions, MountOptions};
 
 pub struct DatasetConfig {
@@ -53,11 +55,10 @@ pub async fn dataset_exists(zfs: &zfskit::Zfs, name: &str) -> Result<bool> {
 
 pub async fn create_base_dataset(
     zfs: &zfskit::Zfs,
-    pool_name: &str,
-    prefix: &str,
+    be: &BootEnvironment,
     encryption_props: &[(&str, &str)],
 ) -> Result<()> {
-    let base_name = format!("{pool_name}/{prefix}");
+    let base_name = be.base();
     if dataset_exists(zfs, &base_name).await? {
         bail!(
             "Dataset '{base_name}' already exists. \
@@ -69,8 +70,7 @@ pub async fn create_base_dataset(
 
 pub async fn create_child_datasets(
     zfs: &zfskit::Zfs,
-    pool_name: &str,
-    prefix: &str,
+    be: &BootEnvironment,
     datasets: &[DatasetConfig],
 ) -> Result<()> {
     // Sort by depth (number of slashes) to ensure parents are created first
@@ -87,13 +87,13 @@ pub async fn create_child_datasets(
         let parts: Vec<&str> = ds.name.split('/').collect();
         for depth in 1..parts.len() {
             let ancestor = parts[..depth].join("/");
-            let ancestor_full = format!("{pool_name}/{prefix}/{ancestor}");
+            let ancestor_full = be.child(&ancestor);
             if created.insert(ancestor_full.clone()) {
                 create_dataset(zfs, &ancestor_full, &[("mountpoint", "none")]).await?;
             }
         }
 
-        let full_name = format!("{pool_name}/{prefix}/{}", ds.name);
+        let full_name = be.child(&ds.name);
         let props: Vec<(&str, &str)> = ds
             .properties
             .iter()
@@ -107,12 +107,11 @@ pub async fn create_child_datasets(
 
 pub async fn mount_datasets_ordered(
     zfs: &zfskit::Zfs,
-    pool_name: &str,
-    prefix: &str,
+    be: &BootEnvironment,
     datasets: &[DatasetConfig],
 ) -> Result<()> {
     // Mount root dataset first (canmount=noauto)
-    let root_ds = format!("{pool_name}/{prefix}/root");
+    let root_ds = be.root();
     zfs.dataset(&root_ds)?
         .mount(&MountOptions::default())
         .await?;
@@ -124,7 +123,7 @@ pub async fn mount_datasets_ordered(
     children.sort_by_key(|dataset| dataset.name.matches('/').count());
 
     for dataset in children {
-        let full_name = format!("{pool_name}/{prefix}/{}", dataset.name);
+        let full_name = be.child(&dataset.name);
         zfs.dataset(&full_name)?
             .mount(&MountOptions::default())
             .await?;
@@ -218,7 +217,7 @@ mod tests {
             );
 
         let zfs = Zfs::with_runner(runner);
-        create_child_datasets(&zfs, "pool", "arch0", &datasets)
+        create_child_datasets(&zfs, &BootEnvironment::new("pool", "arch0"), &datasets)
             .await
             .expect("create_child_datasets succeeds");
     }
@@ -262,7 +261,7 @@ mod tests {
             );
 
         let zfs = Zfs::with_runner(runner);
-        create_child_datasets(&zfs, "pool", "arch0", &datasets)
+        create_child_datasets(&zfs, &BootEnvironment::new("pool", "arch0"), &datasets)
             .await
             .expect("every intermediate dataset is created");
     }
@@ -297,7 +296,7 @@ mod tests {
             );
 
         let zfs = Zfs::with_runner(runner);
-        mount_datasets_ordered(&zfs, "pool", "arch0", &datasets)
+        mount_datasets_ordered(&zfs, &BootEnvironment::new("pool", "arch0"), &datasets)
             .await
             .expect("selected boot environment mounts");
     }
@@ -332,7 +331,7 @@ mod tests {
             );
 
         let zfs = Zfs::with_runner(runner);
-        let error = mount_datasets_ordered(&zfs, "pool", "arch0", &datasets)
+        let error = mount_datasets_ordered(&zfs, &BootEnvironment::new("pool", "arch0"), &datasets)
             .await
             .expect_err("non-empty mountpoint must stop installation");
         assert!(error.to_string().contains("directory is not empty"));

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -23,6 +23,7 @@ use color_eyre::eyre::{Result, bail, eyre};
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
+use crate::boot_environment::BootEnvironment;
 use crate::config::types::{GlobalConfig, SwapMode};
 use crate::system::async_download::{DownloadConfig, DownloadProgress};
 use crate::system::cmd::CommandRunner;
@@ -47,7 +48,7 @@ pub async fn run_install(
         .as_deref()
         .ok_or_else(|| eyre!("pool name not set"))?
         .to_string();
-    let root_dataset = format!("{pool_name}/{}/root", config.dataset_prefix);
+    let root_dataset = BootEnvironment::new(&pool_name, config.dataset_prefix.as_str()).root();
     let cleanup = Arc::new(CleanupState::default());
 
     let result = install(runner.clone(), config, cancel, progress_tx, cleanup.clone()).await;
@@ -137,7 +138,7 @@ async fn install(
         .as_deref()
         .ok_or_else(|| eyre!("pool name not set"))?
         .to_string();
-    let prefix = config.dataset_prefix.clone();
+    let be = BootEnvironment::new(&pool_name, config.dataset_prefix.as_str());
     let kernel = config.primary_kernel().to_string();
     let download_config = DownloadConfig {
         concurrency: config.parallel_downloads as usize,
@@ -265,14 +266,8 @@ async fn install(
         config.swap_mode,
         SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
     );
-    crate::bootmenu::set_zbm_properties(
-        &pool_name,
-        &prefix,
-        config.init_system,
-        zswap_on,
-        config.set_bootfs,
-    )
-    .await?;
+    crate::bootmenu::set_zbm_properties(&be, config.init_system, zswap_on, config.set_bootfs)
+        .await?;
 
     crate::bootmenu::install_and_generate_zbm(
         runner.clone(),

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -25,11 +25,42 @@ use tokio_util::sync::CancellationToken;
 
 use crate::boot_environment::BootEnvironment;
 use crate::config::types::{GlobalConfig, SwapMode};
+use crate::config::validation::ValidationError;
 use crate::system::async_download::{DownloadConfig, DownloadProgress};
 use crate::system::cmd::CommandRunner;
 
 /// Where the pool is mounted while the target system is assembled.
 const MOUNTPOINT: &str = "/mnt";
+
+/// Why an installation stopped.
+///
+/// The interfaces need to tell a cancellation from a failure — one is a
+/// button the user pressed, the other is a problem to report — and they used
+/// to work it out by asking the cancellation token themselves, each in its own
+/// way, while the pipeline said only "installation cancelled" in prose.
+/// Deciding it once, here, is what lets them match on it.
+#[derive(Debug, thiserror::Error)]
+pub enum InstallError {
+    /// The user asked for the installation to stop.
+    #[error("installation cancelled")]
+    Cancelled,
+
+    /// The configuration cannot be installed as it stands.
+    #[error("configuration is not valid:\n  {}", render(.0))]
+    InvalidConfig(Vec<ValidationError>),
+
+    /// Anything that went wrong while installing.
+    #[error(transparent)]
+    Failed(#[from] color_eyre::Report),
+}
+
+fn render(errors: &[ValidationError]) -> String {
+    errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n  ")
+}
 
 type ProgressSender = Arc<watch::Sender<DownloadProgress>>;
 
@@ -42,7 +73,12 @@ pub async fn run_install(
     config: GlobalConfig,
     cancel: CancellationToken,
     progress_tx: Option<ProgressSender>,
-) -> Result<()> {
+) -> Result<(), InstallError> {
+    let problems = config.validate_for_install();
+    if !problems.is_empty() {
+        return Err(InstallError::InvalidConfig(problems));
+    }
+
     let pool_name = config
         .pool_name
         .as_deref()
@@ -51,13 +87,29 @@ pub async fn run_install(
     let root_dataset = BootEnvironment::new(&pool_name, config.dataset_prefix.as_str()).root();
     let cleanup = Arc::new(CleanupState::default());
 
-    let result = install(runner.clone(), config, cancel, progress_tx, cleanup.clone()).await;
+    let result = install(
+        runner.clone(),
+        config,
+        cancel.clone(),
+        progress_tx,
+        cleanup.clone(),
+    )
+    .await;
 
     cleanup
         .run(&*runner, &pool_name, &root_dataset, result.is_ok())
         .await?;
 
-    result?;
+    // A cancelled run fails wherever it happened to be — inside a download,
+    // between phases, part-way through a chroot command — so the token is what
+    // says whether the failure was asked for.
+    result.map_err(|error| {
+        if cancel.is_cancelled() {
+            InstallError::Cancelled
+        } else {
+            InstallError::Failed(error)
+        }
+    })?;
     tracing::info!("Installation complete!");
     Ok(())
 }
@@ -351,6 +403,51 @@ mod tests {
         assert!(cleanup.pool_preexisting.load(Ordering::Acquire));
         assert!(!cleanup.pool_setup_started.load(Ordering::Acquire));
         assert!(!cleanup.efi_mounted.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn an_invalid_configuration_is_reported_as_such() {
+        let runner: Arc<dyn CommandRunner> =
+            Arc::new(crate::system::cmd::tests::RecordingRunner::new(vec![]));
+
+        // No installation mode: nothing about this can be installed.
+        let error = run_install(
+            runner,
+            GlobalConfig::default(),
+            CancellationToken::new(),
+            None,
+        )
+        .await
+        .expect_err("an unusable configuration must not start an installation");
+
+        assert!(
+            matches!(error, InstallError::InvalidConfig(_)),
+            "got {error:?}"
+        );
+        assert!(
+            error.to_string().contains("Installation mode not selected"),
+            "the reason belongs in the message: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_run_is_distinguishable_from_a_failure() {
+        let runner: Arc<dyn CommandRunner> =
+            Arc::new(crate::system::cmd::tests::RecordingRunner::new(vec![]));
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let config = GlobalConfig {
+            installation_mode: Some(crate::config::types::InstallationMode::FullDisk),
+            disk: Some(std::path::PathBuf::from("/dev/disk/by-id/test")),
+            ..Default::default()
+        };
+
+        let error = run_install(runner, config, cancel, None)
+            .await
+            .expect_err("a cancelled run does not succeed");
+
+        assert!(matches!(error, InstallError::Cancelled), "got {error:?}");
     }
 
     #[test]

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -289,18 +289,14 @@ async fn install(
         let cancel = cancel.clone();
         let progress_tx = progress_tx.clone();
         tokio::task::spawn_blocking(move || -> Result<Vec<String>> {
-            let mut installer = crate::installer::Installer::new(
+            crate::installer::perform_installation(crate::installer::InstallRequest {
                 runner,
-                (*config).clone(),
-                &mountpoint,
+                config: (*config).clone(),
+                target: mountpoint,
                 cancel,
-                progress_tx,
-            );
-            if let Some(swap) = swap_partition {
-                installer.set_swap_partition(swap);
-            }
-            installer.perform_installation()?;
-            Ok(installer.notices().to_vec())
+                download_progress_tx: progress_tx,
+                swap_partition,
+            })
         })
         .await??
     };

--- a/core/src/installer/fstab.rs
+++ b/core/src/installer/fstab.rs
@@ -3,13 +3,13 @@ use std::path::Path;
 
 use color_eyre::eyre::{Context, Result};
 
+use crate::boot_environment::BootEnvironment;
 use crate::system::cmd::{CommandRunner, check_exit};
 
 pub fn generate_fstab(
     runner: &dyn CommandRunner,
     target: &Path,
-    pool_name: &str,
-    prefix: &str,
+    be: &BootEnvironment,
 ) -> Result<()> {
     let target_str = target.to_string_lossy();
 
@@ -21,7 +21,7 @@ pub fn generate_fstab(
     let fstab_content: String = output
         .stdout
         .lines()
-        .filter(|line| !is_zfs_managed_mount(line, pool_name))
+        .filter(|line| !is_zfs_managed_mount(line, be.pool()))
         .map(|line| {
             // For the EFI mount (/boot/efi vfat), set passno to 0 (no fsck
             // for vfat) and ensure nofail so a failed mount doesn't block boot
@@ -46,7 +46,7 @@ pub fn generate_fstab(
         .join("\n");
 
     // Add root dataset explicitly
-    let root_ds = format!("{pool_name}/{prefix}/root");
+    let root_ds = be.root();
     let mut final_fstab = fstab_content;
     final_fstab.push_str(&format!(
         "\n# ZFS root dataset\n{root_ds}\t/\tzfs\tdefaults\t0\t0\n"
@@ -142,7 +142,12 @@ testpool/arch0/data/home /home zfs defaults 0 0
             ..Default::default()
         }]);
 
-        generate_fstab(&runner, dir.path(), "testpool", "arch0").unwrap();
+        generate_fstab(
+            &runner,
+            dir.path(),
+            &BootEnvironment::new("testpool", "arch0"),
+        )
+        .unwrap();
 
         let fstab = fs::read_to_string(dir.path().join("etc/fstab")).unwrap();
         // Should keep EFI entry
@@ -170,7 +175,7 @@ zroot/arch0/root\t/\tzfs\tdefaults\t0\t0
             ..Default::default()
         }]);
 
-        generate_fstab(&runner, dir.path(), "zroot", "arch0").unwrap();
+        generate_fstab(&runner, dir.path(), &BootEnvironment::new("zroot", "arch0")).unwrap();
 
         let fstab = fs::read_to_string(dir.path().join("etc/fstab")).unwrap();
         assert!(

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -21,17 +21,35 @@ use crate::system::alpm_pacman::{AlpmContext, TargetMounts};
 use crate::system::async_download::{DownloadConfig, DownloadProgress};
 use crate::system::cmd::CommandRunner;
 
-pub struct Installer {
+/// What an installation needs to know before it starts.
+pub struct InstallRequest {
     pub runner: Arc<dyn CommandRunner>,
     pub config: GlobalConfig,
     pub target: PathBuf,
+    pub cancel: CancellationToken,
+    pub download_progress_tx: Option<Arc<tokio::sync::watch::Sender<DownloadProgress>>>,
+    /// Swap partition computed at runtime by full-disk partitioning, which is
+    /// not in the configuration. Overrides `config.swap_partition`.
+    pub swap_partition: Option<PathBuf>,
+}
+
+/// Phases 4 to 12: the target system being assembled.
+///
+/// Constructed only once the base system is installed, because everything it
+/// does needs the package handle that becomes available at that point. Holding
+/// that handle as an `Option` and asserting it at each use made a state the
+/// type permitted but no method could survive.
+struct Installer {
+    runner: Arc<dyn CommandRunner>,
+    config: GlobalConfig,
+    target: PathBuf,
     cancel: CancellationToken,
     download_progress_tx: Option<Arc<tokio::sync::watch::Sender<DownloadProgress>>>,
-    /// Swap partition computed at runtime (e.g. from full-disk partitioning).
-    /// Overrides `config.swap_partition` when set.
     swap_partition: Option<PathBuf>,
-    _target_mounts: Option<TargetMounts>,
-    alpm_ctx: Option<AlpmContext>,
+    /// Unmounts the target's API filesystems when dropped; kept alive for as
+    /// long as anything runs inside the chroot.
+    _target_mounts: TargetMounts,
+    alpm: AlpmContext,
     /// Kernels that ended up with a working ZFS module. Only these get an
     /// initramfs: one built for a kernel with no module produces a boot entry
     /// that cannot import the pool.
@@ -40,28 +58,78 @@ pub struct Installer {
     notices: Vec<String>,
 }
 
-impl Installer {
-    pub fn new(
-        runner: Arc<dyn CommandRunner>,
-        config: GlobalConfig,
-        target: &Path,
-        cancel: CancellationToken,
-        download_progress_tx: Option<Arc<tokio::sync::watch::Sender<DownloadProgress>>>,
-    ) -> Self {
-        Self {
-            runner,
-            config,
-            target: target.to_path_buf(),
-            cancel,
-            download_progress_tx,
-            swap_partition: None,
-            _target_mounts: None,
-            alpm_ctx: None,
-            kernels_with_zfs: Vec::new(),
-            notices: Vec::new(),
-        }
+/// Put the pool's passphrase in the target, where the initramfs will find it.
+///
+/// Nothing to do when the pool is not encrypted.
+fn write_encryption_key(config: &GlobalConfig, target: &Path) -> Result<()> {
+    if !config.encryption_enabled() {
+        return Ok(());
+    }
+    let password = config
+        .zfs_encryption_password
+        .as_deref()
+        .ok_or_else(|| color_eyre::eyre::eyre!("encryption enabled but password missing"))?;
+    crate::zfs_keyfile::write_key_file(target, password)
+}
+
+/// Install the target system, returning whatever the user should be told.
+///
+/// Phase 4 runs here because its result — the package handle and the mounts —
+/// is what the rest of the installation is built on.
+pub fn perform_installation(request: InstallRequest) -> Result<Vec<String>> {
+    let InstallRequest {
+        runner,
+        config,
+        target,
+        cancel,
+        download_progress_tx,
+        swap_partition,
+    } = request;
+
+    if cancel.is_cancelled() {
+        bail!("installation cancelled");
     }
 
+    tracing::info!("Phase 4: Installing base system...");
+    tracing::info!(target: "metrics", event = "phase_start", num = 4u32, name = "Installing base system");
+    let target_mounts = base::install_base(
+        &*runner,
+        &target,
+        &config,
+        &cancel,
+        download_progress_tx.clone(),
+    )?;
+
+    // The target now has pacman.conf, keyring and mirrorlist from
+    // finalize_target(), so the handle for the remaining phases can be made.
+    let target_conf = target.join("etc/pacman.conf");
+    let mut alpm = AlpmContext::for_target(
+        &target,
+        &target_conf,
+        DownloadConfig {
+            concurrency: config.parallel_downloads as usize,
+            ..Default::default()
+        },
+    )?;
+    alpm.sync_databases(false)?;
+
+    let mut installer = Installer {
+        runner,
+        config,
+        target,
+        cancel,
+        download_progress_tx,
+        swap_partition,
+        _target_mounts: target_mounts,
+        alpm,
+        kernels_with_zfs: Vec::new(),
+        notices: Vec::new(),
+    };
+    installer.configure_target()?;
+    Ok(installer.notices)
+}
+
+impl Installer {
     /// The boot environment this installation is building.
     fn boot_environment(&self) -> crate::boot_environment::BootEnvironment {
         crate::boot_environment::BootEnvironment::new(
@@ -70,52 +138,9 @@ impl Installer {
         )
     }
 
-    /// Messages worth surfacing after a successful installation.
-    pub fn notices(&self) -> &[String] {
-        &self.notices
-    }
-
-    /// Set the swap partition path (used when full-disk partitioning computed
-    /// the path at runtime, since it's not in the static config).
-    pub fn set_swap_partition(&mut self, partition: PathBuf) {
-        self.swap_partition = Some(partition);
-    }
-
     /// Run the full installation pipeline.
-    pub fn perform_installation(&mut self) -> Result<()> {
-        let errors = self.config.validate_for_install();
-        if !errors.is_empty() {
-            let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
-            bail!("Config validation failed:\n  {}", rendered.join("\n  "));
-        }
-        self.ensure_not_cancelled()?;
-
-        // Phase 4: install base system via libalpm
-        tracing::info!("Phase 4: Installing base system...");
-        tracing::info!(target: "metrics", event = "phase_start", num = 4u32, name = "Installing base system");
-        let target_mounts = base::install_base(
-            &*self.runner,
-            &self.target,
-            &self.config,
-            &self.cancel,
-            self.download_progress_tx.clone(),
-        )?;
-        self._target_mounts = Some(target_mounts);
-        self.ensure_not_cancelled()?;
-
-        // Create a reusable AlpmContext for all subsequent package installs.
-        // The target now has pacman.conf, keyring, and mirrorlist from finalize_target().
-        let target_conf = self.target.join("etc/pacman.conf");
-        let mut ctx = AlpmContext::for_target(
-            &self.target,
-            &target_conf,
-            DownloadConfig {
-                concurrency: self.config.parallel_downloads as usize,
-                ..Default::default()
-            },
-        )?;
-        ctx.sync_databases(false)?;
-        self.alpm_ctx = Some(ctx);
+    /// Phases 5 to 12, on a target whose base system is already installed.
+    fn configure_target(&mut self) -> Result<()> {
         self.ensure_not_cancelled()?;
 
         // Phase 5: System config
@@ -132,7 +157,7 @@ impl Installer {
 
         // The encrypted pool key must exist in the target before either
         // initramfs backend tries to embed it in the image.
-        self.prepare_encryption_key()?;
+        write_encryption_key(&self.config, &self.target)?;
 
         // Phase 7: Initramfs
         tracing::info!("Phase 7: Generating initramfs...");
@@ -184,9 +209,7 @@ impl Installer {
         if packages.is_empty() {
             return Ok(());
         }
-        self.alpm_ctx
-            .as_mut()
-            .expect("alpm_ctx must be initialized before installing packages")
+        self.alpm
             .install_packages(packages, &self.cancel, self.download_progress_tx.clone())
     }
 
@@ -238,10 +261,7 @@ impl Installer {
         crate::system::pacman::add_archzfs_repo(&*self.runner, Some(&self.target))?;
 
         // Register archzfs repo in the live alpm handle and sync
-        let ctx = self
-            .alpm_ctx
-            .as_mut()
-            .expect("alpm_ctx must be initialized");
+        let ctx = &mut self.alpm;
         ctx.register_repo(
             "archzfs",
             &["https://github.com/archzfs/archzfs/releases/download/experimental"],
@@ -317,19 +337,6 @@ impl Installer {
         }
 
         Ok(())
-    }
-
-    fn prepare_encryption_key(&self) -> Result<()> {
-        if !self.config.encryption_enabled() {
-            return Ok(());
-        }
-
-        let password = self
-            .config
-            .zfs_encryption_password
-            .as_deref()
-            .ok_or_else(|| color_eyre::eyre::eyre!("encryption enabled but password missing"))?;
-        crate::zfs_keyfile::write_key_file(&self.target, password)
     }
 
     fn configure_users(&self) -> Result<()> {
@@ -698,65 +705,44 @@ impl Installer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::types::{GlobalConfig, ZfsEncryptionMode};
+    use crate::config::types::ZfsEncryptionMode;
     use crate::system::cmd::tests::RecordingRunner;
     use std::os::unix::fs::PermissionsExt;
 
-    #[test]
-    fn test_installer_validates_config() {
-        let runner: Arc<dyn CommandRunner> = Arc::new(RecordingRunner::new(vec![]));
-        let config = GlobalConfig::default(); // missing installation_mode
-        let mut installer = Installer::new(
-            runner,
+    fn request(config: GlobalConfig, target: &Path, cancel: CancellationToken) -> InstallRequest {
+        InstallRequest {
+            runner: Arc::new(RecordingRunner::new(vec![])),
             config,
-            Path::new("/mnt"),
-            CancellationToken::new(),
-            None,
-        );
-        let result = installer.perform_installation();
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("validation failed")
-        );
+            target: target.to_path_buf(),
+            cancel,
+            download_progress_tx: None,
+            swap_partition: None,
+        }
     }
 
     #[test]
-    fn cancelled_installer_stops_before_first_operation() {
+    fn a_cancelled_request_installs_nothing() {
+        let target = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
         cancel.cancel();
-        let runner: Arc<dyn CommandRunner> = Arc::new(RecordingRunner::new(vec![]));
-        let installer = Installer::new(
-            runner,
-            GlobalConfig::default(),
-            Path::new("/mnt"),
-            cancel,
-            None,
-        );
 
-        assert!(installer.ensure_not_cancelled().is_err());
+        let result = perform_installation(request(GlobalConfig::default(), target.path(), cancel));
+
+        assert!(result.is_err());
+        // Nothing was written into the target before the check.
+        assert!(!target.path().join("var/lib/pacman").exists());
     }
 
     #[test]
-    fn prepare_encryption_key_writes_target_key_before_initramfs() {
+    fn the_passphrase_is_written_where_the_initramfs_looks_for_it() {
         let target = tempfile::tempdir().unwrap();
-        let runner: Arc<dyn CommandRunner> = Arc::new(RecordingRunner::new(vec![]));
         let config = GlobalConfig {
             zfs_encryption_mode: ZfsEncryptionMode::Pool,
             zfs_encryption_password: Some("correct horse battery staple".into()),
             ..Default::default()
         };
-        let installer = Installer::new(
-            runner,
-            config,
-            target.path(),
-            CancellationToken::new(),
-            None,
-        );
 
-        installer.prepare_encryption_key().unwrap();
+        write_encryption_key(&config, target.path()).unwrap();
 
         let key_path = crate::zfs_keyfile::key_file_path(target.path());
         assert!(key_path.exists());
@@ -769,19 +755,27 @@ mod tests {
     }
 
     #[test]
-    fn prepare_encryption_key_is_noop_without_encryption() {
+    fn no_key_is_written_for_an_unencrypted_pool() {
         let target = tempfile::tempdir().unwrap();
-        let runner: Arc<dyn CommandRunner> = Arc::new(RecordingRunner::new(vec![]));
-        let installer = Installer::new(
-            runner,
-            GlobalConfig::default(),
-            target.path(),
-            CancellationToken::new(),
-            None,
-        );
 
-        installer.prepare_encryption_key().unwrap();
+        write_encryption_key(&GlobalConfig::default(), target.path()).unwrap();
 
+        assert!(!crate::zfs_keyfile::key_file_path(target.path()).exists());
+    }
+
+    #[test]
+    fn encryption_without_a_passphrase_is_an_error_rather_than_an_empty_key() {
+        let target = tempfile::tempdir().unwrap();
+        let config = GlobalConfig {
+            zfs_encryption_mode: ZfsEncryptionMode::Pool,
+            zfs_encryption_password: None,
+            ..Default::default()
+        };
+
+        let error = write_encryption_key(&config, target.path())
+            .expect_err("an empty key file would fail to unlock the pool at boot");
+
+        assert!(error.to_string().contains("password missing"));
         assert!(!crate::zfs_keyfile::key_file_path(target.path()).exists());
     }
 }

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -85,7 +85,8 @@ impl Installer {
     pub fn perform_installation(&mut self) -> Result<()> {
         let errors = self.config.validate_for_install();
         if !errors.is_empty() {
-            bail!("Config validation failed:\n  {}", errors.join("\n  "));
+            let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
+            bail!("Config validation failed:\n  {}", rendered.join("\n  "));
         }
         self.ensure_not_cancelled()?;
 

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -62,6 +62,14 @@ impl Installer {
         }
     }
 
+    /// The boot environment this installation is building.
+    fn boot_environment(&self) -> crate::boot_environment::BootEnvironment {
+        crate::boot_environment::BootEnvironment::new(
+            self.config.pool_name.as_deref().unwrap_or("zroot"),
+            self.config.dataset_prefix.as_str(),
+        )
+    }
+
     /// Messages worth surfacing after a successful installation.
     pub fn notices(&self) -> &[String] {
         &self.notices
@@ -652,8 +660,7 @@ impl Installer {
     }
 
     fn finalize_zfs(&self) -> Result<()> {
-        let pool_name = self.config.pool_name.as_deref().unwrap_or("zroot");
-        let prefix = &self.config.dataset_prefix;
+        let be = self.boot_environment();
 
         // Enable ZFS services
         for service in crate::zfs_setup::ZFS_SERVICES {
@@ -665,7 +672,7 @@ impl Installer {
         // crate::zfs_trim::configure_zfs_trim, called from run_install.
 
         // genfstab
-        fstab::generate_fstab(&*self.runner, &self.target, pool_name, prefix)?;
+        fstab::generate_fstab(&*self.runner, &self.target, &be)?;
 
         // Copy misc files (hostid, zfs cache). The mountpoint the datasets are
         // currently mounted under is the install target itself — it is what
@@ -674,13 +681,13 @@ impl Installer {
         crate::zfs_target_files::copy_misc_files(
             &*self.runner,
             &self.target,
-            pool_name,
+            be.pool(),
             &self.target,
         )?;
 
         // zrepl
         if self.config.zrepl_enabled {
-            crate::zrepl::setup_zrepl(&self.target, pool_name, prefix)?;
+            crate::zrepl::setup_zrepl(&self.target, &be)?;
         }
 
         Ok(())

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod boot_environment;
 pub mod bootmenu;
 pub mod config;
 pub mod dataset_layout;

--- a/core/src/prepare.rs
+++ b/core/src/prepare.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use color_eyre::eyre::{Result, eyre};
 use zfskit::pool::{ExportOptions, ImportOptions, PoolCreateOptions, Vdev};
 
+use crate::boot_environment::BootEnvironment;
 use crate::config::types::{GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode};
 use crate::system::cmd::CommandRunner;
 
@@ -114,7 +115,7 @@ pub async fn prepare_zfs(
         .pool_name
         .as_deref()
         .ok_or_else(|| eyre!("pool name not set"))?;
-    let prefix = config.dataset_prefix.as_str();
+    let be = BootEnvironment::new(pool_name, config.dataset_prefix.as_str());
     let compression = config.compression.to_string();
     let encryption = config.zfs_encryption_mode;
 
@@ -163,12 +164,10 @@ pub async fn prepare_zfs(
             let base_refs = base_dataset_props(encryption, &key_path, &compression);
             let base_refs_view: Vec<(&str, &str)> =
                 base_refs.iter().map(|(k, v)| (*k, v.as_str())).collect();
-            crate::dataset_layout::create_base_dataset(&zfs, pool_name, prefix, &base_refs_view)
-                .await?;
+            crate::dataset_layout::create_base_dataset(&zfs, &be, &base_refs_view).await?;
 
             let datasets = crate::dataset_layout::default_datasets();
-            crate::dataset_layout::create_child_datasets(&zfs, pool_name, prefix, &datasets)
-                .await?;
+            crate::dataset_layout::create_child_datasets(&zfs, &be, &datasets).await?;
             tracing::info!("Created datasets");
 
             export_pool(&zfs, pool_name).await?;
@@ -190,20 +189,18 @@ pub async fn prepare_zfs(
             let base_refs = base_dataset_props(encryption, &key_path, &compression);
             let base_refs_view: Vec<(&str, &str)> =
                 base_refs.iter().map(|(k, v)| (*k, v.as_str())).collect();
-            crate::dataset_layout::create_base_dataset(&zfs, pool_name, prefix, &base_refs_view)
-                .await?;
+            crate::dataset_layout::create_base_dataset(&zfs, &be, &base_refs_view).await?;
 
             let datasets = crate::dataset_layout::default_datasets();
-            crate::dataset_layout::create_child_datasets(&zfs, pool_name, prefix, &datasets)
-                .await?;
+            crate::dataset_layout::create_child_datasets(&zfs, &be, &datasets).await?;
             tracing::info!("Created new BE in existing pool");
         }
     }
 
-    load_install_encryption_key(&zfs, pool_name, prefix, encryption, &key_path).await?;
+    load_install_encryption_key(&zfs, &be, encryption, &key_path).await?;
 
     let datasets = crate::dataset_layout::default_datasets();
-    crate::dataset_layout::mount_datasets_ordered(&zfs, pool_name, prefix, &datasets).await?;
+    crate::dataset_layout::mount_datasets_ordered(&zfs, &be, &datasets).await?;
     tracing::info!("Datasets mounted");
 
     Ok(())
@@ -232,14 +229,13 @@ fn base_dataset_props(
 
 async fn load_install_encryption_key(
     zfs: &zfskit::Zfs,
-    pool_name: &str,
-    prefix: &str,
+    be: &BootEnvironment,
     encryption: ZfsEncryptionMode,
     key_path: &Path,
 ) -> Result<()> {
     let key_dataset = match encryption {
-        ZfsEncryptionMode::Pool => pool_name.to_string(),
-        ZfsEncryptionMode::Dataset => format!("{pool_name}/{prefix}"),
+        ZfsEncryptionMode::Pool => be.pool().to_string(),
+        ZfsEncryptionMode::Dataset => be.base(),
         ZfsEncryptionMode::None => return Ok(()),
     };
     let key_loc = format!("file://{}", key_path.display());
@@ -383,8 +379,7 @@ mod tests {
 
         load_install_encryption_key(
             &zfs,
-            "zroot",
-            "arch0",
+            &BootEnvironment::new("zroot", "arch0"),
             ZfsEncryptionMode::Pool,
             Path::new("/etc/zfs/zroot.key"),
         )
@@ -404,8 +399,7 @@ mod tests {
 
         load_install_encryption_key(
             &zfs,
-            "zroot",
-            "arch0",
+            &BootEnvironment::new("zroot", "arch0"),
             ZfsEncryptionMode::Dataset,
             Path::new("/etc/zfs/zroot.key"),
         )
@@ -419,8 +413,7 @@ mod tests {
 
         load_install_encryption_key(
             &zfs,
-            "zroot",
-            "arch0",
+            &BootEnvironment::new("zroot", "arch0"),
             ZfsEncryptionMode::None,
             Path::new("/etc/zfs/zroot.key"),
         )

--- a/core/src/system/async_download.rs
+++ b/core/src/system/async_download.rs
@@ -346,10 +346,13 @@ async fn run_downloads(
     }
 
     if !errors.is_empty() {
-        let first = errors.remove(0);
-        if first.to_string().contains("cancelled") {
+        // Ask the token rather than reading the message: a cancelled run
+        // fails every download in flight, and matching on the words those
+        // failures happen to use is not a way to tell the two apart.
+        if cancel.is_cancelled() {
             bail!("download cancelled");
         }
+        let first = errors.remove(0);
         return Err(first.wrap_err(format!("{} package download(s) failed", errors.len() + 1)));
     }
 

--- a/core/src/zrepl.rs
+++ b/core/src/zrepl.rs
@@ -3,13 +3,16 @@ use std::path::Path;
 
 use color_eyre::eyre::{Context, Result};
 
-pub fn generate_zrepl_config(pool_name: &str, dataset_prefix: &str) -> String {
+use crate::boot_environment::BootEnvironment;
+
+pub fn generate_zrepl_config(be: &BootEnvironment) -> String {
+    let base = be.base();
     format!(
         r#"jobs:
 - name: snap
   type: snap
   filesystems:
-    "{pool_name}/{dataset_prefix}<": true
+    "{base}<": true
   snapshotting:
     type: periodic
     interval: 15m
@@ -23,8 +26,8 @@ pub fn generate_zrepl_config(pool_name: &str, dataset_prefix: &str) -> String {
     )
 }
 
-pub fn setup_zrepl(target: &Path, pool_name: &str, dataset_prefix: &str) -> Result<()> {
-    let config = generate_zrepl_config(pool_name, dataset_prefix);
+pub fn setup_zrepl(target: &Path, be: &BootEnvironment) -> Result<()> {
+    let config = generate_zrepl_config(be);
 
     let config_dir = target.join("etc/zrepl");
     fs::create_dir_all(&config_dir)?;
@@ -42,7 +45,7 @@ mod tests {
 
     #[test]
     fn test_generate_zrepl_config() {
-        let config = generate_zrepl_config("mypool", "arch0");
+        let config = generate_zrepl_config(&BootEnvironment::new("mypool", "arch0"));
         assert!(config.contains("mypool/arch0<"));
         assert!(config.contains("15m"));
         assert!(config.contains("zrepl_"));
@@ -52,7 +55,7 @@ mod tests {
     #[test]
     fn test_setup_zrepl() {
         let dir = tempfile::tempdir().unwrap();
-        setup_zrepl(dir.path(), "testpool", "arch0").unwrap();
+        setup_zrepl(dir.path(), &BootEnvironment::new("testpool", "arch0")).unwrap();
 
         let config_path = dir.path().join("etc/zrepl/zrepl.yml");
         assert!(config_path.exists());

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -4,9 +4,10 @@
 use slint::SharedString;
 use std::path::PathBuf;
 
+use archinstall_zfs_core::config::choices::Choice;
 use archinstall_zfs_core::config::types::{
-    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
-    SeatAccess, SwapMode, ZfsEncryptionMode,
+    AudioServer, CompressionAlgo, GlobalConfig, InstallationMode, ProfileSelection, SeatAccess,
+    SwapMode, ZfsEncryptionMode,
 };
 use archinstall_zfs_core::disk::device::DeviceChoice;
 
@@ -100,16 +101,10 @@ fn build_welcome_items(_c: &GlobalConfig) -> Vec<ConfigItem> {
 fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     let mode = c.installation_mode;
 
-    let mut items = radio_group(
+    let mut items = choice_group(
         "installation_mode",
         "Installation mode",
-        &["Full Disk", "New Pool", "Existing Pool"],
-        match mode {
-            Some(InstallationMode::FullDisk) => 0,
-            Some(InstallationMode::NewPool) => 1,
-            Some(InstallationMode::ExistingPool) => 2,
-            None => 0,
-        },
+        mode.unwrap_or(InstallationMode::FullDisk),
     );
 
     if matches!(mode, Some(InstallationMode::FullDisk) | None) {
@@ -184,33 +179,17 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         ),
     ];
 
-    items.extend(radio_group_with_off(
+    items.extend(choice_group_with_off(
         "compression",
         "Compression",
-        &["lz4", "zstd", "zstd-5", "zstd-10", "off"],
-        match c.compression {
-            CompressionAlgo::Lz4 => 0,
-            CompressionAlgo::Zstd => 1,
-            CompressionAlgo::Zstd5 => 2,
-            CompressionAlgo::Zstd10 => 3,
-            CompressionAlgo::Off => 4,
-        },
-        4,
+        c.compression,
+        CompressionAlgo::Off,
     ));
 
-    items.extend(radio_group(
+    items.extend(choice_group(
         "encryption",
         "Encryption",
-        &[
-            "No encryption",
-            "Encrypt entire pool",
-            "Encrypt base dataset only",
-        ],
-        match c.zfs_encryption_mode {
-            ZfsEncryptionMode::None => 0,
-            ZfsEncryptionMode::Pool => 1,
-            ZfsEncryptionMode::Dataset => 2,
-        },
+        c.zfs_encryption_mode,
     ));
 
     if c.zfs_encryption_mode != ZfsEncryptionMode::None {
@@ -222,22 +201,11 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         ));
     }
 
-    items.extend(radio_group_with_off(
+    items.extend(choice_group_with_off(
         "swap_mode",
         "Swap",
-        &[
-            "None",
-            "ZRAM",
-            "Swap partition",
-            "Swap partition (encrypted)",
-        ],
-        match c.swap_mode {
-            SwapMode::None => 0,
-            SwapMode::Zram => 1,
-            SwapMode::ZswapPartition => 2,
-            SwapMode::ZswapPartitionEncrypted => 3,
-        },
-        0,
+        c.swap_mode,
+        SwapMode::None,
     ));
 
     if matches!(mode, Some(InstallationMode::FullDisk)) && has_swap_partition {
@@ -264,15 +232,7 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         ));
     }
 
-    items.extend(radio_group(
-        "init_system",
-        "Init system",
-        &["dracut", "mkinitcpio"],
-        match c.init_system {
-            InitSystem::Dracut => 0,
-            InitSystem::Mkinitcpio => 1,
-        },
-    ));
+    items.extend(choice_group("init_system", "Init system", c.init_system));
 
     items
 }
@@ -422,31 +382,16 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         // Seat access (Wayland compositors). Its own section card via
         // radio_group, like Audio.
         if p.needs_seat_access() {
-            items.extend(radio_group_with_off(
+            items.extend(choice_group_with_off(
                 "seat_access",
                 "Seat access",
-                &["None", "seatd", "polkit"],
-                match sel.seat_access {
-                    None => 0,
-                    Some(SeatAccess::Seatd) => 1,
-                    Some(SeatAccess::Polkit) => 2,
-                },
-                0,
+                sel.seat_access,
+                None,
             ));
         }
     }
 
-    items.extend(radio_group_with_off(
-        "audio",
-        "Audio",
-        &["None", "pipewire", "pulseaudio"],
-        match c.audio {
-            None => 0,
-            Some(AudioServer::Pipewire) => 1,
-            Some(AudioServer::Pulseaudio) => 2,
-        },
-        0,
-    ));
+    items.extend(choice_group_with_off("audio", "Audio", c.audio, None));
 
     items.push(section_header("Hardware"));
     // GPU driver — only shown for graphical profiles (mirrors upstream
@@ -700,6 +645,32 @@ fn radio_group(key: &str, label: &str, options: &[&str], selected: i32) -> Vec<C
     radio_group_inner(key, label, options, selected, None)
 }
 
+/// Build a radio group from a [`Choice`] enum, so the order, the labels and
+/// the selected index all come from one table rather than being spelled out
+/// here and inverted again in [`apply_radio`].
+fn choice_group<T: Choice>(key: &str, label: &str, current: T) -> Vec<ConfigItem> {
+    radio_group(key, label, &T::labels(), current.index() as i32)
+}
+
+/// [`choice_group`] for lists with a semantic "off" alternative, named by
+/// value rather than by index.
+fn choice_group_with_off<T: Choice>(key: &str, label: &str, current: T, off: T) -> Vec<ConfigItem> {
+    radio_group_with_off(
+        key,
+        label,
+        &T::labels(),
+        current.index() as i32,
+        off.index(),
+    )
+}
+
+/// Resolve a radio index coming back from the interface. Out of range — or
+/// negative, which the widget layer types as a plain `i32` — yields `None`
+/// rather than silently landing on a neighbouring variant.
+fn selected<T: Choice>(index: i32) -> Option<T> {
+    usize::try_from(index).ok().and_then(T::from_index)
+}
+
 /// Variant of [`radio_group`] that marks one option as the semantic "off"
 /// state (e.g. compression "off", audio "None"). The off row's `is_empty`
 /// flag is propagated to the review screen's collapsed Readonly row when
@@ -910,10 +881,8 @@ pub fn next_selectable_index(items: &[ConfigItem], current: i32, dir: i32) -> i3
 pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
     match group_key {
         "installation_mode" => {
-            let new_mode = match idx {
-                0 => InstallationMode::FullDisk,
-                1 => InstallationMode::NewPool,
-                _ => InstallationMode::ExistingPool,
+            let Some(new_mode) = selected::<InstallationMode>(idx) else {
+                return;
             };
             if config.installation_mode != Some(new_mode) {
                 config.disk = None;
@@ -949,36 +918,27 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
             }
         }
         "compression" => {
-            config.compression = match idx {
-                0 => CompressionAlgo::Lz4,
-                1 => CompressionAlgo::Zstd,
-                2 => CompressionAlgo::Zstd5,
-                3 => CompressionAlgo::Zstd10,
-                _ => CompressionAlgo::Off,
+            if let Some(algo) = selected(idx) {
+                config.compression = algo;
             }
         }
         "encryption" => {
-            config.zfs_encryption_mode = match idx {
-                0 => ZfsEncryptionMode::None,
-                1 => ZfsEncryptionMode::Pool,
-                _ => ZfsEncryptionMode::Dataset,
+            let Some(mode) = selected::<ZfsEncryptionMode>(idx) else {
+                return;
             };
-            if config.zfs_encryption_mode == ZfsEncryptionMode::None {
+            config.zfs_encryption_mode = mode;
+            if mode == ZfsEncryptionMode::None {
                 config.zfs_encryption_password = None;
             }
         }
         "swap_mode" => {
-            config.swap_mode = match idx {
-                0 => SwapMode::None,
-                1 => SwapMode::Zram,
-                2 => SwapMode::ZswapPartition,
-                _ => SwapMode::ZswapPartitionEncrypted,
+            if let Some(mode) = selected(idx) {
+                config.swap_mode = mode;
             }
         }
         "init_system" => {
-            config.init_system = match idx {
-                0 => InitSystem::Dracut,
-                _ => InitSystem::Mkinitcpio,
+            if let Some(init) = selected(idx) {
+                config.init_system = init;
             }
         }
         "profile" => {
@@ -992,19 +952,16 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
             };
         }
         "audio" => {
-            config.audio = match idx {
-                0 => None,
-                1 => Some(AudioServer::Pipewire),
-                _ => Some(AudioServer::Pulseaudio),
+            if let Some(server) = selected::<Option<AudioServer>>(idx) {
+                config.audio = server;
             }
         }
         "seat_access" => {
-            if let Some(sel) = config.profile_selection.as_mut() {
-                sel.seat_access = match idx {
-                    0 => None,
-                    1 => Some(SeatAccess::Seatd),
-                    _ => Some(SeatAccess::Polkit),
-                };
+            if let (Some(sel), Some(access)) = (
+                config.profile_selection.as_mut(),
+                selected::<Option<SeatAccess>>(idx),
+            ) {
+                sel.seat_access = access;
             }
         }
         _ => {}
@@ -1052,6 +1009,7 @@ pub fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use archinstall_zfs_core::config::types::InitSystem;
 
     fn cfg() -> GlobalConfig {
         GlobalConfig::default()

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -727,7 +727,7 @@ fn radio_choice_group(
     }];
     for (i, option) in options.iter().enumerate() {
         items.push(ConfigItem {
-            key: format!("radio:{key}:{i}").into(),
+            key: device_key(key, &option.path),
             label: option.label.as_str().into(),
             icon: option.icon.as_str().into(),
             detail_model: option.model.as_str().into(),
@@ -789,7 +789,7 @@ fn radio_partition_choice_group(
         }
 
         items.push(ConfigItem {
-            key: format!("radio:{key}:{i}").into(),
+            key: device_key(key, &option.path),
             label: option.label.as_str().into(),
             detail_size: option.size.as_str().into(),
             persistent_path: option.persistent_path.as_str().into(),
@@ -878,6 +878,36 @@ pub fn next_selectable_index(items: &[ConfigItem], current: i32, dir: i32) -> i3
 // ── Apply mutations ─────────────────────────────────
 
 /// Apply an inline radio selection. `group_key` is e.g. "compression".
+/// Key for a device row.
+///
+/// The device's path travels with the row rather than its position in the
+/// list. Resolving a position means enumerating the block devices a second
+/// time when the click arrives, and the set can change in between — a stick
+/// plugged in, udev still settling — which silently shifts every index after
+/// it. For a screen whose next step erases the chosen disk, selecting by
+/// identity rather than by position is the only version that is safe to be
+/// wrong about.
+fn device_key(group_key: &str, path: &std::path::Path) -> SharedString {
+    format!("device:{group_key}:{}", path.display()).into()
+}
+
+/// Apply a device selection. `path` comes from the row the user activated, so
+/// no second enumeration is involved.
+pub fn apply_device(config: &mut GlobalConfig, group_key: &str, path: &std::path::Path) {
+    let path = path.to_path_buf();
+    match group_key {
+        "disk" => {
+            // Choosing a disk is what puts the wizard in full-disk mode.
+            config.installation_mode = Some(InstallationMode::FullDisk);
+            config.disk = Some(path);
+        }
+        "efi_partition" => config.efi_partition = Some(path),
+        "zfs_partition" => config.zfs_partition = Some(path),
+        "swap_partition" => config.swap_partition = Some(path),
+        _ => {}
+    }
+}
+
 pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
     match group_key {
         "installation_mode" => {
@@ -891,31 +921,6 @@ pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
                 config.swap_partition = None;
             }
             config.installation_mode = Some(new_mode);
-        }
-        "disk" => {
-            let disks = disk_choices();
-            if let Some(choice) = disks.get(idx as usize) {
-                config.installation_mode = Some(InstallationMode::FullDisk);
-                config.disk = Some(choice.path.clone());
-            }
-        }
-        "efi_partition" => {
-            let parts = partition_choices();
-            if let Some(choice) = parts.get(idx as usize) {
-                config.efi_partition = Some(choice.path.clone());
-            }
-        }
-        "zfs_partition" => {
-            let parts = partition_choices();
-            if let Some(choice) = parts.get(idx as usize) {
-                config.zfs_partition = Some(choice.path.clone());
-            }
-        }
-        "swap_partition" => {
-            let parts = partition_choices();
-            if let Some(choice) = parts.get(idx as usize) {
-                config.swap_partition = Some(choice.path.clone());
-            }
         }
         "compression" => {
             if let Some(algo) = selected(idx) {
@@ -1132,6 +1137,56 @@ mod tests {
             apply_radio(&mut c, "audio", idx);
             assert_eq!(c.audio, expected, "idx={idx}");
         }
+    }
+
+    #[test]
+    fn a_device_row_carries_the_path_it_selects() {
+        let path = std::path::Path::new("/dev/disk/by-path/pci-0000:00:04.0");
+        // Colons in persistent paths must survive the round trip through the
+        // key, so the dispatcher has to split on the first one only.
+        let key = device_key("disk", path);
+        let rest = key.strip_prefix("device:").expect("device prefix");
+        let (group, payload) = rest.split_once(':').expect("group and payload");
+
+        assert_eq!(group, "disk");
+        assert_eq!(std::path::Path::new(payload), path);
+    }
+
+    #[test]
+    fn selecting_a_device_stores_that_device() {
+        let mut c = cfg();
+        let disk = std::path::Path::new("/dev/disk/by-id/nvme-eui.0001");
+
+        apply_device(&mut c, "disk", disk);
+
+        assert_eq!(c.disk.as_deref(), Some(disk));
+        assert_eq!(c.installation_mode, Some(InstallationMode::FullDisk));
+    }
+
+    #[test]
+    fn a_device_selection_does_not_depend_on_list_position() {
+        // The whole point: two different rows resolve to two different disks
+        // regardless of what the enumeration would return now.
+        let mut c = cfg();
+        apply_device(&mut c, "efi_partition", std::path::Path::new("/dev/sda1"));
+        apply_device(&mut c, "zfs_partition", std::path::Path::new("/dev/sdb2"));
+
+        assert_eq!(
+            c.efi_partition.as_deref(),
+            Some(std::path::Path::new("/dev/sda1"))
+        );
+        assert_eq!(
+            c.zfs_partition.as_deref(),
+            Some(std::path::Path::new("/dev/sdb2"))
+        );
+    }
+
+    #[test]
+    fn device_unknown_group_is_noop() {
+        let mut c = cfg();
+        apply_device(&mut c, "nonsense", std::path::Path::new("/dev/sda"));
+        assert!(c.disk.is_none());
+        assert!(c.efi_partition.is_none());
     }
 
     #[test]

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -584,7 +584,7 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         items.push(section_header("Validation"));
         for error in &errors {
             items.push(ConfigItem {
-                value: error.as_str().into(),
+                value: error.to_string().into(),
                 item_type: ItemType::Warning,
                 ..Default::default()
             });

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -5,7 +5,9 @@ use slint::SharedString;
 use std::path::PathBuf;
 
 use archinstall_zfs_core::config::choices::Choice;
-use archinstall_zfs_core::config::edit::{ChoiceSetting, DeviceSetting, TextSetting};
+use archinstall_zfs_core::config::edit::{
+    ChoiceSetting, DeviceSetting, EditorSetting, TextSetting,
+};
 use archinstall_zfs_core::config::types::{
     CompressionAlgo, GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode,
 };
@@ -278,7 +280,7 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         section_header("Locale"),
         ci_opt("locale", "Locale", c.locale.as_deref(), ItemType::Select),
         ci_opt(
-            TextSetting::Timezone.as_str(),
+            EditorSetting::Timezone.as_str(),
             "Timezone",
             c.timezone.as_deref(),
             ItemType::Select,

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -5,9 +5,9 @@ use slint::SharedString;
 use std::path::PathBuf;
 
 use archinstall_zfs_core::config::choices::Choice;
+use archinstall_zfs_core::config::edit::{ChoiceSetting, DeviceSetting, TextSetting};
 use archinstall_zfs_core::config::types::{
-    AudioServer, CompressionAlgo, GlobalConfig, InstallationMode, ProfileSelection, SeatAccess,
-    SwapMode, ZfsEncryptionMode,
+    CompressionAlgo, GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode,
 };
 use archinstall_zfs_core::disk::device::DeviceChoice;
 
@@ -102,7 +102,7 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     let mode = c.installation_mode;
 
     let mut items = choice_group(
-        "installation_mode",
+        ChoiceSetting::InstallationMode,
         "Installation mode",
         mode.unwrap_or(InstallationMode::FullDisk),
     );
@@ -115,7 +115,12 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             .and_then(|sel| disks.iter().position(|choice| &choice.path == sel))
             .map(|i| i as i32)
             .unwrap_or(-1);
-        items.extend(radio_choice_group("disk", "Disk", &disks, selected));
+        items.extend(radio_choice_group(
+            DeviceSetting::Disk,
+            "Disk",
+            &disks,
+            selected,
+        ));
     }
 
     if matches!(
@@ -131,7 +136,7 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             .map(|i| i as i32)
             .unwrap_or(-1);
         items.extend(radio_partition_choice_group(
-            "efi_partition",
+            DeviceSetting::EfiPartition,
             "EFI partition",
             &parts,
             efi_selected,
@@ -145,7 +150,7 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                 .map(|i| i as i32)
                 .unwrap_or(-1);
             items.extend(radio_partition_choice_group(
-                "zfs_partition",
+                DeviceSetting::ZfsPartition,
                 "ZFS partition",
                 &parts,
                 zfs_selected,
@@ -166,13 +171,13 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     let mut items = vec![
         section_header("Pool"),
         ci_opt(
-            "pool_name",
+            TextSetting::PoolName.as_str(),
             "Pool name",
             c.pool_name.as_deref(),
             ItemType::Text,
         ),
         ci(
-            "dataset_prefix",
+            TextSetting::DatasetPrefix.as_str(),
             "Dataset prefix",
             &c.dataset_prefix,
             ItemType::Text,
@@ -180,21 +185,21 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     ];
 
     items.extend(choice_group_with_off(
-        "compression",
+        ChoiceSetting::Compression,
         "Compression",
         c.compression,
         CompressionAlgo::Off,
     ));
 
     items.extend(choice_group(
-        "encryption",
+        ChoiceSetting::Encryption,
         "Encryption",
         c.zfs_encryption_mode,
     ));
 
     if c.zfs_encryption_mode != ZfsEncryptionMode::None {
         items.push(ci_opt(
-            "encryption_password",
+            TextSetting::EncryptionPassword.as_str(),
             "Encryption password",
             c.zfs_encryption_password.as_ref().map(|_| "Set"),
             ItemType::Password,
@@ -202,7 +207,7 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     }
 
     items.extend(choice_group_with_off(
-        "swap_mode",
+        ChoiceSetting::SwapMode,
         "Swap",
         c.swap_mode,
         SwapMode::None,
@@ -210,7 +215,7 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 
     if matches!(mode, Some(InstallationMode::FullDisk)) && has_swap_partition {
         items.push(ci_opt(
-            "swap_partition_size",
+            TextSetting::SwapPartitionSize.as_str(),
             "Swap size",
             c.swap_partition_size.as_deref(),
             ItemType::Text,
@@ -225,14 +230,18 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             .map(|i| i as i32)
             .unwrap_or(-1);
         items.extend(radio_choice_group(
-            "swap_partition",
+            DeviceSetting::SwapPartition,
             "Swap partition",
             &parts,
             swap_selected,
         ));
     }
 
-    items.extend(choice_group("init_system", "Init system", c.init_system));
+    items.extend(choice_group(
+        ChoiceSetting::InitSystem,
+        "Init system",
+        c.init_system,
+    ));
 
     items
 }
@@ -254,14 +263,14 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             ItemType::Select,
         ),
         ci_opt(
-            "hostname",
+            TextSetting::Hostname.as_str(),
             "Hostname",
             c.hostname.as_deref(),
             ItemType::Text,
         ),
         ci_toggle("ntp", "NTP (time sync)", c.ntp),
         ci(
-            "parallel_downloads",
+            TextSetting::ParallelDownloads.as_str(),
             "Parallel downloads",
             &c.parallel_downloads.to_string(),
             ItemType::Text,
@@ -269,7 +278,7 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         section_header("Locale"),
         ci_opt("locale", "Locale", c.locale.as_deref(), ItemType::Select),
         ci_opt(
-            "timezone",
+            TextSetting::Timezone.as_str(),
             "Timezone",
             c.timezone.as_deref(),
             ItemType::Select,
@@ -287,7 +296,7 @@ fn build_users_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     vec![
         section_header("Authentication"),
         ci_opt(
-            "root_password",
+            TextSetting::RootPassword.as_str(),
             "Root password",
             c.root_password.as_ref().map(|_| "Set"),
             ItemType::Password,
@@ -383,7 +392,7 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         // radio_group, like Audio.
         if p.needs_seat_access() {
             items.extend(choice_group_with_off(
-                "seat_access",
+                ChoiceSetting::SeatAccess,
                 "Seat access",
                 sel.seat_access,
                 None,
@@ -391,7 +400,12 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         }
     }
 
-    items.extend(choice_group_with_off("audio", "Audio", c.audio, None));
+    items.extend(choice_group_with_off(
+        ChoiceSetting::Audio,
+        "Audio",
+        c.audio,
+        None,
+    ));
 
     items.push(section_header("Hardware"));
     // GPU driver — only shown for graphical profiles (mirrors upstream
@@ -648,27 +662,30 @@ fn radio_group(key: &str, label: &str, options: &[&str], selected: i32) -> Vec<C
 /// Build a radio group from a [`Choice`] enum, so the order, the labels and
 /// the selected index all come from one table rather than being spelled out
 /// here and inverted again in [`apply_radio`].
-fn choice_group<T: Choice>(key: &str, label: &str, current: T) -> Vec<ConfigItem> {
-    radio_group(key, label, &T::labels(), current.index() as i32)
+fn choice_group<T: Choice>(setting: ChoiceSetting, label: &str, current: T) -> Vec<ConfigItem> {
+    radio_group(
+        setting.as_str(),
+        label,
+        &T::labels(),
+        current.index() as i32,
+    )
 }
 
 /// [`choice_group`] for lists with a semantic "off" alternative, named by
 /// value rather than by index.
-fn choice_group_with_off<T: Choice>(key: &str, label: &str, current: T, off: T) -> Vec<ConfigItem> {
+fn choice_group_with_off<T: Choice>(
+    setting: ChoiceSetting,
+    label: &str,
+    current: T,
+    off: T,
+) -> Vec<ConfigItem> {
     radio_group_with_off(
-        key,
+        setting.as_str(),
         label,
         &T::labels(),
         current.index() as i32,
         off.index(),
     )
-}
-
-/// Resolve a radio index coming back from the interface. Out of range — or
-/// negative, which the widget layer types as a plain `i32` — yields `None`
-/// rather than silently landing on a neighbouring variant.
-fn selected<T: Choice>(index: i32) -> Option<T> {
-    usize::try_from(index).ok().and_then(T::from_index)
 }
 
 /// Variant of [`radio_group`] that marks one option as the semantic "off"
@@ -715,7 +732,7 @@ fn radio_group_inner(
 }
 
 fn radio_choice_group(
-    key: &str,
+    setting: DeviceSetting,
     label: &str,
     options: &[ChoiceRow],
     selected: i32,
@@ -727,7 +744,7 @@ fn radio_choice_group(
     }];
     for (i, option) in options.iter().enumerate() {
         items.push(ConfigItem {
-            key: device_key(key, &option.path),
+            key: device_key(setting, &option.path),
             label: option.label.as_str().into(),
             icon: option.icon.as_str().into(),
             detail_model: option.model.as_str().into(),
@@ -758,7 +775,7 @@ fn radio_choice_group(
 }
 
 fn radio_partition_choice_group(
-    key: &str,
+    setting: DeviceSetting,
     label: &str,
     options: &[ChoiceRow],
     selected: i32,
@@ -789,7 +806,7 @@ fn radio_partition_choice_group(
         }
 
         items.push(ConfigItem {
-            key: device_key(key, &option.path),
+            key: device_key(setting, &option.path),
             label: option.label.as_str().into(),
             detail_size: option.size.as_str().into(),
             persistent_path: option.persistent_path.as_str().into(),
@@ -887,90 +904,8 @@ pub fn next_selectable_index(items: &[ConfigItem], current: i32, dir: i32) -> i3
 /// it. For a screen whose next step erases the chosen disk, selecting by
 /// identity rather than by position is the only version that is safe to be
 /// wrong about.
-fn device_key(group_key: &str, path: &std::path::Path) -> SharedString {
-    format!("device:{group_key}:{}", path.display()).into()
-}
-
-/// Apply a device selection. `path` comes from the row the user activated, so
-/// no second enumeration is involved.
-pub fn apply_device(config: &mut GlobalConfig, group_key: &str, path: &std::path::Path) {
-    let path = path.to_path_buf();
-    match group_key {
-        "disk" => {
-            // Choosing a disk is what puts the wizard in full-disk mode.
-            config.installation_mode = Some(InstallationMode::FullDisk);
-            config.disk = Some(path);
-        }
-        "efi_partition" => config.efi_partition = Some(path),
-        "zfs_partition" => config.zfs_partition = Some(path),
-        "swap_partition" => config.swap_partition = Some(path),
-        _ => {}
-    }
-}
-
-pub fn apply_radio(config: &mut GlobalConfig, group_key: &str, idx: i32) {
-    match group_key {
-        "installation_mode" => {
-            let Some(new_mode) = selected::<InstallationMode>(idx) else {
-                return;
-            };
-            if config.installation_mode != Some(new_mode) {
-                config.disk = None;
-                config.efi_partition = None;
-                config.zfs_partition = None;
-                config.swap_partition = None;
-            }
-            config.installation_mode = Some(new_mode);
-        }
-        "compression" => {
-            if let Some(algo) = selected(idx) {
-                config.compression = algo;
-            }
-        }
-        "encryption" => {
-            let Some(mode) = selected::<ZfsEncryptionMode>(idx) else {
-                return;
-            };
-            config.zfs_encryption_mode = mode;
-            if mode == ZfsEncryptionMode::None {
-                config.zfs_encryption_password = None;
-            }
-        }
-        "swap_mode" => {
-            if let Some(mode) = selected(idx) {
-                config.swap_mode = mode;
-            }
-        }
-        "init_system" => {
-            if let Some(init) = selected(idx) {
-                config.init_system = init;
-            }
-        }
-        "profile" => {
-            let profiles = archinstall_zfs_core::profile::all_profiles();
-            config.profile_selection = if idx == 0 {
-                None
-            } else {
-                profiles
-                    .get((idx - 1) as usize)
-                    .and_then(|p| ProfileSelection::new(p.name))
-            };
-        }
-        "audio" => {
-            if let Some(server) = selected::<Option<AudioServer>>(idx) {
-                config.audio = server;
-            }
-        }
-        "seat_access" => {
-            if let (Some(sel), Some(access)) = (
-                config.profile_selection.as_mut(),
-                selected::<Option<SeatAccess>>(idx),
-            ) {
-                sel.seat_access = access;
-            }
-        }
-        _ => {}
-    }
+fn device_key(setting: DeviceSetting, path: &std::path::Path) -> SharedString {
+    format!("device:{}:{}", setting.as_str(), path.display()).into()
 }
 
 fn disk_choices() -> Vec<ChoiceRow> {
@@ -985,166 +920,18 @@ fn partition_choices() -> Vec<ChoiceRow> {
         .unwrap_or_default()
 }
 
-pub fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {
-    let opt = if val.is_empty() {
-        None
-    } else {
-        Some(val.to_string())
-    };
-    match key {
-        "pool_name" => config.pool_name = opt,
-        "dataset_prefix" if !val.is_empty() => {
-            config.dataset_prefix = val.to_string();
-        }
-        "hostname" => config.hostname = opt,
-        "locale" => config.locale = opt,
-        "timezone" => config.timezone = opt,
-        "root_password" => config.root_password = opt,
-        "encryption_password" => config.zfs_encryption_password = opt,
-        "swap_partition_size" => config.swap_partition_size = opt,
-        "parallel_downloads" => {
-            if let Ok(n) = val.parse::<u32>() {
-                config.parallel_downloads = n.clamp(1, 20);
-            }
-        }
-        _ => {}
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use archinstall_zfs_core::config::types::InitSystem;
-
-    fn cfg() -> GlobalConfig {
-        GlobalConfig::default()
-    }
 
     // ── apply_radio ─────────────────────────────────────
-
-    #[test]
-    fn radio_installation_mode_sets_and_clears_dependents() {
-        let mut c = cfg();
-        c.disk = Some("/dev/sda".into());
-        c.efi_partition = Some("/dev/sda1".into());
-
-        // Switching mode should clear all device selections
-        apply_radio(&mut c, "installation_mode", 1);
-        assert_eq!(c.installation_mode, Some(InstallationMode::NewPool));
-        assert!(c.disk.is_none());
-        assert!(c.efi_partition.is_none());
-        assert!(c.zfs_partition.is_none());
-        assert!(c.swap_partition.is_none());
-    }
-
-    #[test]
-    fn radio_installation_mode_no_clear_when_unchanged() {
-        let mut c = cfg();
-        c.installation_mode = Some(InstallationMode::FullDisk);
-        c.disk = Some("/dev/sda".into());
-
-        apply_radio(&mut c, "installation_mode", 0); // Same mode (FullDisk)
-        assert_eq!(c.installation_mode, Some(InstallationMode::FullDisk));
-        // Selections should be preserved when mode doesn't actually change
-        assert!(c.disk.is_some());
-    }
-
-    #[test]
-    fn radio_installation_mode_indices() {
-        let cases = [
-            (0, InstallationMode::FullDisk),
-            (1, InstallationMode::NewPool),
-            (2, InstallationMode::ExistingPool),
-        ];
-        for (idx, expected) in cases {
-            let mut c = cfg();
-            apply_radio(&mut c, "installation_mode", idx);
-            assert_eq!(c.installation_mode, Some(expected), "idx={idx}");
-        }
-    }
-
-    #[test]
-    fn radio_compression_indices() {
-        let cases = [
-            (0, CompressionAlgo::Lz4),
-            (1, CompressionAlgo::Zstd),
-            (2, CompressionAlgo::Zstd5),
-            (3, CompressionAlgo::Zstd10),
-            (4, CompressionAlgo::Off),
-        ];
-        for (idx, expected) in cases {
-            let mut c = cfg();
-            apply_radio(&mut c, "compression", idx);
-            assert_eq!(c.compression, expected, "idx={idx}");
-        }
-    }
-
-    #[test]
-    fn radio_encryption_clears_password_when_set_to_none() {
-        let mut c = cfg();
-        c.zfs_encryption_mode = ZfsEncryptionMode::Pool;
-        c.zfs_encryption_password = Some("hunter2".into());
-
-        apply_radio(&mut c, "encryption", 0); // None
-        assert_eq!(c.zfs_encryption_mode, ZfsEncryptionMode::None);
-        assert!(c.zfs_encryption_password.is_none());
-    }
-
-    #[test]
-    fn radio_encryption_keeps_password_when_set_to_pool() {
-        let mut c = cfg();
-        c.zfs_encryption_mode = ZfsEncryptionMode::Dataset;
-        c.zfs_encryption_password = Some("hunter2".into());
-
-        apply_radio(&mut c, "encryption", 1); // Pool
-        assert_eq!(c.zfs_encryption_mode, ZfsEncryptionMode::Pool);
-        assert_eq!(c.zfs_encryption_password.as_deref(), Some("hunter2"));
-    }
-
-    #[test]
-    fn radio_swap_mode_indices() {
-        let cases = [
-            (0, SwapMode::None),
-            (1, SwapMode::Zram),
-            (2, SwapMode::ZswapPartition),
-            (3, SwapMode::ZswapPartitionEncrypted),
-        ];
-        for (idx, expected) in cases {
-            let mut c = cfg();
-            apply_radio(&mut c, "swap_mode", idx);
-            assert_eq!(c.swap_mode, expected, "idx={idx}");
-        }
-    }
-
-    #[test]
-    fn radio_init_system_indices() {
-        let mut c = cfg();
-        apply_radio(&mut c, "init_system", 0);
-        assert_eq!(c.init_system, InitSystem::Dracut);
-        apply_radio(&mut c, "init_system", 1);
-        assert_eq!(c.init_system, InitSystem::Mkinitcpio);
-    }
-
-    #[test]
-    fn radio_audio_indices() {
-        let cases = [
-            (0, None),
-            (1, Some(AudioServer::Pipewire)),
-            (2, Some(AudioServer::Pulseaudio)),
-        ];
-        for (idx, expected) in cases {
-            let mut c = cfg();
-            apply_radio(&mut c, "audio", idx);
-            assert_eq!(c.audio, expected, "idx={idx}");
-        }
-    }
 
     #[test]
     fn a_device_row_carries_the_path_it_selects() {
         let path = std::path::Path::new("/dev/disk/by-path/pci-0000:00:04.0");
         // Colons in persistent paths must survive the round trip through the
         // key, so the dispatcher has to split on the first one only.
-        let key = device_key("disk", path);
+        let key = device_key(DeviceSetting::Disk, path);
         let rest = key.strip_prefix("device:").expect("device prefix");
         let (group, payload) = rest.split_once(':').expect("group and payload");
 
@@ -1152,156 +939,7 @@ mod tests {
         assert_eq!(std::path::Path::new(payload), path);
     }
 
-    #[test]
-    fn selecting_a_device_stores_that_device() {
-        let mut c = cfg();
-        let disk = std::path::Path::new("/dev/disk/by-id/nvme-eui.0001");
-
-        apply_device(&mut c, "disk", disk);
-
-        assert_eq!(c.disk.as_deref(), Some(disk));
-        assert_eq!(c.installation_mode, Some(InstallationMode::FullDisk));
-    }
-
-    #[test]
-    fn a_device_selection_does_not_depend_on_list_position() {
-        // The whole point: two different rows resolve to two different disks
-        // regardless of what the enumeration would return now.
-        let mut c = cfg();
-        apply_device(&mut c, "efi_partition", std::path::Path::new("/dev/sda1"));
-        apply_device(&mut c, "zfs_partition", std::path::Path::new("/dev/sdb2"));
-
-        assert_eq!(
-            c.efi_partition.as_deref(),
-            Some(std::path::Path::new("/dev/sda1"))
-        );
-        assert_eq!(
-            c.zfs_partition.as_deref(),
-            Some(std::path::Path::new("/dev/sdb2"))
-        );
-    }
-
-    #[test]
-    fn device_unknown_group_is_noop() {
-        let mut c = cfg();
-        apply_device(&mut c, "nonsense", std::path::Path::new("/dev/sda"));
-        assert!(c.disk.is_none());
-        assert!(c.efi_partition.is_none());
-    }
-
-    #[test]
-    fn radio_unknown_key_is_noop() {
-        let mut c = cfg();
-        let before_mode = c.installation_mode;
-        let before_compression = c.compression;
-        let before_swap = c.swap_mode;
-        apply_radio(&mut c, "totally_made_up", 5);
-        assert_eq!(c.installation_mode, before_mode);
-        assert_eq!(c.compression, before_compression);
-        assert_eq!(c.swap_mode, before_swap);
-    }
-
     // ── apply_text ──────────────────────────────────────
-
-    #[test]
-    fn text_pool_name_sets_and_clears() {
-        let mut c = cfg();
-        apply_text(&mut c, "pool_name", "rpool");
-        assert_eq!(c.pool_name.as_deref(), Some("rpool"));
-
-        // Empty string clears the field
-        apply_text(&mut c, "pool_name", "");
-        assert!(c.pool_name.is_none());
-    }
-
-    #[test]
-    fn text_dataset_prefix_does_not_clear_on_empty() {
-        let mut c = cfg();
-        let original = c.dataset_prefix.clone();
-        apply_text(&mut c, "dataset_prefix", "myprefix");
-        assert_eq!(c.dataset_prefix, "myprefix");
-
-        // Empty string is a no-op (must not blank the prefix)
-        apply_text(&mut c, "dataset_prefix", "");
-        assert_eq!(c.dataset_prefix, "myprefix");
-
-        // Restoring the default works
-        apply_text(&mut c, "dataset_prefix", &original);
-        assert_eq!(c.dataset_prefix, original);
-    }
-
-    #[test]
-    fn text_hostname_sets_and_clears() {
-        let mut c = cfg();
-        apply_text(&mut c, "hostname", "archbox");
-        assert_eq!(c.hostname.as_deref(), Some("archbox"));
-        apply_text(&mut c, "hostname", "");
-        assert!(c.hostname.is_none());
-    }
-
-    #[test]
-    fn text_timezone_sets_and_clears() {
-        let mut c = cfg();
-        apply_text(&mut c, "timezone", "Europe/Berlin");
-        assert_eq!(c.timezone.as_deref(), Some("Europe/Berlin"));
-        apply_text(&mut c, "timezone", "");
-        assert!(c.timezone.is_none());
-    }
-
-    #[test]
-    fn text_root_password_sets_and_clears() {
-        let mut c = cfg();
-        apply_text(&mut c, "root_password", "hunter2");
-        assert_eq!(c.root_password.as_deref(), Some("hunter2"));
-        apply_text(&mut c, "root_password", "");
-        assert!(c.root_password.is_none());
-    }
-
-    #[test]
-    fn text_encryption_password_sets_and_clears() {
-        let mut c = cfg();
-        apply_text(&mut c, "encryption_password", "secret");
-        assert_eq!(c.zfs_encryption_password.as_deref(), Some("secret"));
-        apply_text(&mut c, "encryption_password", "");
-        assert!(c.zfs_encryption_password.is_none());
-    }
-
-    #[test]
-    fn text_parallel_downloads_clamps_and_rejects_garbage() {
-        let mut c = cfg();
-
-        apply_text(&mut c, "parallel_downloads", "8");
-        assert_eq!(c.parallel_downloads, 8);
-
-        // Above 20 → clamped to 20
-        apply_text(&mut c, "parallel_downloads", "100");
-        assert_eq!(c.parallel_downloads, 20);
-
-        // Zero → clamped to 1
-        apply_text(&mut c, "parallel_downloads", "0");
-        assert_eq!(c.parallel_downloads, 1);
-
-        // Garbage / non-numeric → previous value preserved
-        c.parallel_downloads = 5;
-        apply_text(&mut c, "parallel_downloads", "abc");
-        assert_eq!(c.parallel_downloads, 5);
-
-        // Negative parses fail (it's u32) → preserved
-        apply_text(&mut c, "parallel_downloads", "-3");
-        assert_eq!(c.parallel_downloads, 5);
-    }
-
-    #[test]
-    fn text_unknown_key_is_noop() {
-        let mut c = cfg();
-        let before_pool = c.pool_name.clone();
-        let before_hostname = c.hostname.clone();
-        let before_parallel = c.parallel_downloads;
-        apply_text(&mut c, "totally_made_up", "value");
-        assert_eq!(c.pool_name, before_pool);
-        assert_eq!(c.hostname, before_hostname);
-        assert_eq!(c.parallel_downloads, before_parallel);
-    }
 
     // ── next_selectable_index ───────────────────────────
 

--- a/slint-ui/src/controllers/install.rs
+++ b/slint-ui/src/controllers/install.rs
@@ -18,12 +18,49 @@ use crate::ui::{App, DownloadInfo, InstallState, LogMessage, WizardState};
 
 const MAX_LOG_LINES: usize = 2000;
 
+/// The install view's high-level mode.
+///
+/// The markup holds this as a number and compares it by order — anything at
+/// or past `Running` means the installation has started, anything at or past
+/// `Done` means it has finished — so the values are a protocol rather than an
+/// arbitrary numbering, and both sides have to agree on them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallPhase {
+    Configuring,
+    Running,
+    Done,
+    Failed,
+    Cancelling,
+    Cancelled,
+}
+
+impl InstallPhase {
+    const fn code(self) -> i32 {
+        match self {
+            Self::Configuring => 0,
+            Self::Running => 1,
+            Self::Done => 2,
+            Self::Failed => 3,
+            Self::Cancelling => 4,
+            Self::Cancelled => 5,
+        }
+    }
+}
+
+fn set_phase(app: &App, phase: InstallPhase) {
+    app.global::<InstallState>().set_state(phase.code());
+}
+
 pub fn setup(
     app: &App,
     config: &Rc<RefCell<GlobalConfig>>,
     demo: bool,
     log_rx: crossbeam_channel::Receiver<(String, i32)>,
 ) {
+    // The markup starts at this phase too; setting it here keeps the value
+    // owned in one place rather than agreeing by coincidence.
+    set_phase(app, InstallPhase::Configuring);
+
     // One pump for the process, fed by the global subscriber. It starts here
     // rather than per installation so nothing emitted before or between runs
     // is lost, and so the receiver is not re-created behind the layer's back.
@@ -37,7 +74,7 @@ pub fn setup(
         let Some(app) = weak.upgrade() else { return };
         if let Some(token) = cancel_slot.lock().unwrap().as_ref() {
             token.cancel();
-            app.global::<InstallState>().set_state(4);
+            set_phase(&app, InstallPhase::Cancelling);
         }
     });
 
@@ -60,7 +97,7 @@ pub fn setup(
             return;
         }
 
-        app.global::<InstallState>().set_state(1);
+        set_phase(&app, InstallPhase::Running);
         app.global::<InstallState>()
             .set_log_messages(ModelRc::new(VecModel::<LogMessage>::default()));
 
@@ -273,24 +310,38 @@ fn spawn_install(
         )
         .await;
 
-        let state = match &result {
-            Ok(()) => 2,
-            Err(_) if cancel.is_cancelled() => 5,
+        let phase = match &result {
+            Ok(()) => InstallPhase::Done,
+            Err(_) if cancel.is_cancelled() => InstallPhase::Cancelled,
             Err(error) => {
                 tracing::error!("{error}");
-                3
+                InstallPhase::Failed
             }
         };
         *cancel_slot.lock().unwrap() = None;
-        let _ = weak.upgrade_in_event_loop(move |app| {
-            app.global::<InstallState>().set_state(state);
-        });
+        let _ = weak.upgrade_in_event_loop(move |app| set_phase(&app, phase));
     });
 }
 
 #[cfg(test)]
 mod tests {
-    use super::installation_allowed;
+    use super::{InstallPhase, installation_allowed};
+
+    /// The markup compares these by order, so the codes are load-bearing.
+    #[test]
+    fn phase_codes_match_the_markup_protocol() {
+        assert_eq!(InstallPhase::Configuring.code(), 0);
+        assert_eq!(InstallPhase::Running.code(), 1);
+        assert_eq!(InstallPhase::Done.code(), 2);
+        assert_eq!(InstallPhase::Failed.code(), 3);
+        assert_eq!(InstallPhase::Cancelling.code(), 4);
+        assert_eq!(InstallPhase::Cancelled.code(), 5);
+
+        // "started" and "finished" are expressed as >= in the markup.
+        assert!(InstallPhase::Running.code() > InstallPhase::Configuring.code());
+        assert!(InstallPhase::Done.code() > InstallPhase::Running.code());
+        assert!(InstallPhase::Cancelling.code() > InstallPhase::Failed.code());
+    }
 
     #[test]
     fn safe_demo_cannot_start_installation() {

--- a/slint-ui/src/controllers/install.rs
+++ b/slint-ui/src/controllers/install.rs
@@ -10,6 +10,7 @@ use std::thread;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use archinstall_zfs_core::config::types::GlobalConfig;
+use archinstall_zfs_core::install::InstallError;
 use archinstall_zfs_core::system::async_download::{PackageProgress, PackageState};
 use tokio_util::sync::CancellationToken;
 
@@ -312,7 +313,7 @@ fn spawn_install(
 
         let phase = match &result {
             Ok(()) => InstallPhase::Done,
-            Err(_) if cancel.is_cancelled() => InstallPhase::Cancelled,
+            Err(InstallError::Cancelled) => InstallPhase::Cancelled,
             Err(error) => {
                 tracing::error!("{error}");
                 InstallPhase::Failed

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -13,7 +13,8 @@ use archinstall_zfs_core::profile::DisplayManager;
 use archinstall_zfs_core::system::gpu::{GfxDriver, detect_gpus, suggested_driver};
 
 use archinstall_zfs_core::config::edit::{
-    ChoiceSetting, DeviceSetting, TextSetting, apply_choice, apply_device, apply_text,
+    ChoiceSetting, DeviceSetting, EditorSetting, TextSetting, ToggleSetting, apply_choice,
+    apply_device, apply_text, apply_toggle,
 };
 
 use crate::config_items::{build_step_items, next_selectable_index};
@@ -94,12 +95,11 @@ fn setup_toggle(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     app.on_toggle_activated(move |key| {
         let Some(app) = weak.upgrade() else { return };
         let mut c = cfg.borrow_mut();
-        match key.as_str() {
-            "ntp" => c.ntp = !c.ntp,
-            "bluetooth" => c.bluetooth = !c.bluetooth,
-            "zrepl" => c.zrepl_enabled = !c.zrepl_enabled,
-            _ => return,
-        }
+        let Some(setting) = ToggleSetting::parse(&key) else {
+            tracing::warn!(%key, "toggle names no known setting");
+            return;
+        };
+        apply_toggle(&mut c, setting);
         refresh_items(&app, &c);
     });
 }
@@ -440,8 +440,18 @@ fn dm_picker_labels(profile_default: Option<DisplayManager>) -> Vec<String> {
 // ── Item activation (open the right popup for the clicked row) ──────
 
 fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_scan: &KernelScan) {
-    match key {
-        "kernel" => {
+    if let Some(setting) = TextSetting::parse(key) {
+        show_setting_text_input(app, setting, config);
+        return;
+    }
+
+    let Some(setting) = EditorSetting::parse(key) else {
+        tracing::warn!(key, "row names no known setting");
+        return;
+    };
+
+    match setting {
+        EditorSetting::Kernel => {
             // Use the cached scan results if available; otherwise block-scan now.
             let fresh: Vec<archinstall_zfs_core::kernel::scanner::CompatibilityResult>;
             let options =
@@ -467,7 +477,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
                 current_idx as i32,
             );
         }
-        "profile" => {
+        EditorSetting::Profile => {
             let profiles = archinstall_zfs_core::profile::all_profiles();
             let mut names: Vec<String> = vec!["None".to_string()];
             names.extend(profiles.iter().map(|p| p.display_name.to_string()));
@@ -480,7 +490,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
                 .unwrap_or(0);
             show_select(app, "profile", "Profile", &refs, current);
         }
-        "optional_packages" => {
+        EditorSetting::OptionalPackages => {
             // Build a fresh MultiSelectOption list from the profile's
             // optional packages and the user's current checked subset.
             let Some(sel) = config.profile_selection.as_ref() else {
@@ -502,7 +512,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             popup.set_multi_select_title(format!("Optional packages — {}", p.display_name).into());
             popup.set_multi_select_visible(true);
         }
-        "gpu_driver" => {
+        EditorSetting::GpuDriver => {
             // Build the GPU driver options list. Order matches the TUI
             // picker (None first, then drivers in display order). The
             // suggested driver based on detected hardware is annotated.
@@ -537,7 +547,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
                 .unwrap_or(0) as i32;
             show_select(app, "gfx_driver_select", "GPU driver", &refs, current);
         }
-        "display_manager" => {
+        EditorSetting::DisplayManager => {
             // Open SelectPopup with the full DisplayManager list, annotating
             // the profile's own default with `  ✦ default` (same idiom as the
             // GPU driver picker uses for its suggestion). Picking the
@@ -560,11 +570,11 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
                 .unwrap_or(-1);
             show_select(app, "dm_select", "Display manager", &refs, current);
         }
-        "timezone" => {
+        EditorSetting::Timezone => {
             let regions = archinstall_zfs_core::installer::locale::list_timezone_regions();
             show_select(app, "timezone_region", "Timezone region", &regions, 0);
         }
-        "locale" => {
+        EditorSetting::Locale => {
             let locales = archinstall_zfs_core::installer::locale::list_locales();
             let locale_strs: Vec<&str> = locales.iter().map(|s| s.as_str()).collect();
             let current_idx = config
@@ -582,10 +592,10 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
                 true,
             );
         }
-        "users" => {
+        EditorSetting::Users => {
             show_users_popup(app);
         }
-        "keyboard" => {
+        EditorSetting::Keyboard => {
             let keymaps = archinstall_zfs_core::installer::locale::list_keymaps();
             let keymap_strs: Vec<&str> = keymaps.iter().map(|s| s.as_str()).collect();
             let current_idx = keymaps
@@ -602,40 +612,53 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
                 true,
             );
         }
-        "packages" => {
-            show_package_search(app);
-        }
-        "extra_services" => {
-            show_string_list(app, "Extra systemd services");
-        }
-        "pool_name"
-        | "dataset_prefix"
-        | "hostname"
-        | "swap_partition_size"
-        | "parallel_downloads" => {
-            let (title, current) = match key {
-                "pool_name" => ("Pool name", config.pool_name.clone().unwrap_or_default()),
-                "dataset_prefix" => ("Dataset prefix", config.dataset_prefix.clone()),
-                "hostname" => ("Hostname", config.hostname.clone().unwrap_or_default()),
-                "swap_partition_size" => (
-                    "Swap partition size",
-                    config.swap_partition_size.clone().unwrap_or_default(),
-                ),
-                "parallel_downloads" => {
-                    ("Parallel downloads", config.parallel_downloads.to_string())
-                }
-                _ => ("", String::new()),
-            };
-            show_text_input(app, key, title, &current, false);
-        }
-        "root_password" => {
-            show_text_input(app, key, "Root password", "", true);
-        }
-        "encryption_password" => {
-            show_text_input(app, key, "Encryption password", "", true);
-        }
-        _ => {}
+        // The pool picker and the package list are the terminal interface's;
+        // here those rows are typed into and handled above.
+        EditorSetting::PoolName | EditorSetting::Packages => {}
     }
+}
+
+/// Open the text editor for a row that is typed into.
+///
+/// The title and the starting text are the row's own business; the setting
+/// travels with the popup so the confirmation handler knows what was edited.
+fn show_setting_text_input(app: &App, setting: TextSetting, config: &GlobalConfig) {
+    let (title, current, secret) = match setting {
+        TextSetting::PoolName => (
+            "Pool name",
+            config.pool_name.clone().unwrap_or_default(),
+            false,
+        ),
+        TextSetting::DatasetPrefix => ("Dataset prefix", config.dataset_prefix.clone(), false),
+        TextSetting::Hostname => (
+            "Hostname",
+            config.hostname.clone().unwrap_or_default(),
+            false,
+        ),
+        TextSetting::SwapPartitionSize => (
+            "Swap partition size",
+            config.swap_partition_size.clone().unwrap_or_default(),
+            false,
+        ),
+        TextSetting::ParallelDownloads => (
+            "Parallel downloads",
+            config.parallel_downloads.to_string(),
+            false,
+        ),
+        // Never shown filled in: a stored secret is not echoed back.
+        TextSetting::RootPassword => ("Root password", String::new(), true),
+        TextSetting::EncryptionPassword => ("Encryption password", String::new(), true),
+        // Edited through the list editor rather than a single line.
+        TextSetting::AdditionalPackages | TextSetting::AurPackages => {
+            show_package_search(app);
+            return;
+        }
+        TextSetting::ExtraServices => {
+            show_string_list(app, "Extra systemd services");
+            return;
+        }
+    };
+    show_text_input(app, setting.as_str(), title, &current, secret);
 }
 
 // ── Popup show helpers ──────────────────────────────

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -12,9 +12,11 @@ use archinstall_zfs_core::config::types::GlobalConfig;
 use archinstall_zfs_core::profile::DisplayManager;
 use archinstall_zfs_core::system::gpu::{GfxDriver, detect_gpus, suggested_driver};
 
-use crate::config_items::{
-    apply_device, apply_radio, apply_text, build_step_items, next_selectable_index,
+use archinstall_zfs_core::config::edit::{
+    ChoiceSetting, DeviceSetting, TextSetting, apply_choice, apply_device, apply_text,
 };
+
+use crate::config_items::{build_step_items, next_selectable_index};
 use crate::controllers::welcome::KernelScan;
 use crate::editing_models::set_multi_select_options;
 use crate::refresh::refresh_items;
@@ -49,26 +51,35 @@ fn setup_item_activated(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_sc
     app.on_item_activated(move |key| {
         let Some(app) = weak.upgrade() else { return };
 
-        // Device rows: "device:{group_key}:{path}". Split on the first colon
+        // Device rows: "device:{setting}:{path}". Split on the first colon
         // only — persistent device paths contain colons of their own, as in
         // by-path/pci-0000:00:04.0.
         if let Some(rest) = key.strip_prefix("device:") {
-            if let Some((group_key, path)) = rest.split_once(':') {
-                let mut c = cfg.borrow_mut();
-                apply_device(&mut c, group_key, std::path::Path::new(path));
-                refresh_items(&app, &c);
+            match rest
+                .split_once(':')
+                .and_then(|(name, path)| DeviceSetting::parse(name).map(|setting| (setting, path)))
+            {
+                Some((setting, path)) => {
+                    let mut c = cfg.borrow_mut();
+                    apply_device(&mut c, setting, std::path::Path::new(path));
+                    refresh_items(&app, &c);
+                }
+                None => tracing::warn!(%key, "device row names no known setting"),
             }
             return;
         }
 
-        // Inline radio option clicks: "radio:{group_key}:{index}"
+        // Inline radio option clicks: "radio:{setting}:{index}"
         if let Some(rest) = key.strip_prefix("radio:") {
-            if let Some((group_key, idx_str)) = rest.rsplit_once(':')
-                && let Ok(idx) = idx_str.parse::<i32>()
-            {
-                let mut c = cfg.borrow_mut();
-                apply_radio(&mut c, group_key, idx);
-                refresh_items(&app, &c);
+            match rest.rsplit_once(':').and_then(|(name, index)| {
+                Some((ChoiceSetting::parse(name)?, index.parse::<usize>().ok()?))
+            }) {
+                Some((setting, index)) => {
+                    let mut c = cfg.borrow_mut();
+                    apply_choice(&mut c, setting, index);
+                    refresh_items(&app, &c);
+                }
+                None => tracing::warn!(%key, "radio row names no known setting"),
             }
             return;
         }
@@ -210,9 +221,14 @@ fn setup_select_confirmed(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_
             return;
         }
 
-        let mut c = cfg.borrow_mut();
-        apply_radio(&mut c, &key, idx);
-        refresh_items(&app, &c);
+        match ChoiceSetting::parse(&key) {
+            Some(setting) => {
+                let mut c = cfg.borrow_mut();
+                apply_choice(&mut c, setting, idx.max(0) as usize);
+                refresh_items(&app, &c);
+            }
+            None => tracing::warn!(%key, "selection names no known setting"),
+        }
     });
 }
 
@@ -221,9 +237,14 @@ fn setup_text_confirmed(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let cfg = config.clone();
     app.on_text_confirmed(move |key, val| {
         let Some(app) = weak.upgrade() else { return };
-        let mut c = cfg.borrow_mut();
-        apply_text(&mut c, &key, &val);
-        refresh_items(&app, &c);
+        match TextSetting::parse(&key) {
+            Some(setting) => {
+                let mut c = cfg.borrow_mut();
+                apply_text(&mut c, setting, &val);
+                refresh_items(&app, &c);
+            }
+            None => tracing::warn!(%key, "edited row names no known setting"),
+        }
     });
 }
 

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -12,7 +12,9 @@ use archinstall_zfs_core::config::types::GlobalConfig;
 use archinstall_zfs_core::profile::DisplayManager;
 use archinstall_zfs_core::system::gpu::{GfxDriver, detect_gpus, suggested_driver};
 
-use crate::config_items::{apply_radio, apply_text, build_step_items, next_selectable_index};
+use crate::config_items::{
+    apply_device, apply_radio, apply_text, build_step_items, next_selectable_index,
+};
 use crate::controllers::welcome::KernelScan;
 use crate::editing_models::set_multi_select_options;
 use crate::refresh::refresh_items;
@@ -46,6 +48,18 @@ fn setup_item_activated(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_sc
     let kscan = kernel_scan.clone();
     app.on_item_activated(move |key| {
         let Some(app) = weak.upgrade() else { return };
+
+        // Device rows: "device:{group_key}:{path}". Split on the first colon
+        // only — persistent device paths contain colons of their own, as in
+        // by-path/pci-0000:00:04.0.
+        if let Some(rest) = key.strip_prefix("device:") {
+            if let Some((group_key, path)) = rest.split_once(':') {
+                let mut c = cfg.borrow_mut();
+                apply_device(&mut c, group_key, std::path::Path::new(path));
+                refresh_items(&app, &c);
+            }
+            return;
+        }
 
         // Inline radio option clicks: "radio:{group_key}:{index}"
         if let Some(rest) = key.strip_prefix("radio:") {

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -128,20 +128,15 @@ async fn main() -> Result<()> {
         if cli.config.is_none() {
             bail!("--silent requires --config");
         }
-        let errors = config.validate_for_install();
-        if !errors.is_empty() {
-            let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
-            bail!("Config validation failed:\n  {}", rendered.join("\n  "));
-        }
         let runner: Arc<dyn archinstall_zfs_core::system::cmd::CommandRunner> =
             Arc::new(archinstall_zfs_core::system::cmd::RealRunner);
-        archinstall_zfs_core::install::run_install(
+        Ok(archinstall_zfs_core::install::run_install(
             runner,
             config,
             tokio_util::sync::CancellationToken::new(),
             None,
         )
-        .await
+        .await?)
     } else {
         run_gui(config, demo, log_rx)
     }

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -130,7 +130,8 @@ async fn main() -> Result<()> {
         }
         let errors = config.validate_for_install();
         if !errors.is_empty() {
-            bail!("Config validation failed:\n  {}", errors.join("\n  "));
+            let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
+            bail!("Config validation failed:\n  {}", rendered.join("\n  "));
         }
         let runner: Arc<dyn archinstall_zfs_core::system::cmd::CommandRunner> =
             Arc::new(archinstall_zfs_core::system::cmd::RealRunner);

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -34,7 +34,8 @@ pub async fn run(
         }
         let errors = config.validate_for_install();
         if !errors.is_empty() {
-            bail!("Config validation failed:\n  {}", errors.join("\n  "));
+            let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
+            bail!("Config validation failed:\n  {}", rendered.join("\n  "));
         }
         tracing::info!("silent mode: config valid, starting installation");
         let runner: Arc<dyn CommandRunner> = Arc::new(RealRunner);

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -32,15 +32,10 @@ pub async fn run(
         if cli.config.is_none() {
             bail!("--silent requires --config");
         }
-        let errors = config.validate_for_install();
-        if !errors.is_empty() {
-            let rendered: Vec<String> = errors.iter().map(ToString::to_string).collect();
-            bail!("Config validation failed:\n  {}", rendered.join("\n  "));
-        }
-        tracing::info!("silent mode: config valid, starting installation");
+        tracing::info!("silent mode: starting installation");
         let runner: Arc<dyn CommandRunner> = Arc::new(RealRunner);
         let cancel = CancellationToken::new();
-        return archinstall_zfs_core::install::run_install(runner, config, cancel, None).await;
+        return Ok(archinstall_zfs_core::install::run_install(runner, config, cancel, None).await?);
     }
 
     // Interactive TUI mode

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use color_eyre::eyre::Result;
 
+use archinstall_zfs_core::config::choices::Choice;
 use archinstall_zfs_core::config::types::{
     AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
     SeatAccess, SwapMode, UserConfig, ZfsEncryptionMode, ZfsModuleMode,
@@ -591,11 +592,8 @@ pub fn apply_select(
 ) -> Result<()> {
     match key {
         "installation_mode" => {
-            let new_mode = match idx {
-                0 => InstallationMode::FullDisk,
-                1 => InstallationMode::NewPool,
-                2 => InstallationMode::ExistingPool,
-                _ => return Ok(()),
+            let Some(new_mode) = InstallationMode::from_index(idx) else {
+                return Ok(());
             };
             if config.installation_mode != Some(new_mode) {
                 config.disk = None;
@@ -606,11 +604,8 @@ pub fn apply_select(
             config.installation_mode = Some(new_mode);
         }
         "encryption" => {
-            let new_mode = match idx {
-                0 => ZfsEncryptionMode::None,
-                1 => ZfsEncryptionMode::Pool,
-                2 => ZfsEncryptionMode::Dataset,
-                _ => return Ok(()),
+            let Some(new_mode) = ZfsEncryptionMode::from_index(idx) else {
+                return Ok(());
             };
             config.zfs_encryption_mode = new_mode;
             if new_mode != ZfsEncryptionMode::None && config.zfs_encryption_password.is_none() {
@@ -626,50 +621,34 @@ pub fn apply_select(
             }
         }
         "compression" => {
-            config.compression = match idx {
-                0 => CompressionAlgo::Lz4,
-                1 => CompressionAlgo::Zstd,
-                2 => CompressionAlgo::Zstd5,
-                3 => CompressionAlgo::Zstd10,
-                4 => CompressionAlgo::Off,
-                _ => return Ok(()),
-            };
+            if let Some(algo) = CompressionAlgo::from_index(idx) {
+                config.compression = algo;
+            }
         }
         "swap_mode" => {
-            config.swap_mode = match idx {
-                0 => SwapMode::None,
-                1 => SwapMode::Zram,
-                2 => SwapMode::ZswapPartition,
-                3 => SwapMode::ZswapPartitionEncrypted,
-                _ => return Ok(()),
-            };
+            if let Some(mode) = SwapMode::from_index(idx) {
+                config.swap_mode = mode;
+            }
         }
         "init_system" => {
-            config.init_system = match idx {
-                0 => InitSystem::Dracut,
-                1 => InitSystem::Mkinitcpio,
-                _ => return Ok(()),
-            };
+            if let Some(init) = InitSystem::from_index(idx) {
+                config.init_system = init;
+            }
         }
         "audio" => {
-            config.audio = match idx {
-                0 => None,
-                1 => Some(AudioServer::Pipewire),
-                2 => Some(AudioServer::Pulseaudio),
-                _ => return Ok(()),
-            };
+            if let Some(server) = <Option<AudioServer>>::from_index(idx) {
+                config.audio = server;
+            }
         }
         "network" => {
             config.network_copy_iso = idx == 0;
         }
         "seat_access" => {
-            if let Some(sel) = config.profile_selection.as_mut() {
-                sel.seat_access = match idx {
-                    0 => None,
-                    1 => Some(SeatAccess::Seatd),
-                    2 => Some(SeatAccess::Polkit),
-                    _ => return Ok(()),
-                };
+            if let (Some(sel), Some(access)) = (
+                config.profile_selection.as_mut(),
+                <Option<SeatAccess>>::from_index(idx),
+            ) {
+                sel.seat_access = access;
             }
         }
         _ => {}

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -2,10 +2,11 @@ use std::path::PathBuf;
 
 use color_eyre::eyre::Result;
 
-use archinstall_zfs_core::config::choices::Choice;
+use archinstall_zfs_core::config::edit::{
+    ChoiceSetting, TextSetting, apply_choice, apply_text as apply_text_setting,
+};
 use archinstall_zfs_core::config::types::{
-    AudioServer, CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, ProfileSelection,
-    SeatAccess, SwapMode, UserConfig, ZfsEncryptionMode, ZfsModuleMode,
+    GlobalConfig, ProfileSelection, SeatAccess, UserConfig, ZfsEncryptionMode, ZfsModuleMode,
 };
 use archinstall_zfs_core::profile::{DisplayManager, OptionalPackage};
 use archinstall_zfs_core::system::gpu::{GfxDriver, detect_gpus, suggested_driver};
@@ -590,115 +591,33 @@ pub fn apply_select(
     idx: usize,
     terminal: &mut ratatui::DefaultTerminal,
 ) -> Result<()> {
-    match key {
-        "installation_mode" => {
-            let Some(new_mode) = InstallationMode::from_index(idx) else {
-                return Ok(());
-            };
-            if config.installation_mode != Some(new_mode) {
-                config.disk = None;
-                config.efi_partition = None;
-                config.zfs_partition = None;
-                config.swap_partition = None;
-            }
-            config.installation_mode = Some(new_mode);
+    let Some(setting) = ChoiceSetting::parse(key) else {
+        tracing::warn!(key, "selection names no known setting");
+        return Ok(());
+    };
+
+    apply_choice(config, setting, idx);
+
+    // Asking for the passphrase belongs here rather than in core: it is a
+    // prompt, not a configuration change, and each interface asks its own way.
+    if setting == ChoiceSetting::Encryption
+        && config.zfs_encryption_mode != ZfsEncryptionMode::None
+        && config.zfs_encryption_password.is_none()
+    {
+        let result = run_edit(terminal, "Encryption password (min 8 chars)", "", true)?;
+        if let Some(pw) = result.value
+            && !pw.is_empty()
+        {
+            config.zfs_encryption_password = Some(pw);
         }
-        "encryption" => {
-            let Some(new_mode) = ZfsEncryptionMode::from_index(idx) else {
-                return Ok(());
-            };
-            config.zfs_encryption_mode = new_mode;
-            if new_mode != ZfsEncryptionMode::None && config.zfs_encryption_password.is_none() {
-                let result = run_edit(terminal, "Encryption password (min 8 chars)", "", true)?;
-                if let Some(pw) = result.value
-                    && !pw.is_empty()
-                {
-                    config.zfs_encryption_password = Some(pw);
-                }
-            }
-            if new_mode == ZfsEncryptionMode::None {
-                config.zfs_encryption_password = None;
-            }
-        }
-        "compression" => {
-            if let Some(algo) = CompressionAlgo::from_index(idx) {
-                config.compression = algo;
-            }
-        }
-        "swap_mode" => {
-            if let Some(mode) = SwapMode::from_index(idx) {
-                config.swap_mode = mode;
-            }
-        }
-        "init_system" => {
-            if let Some(init) = InitSystem::from_index(idx) {
-                config.init_system = init;
-            }
-        }
-        "audio" => {
-            if let Some(server) = <Option<AudioServer>>::from_index(idx) {
-                config.audio = server;
-            }
-        }
-        "network" => {
-            config.network_copy_iso = idx == 0;
-        }
-        "seat_access" => {
-            if let (Some(sel), Some(access)) = (
-                config.profile_selection.as_mut(),
-                <Option<SeatAccess>>::from_index(idx),
-            ) {
-                sel.seat_access = access;
-            }
-        }
-        _ => {}
     }
+
     Ok(())
 }
 
 pub fn apply_text(config: &mut GlobalConfig, key: &str, val: &str) {
-    let val_opt = if val.is_empty() {
-        None
-    } else {
-        Some(val.to_string())
-    };
-    match key {
-        "pool_name" => config.pool_name = val_opt,
-        "dataset_prefix" if !val.is_empty() => {
-            config.dataset_prefix = val.to_string();
-        }
-        "hostname" => config.hostname = val_opt,
-        "locale" => config.locale = val_opt,
-        "timezone" => config.timezone = val_opt,
-        "root_password" => config.root_password = val_opt,
-        "encryption_password" => config.zfs_encryption_password = val_opt,
-        "swap_partition_size" => config.swap_partition_size = val_opt,
-        "parallel_downloads" => {
-            if let Ok(n) = val.parse::<u32>() {
-                config.parallel_downloads = n.clamp(1, 20);
-            }
-        }
-        "additional_packages" => {
-            config.additional_packages = val
-                .split_whitespace()
-                .map(|s| s.trim_matches(',').to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-        }
-        "aur_packages" => {
-            config.aur_packages = val
-                .split_whitespace()
-                .map(|s| s.trim_matches(',').to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-        }
-        "extra_services" => {
-            config.extra_services = val
-                .split_whitespace()
-                .map(|s| s.trim_matches(',').to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-        }
-        _ => {}
+    match TextSetting::parse(key) {
+        Some(setting) => apply_text_setting(config, setting, val),
+        None => tracing::warn!(key, "edited row names no known setting"),
     }
 }

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -576,15 +576,6 @@ pub fn manage_users(
 
 // ── Apply handlers ──────────────────────────────────
 
-pub fn apply_toggle(config: &mut GlobalConfig, key: &str) {
-    match key {
-        "ntp" => config.ntp = !config.ntp,
-        "bluetooth" => config.bluetooth = !config.bluetooth,
-        "zrepl" => config.zrepl_enabled = !config.zrepl_enabled,
-        _ => {}
-    }
-}
-
 pub fn apply_select(
     config: &mut GlobalConfig,
     key: &str,

--- a/tui/src/tui/screens/steps/desktop.rs
+++ b/tui/src/tui/screens/steps/desktop.rs
@@ -1,3 +1,4 @@
+use archinstall_zfs_core::config::edit::{ChoiceSetting, TextSetting};
 use archinstall_zfs_core::config::types::GlobalConfig;
 
 use super::{MenuItem, MenuKind, choice_group};
@@ -28,7 +29,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     ];
 
     items.extend(choice_group(
-        "seat_access",
+        ChoiceSetting::SeatAccess,
         "Seat access",
         sel.and_then(|s| s.seat_access),
     ));
@@ -50,7 +51,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         });
     }
 
-    items.extend(choice_group("audio", "Audio", config.audio));
+    items.extend(choice_group(ChoiceSetting::Audio, "Audio", config.audio));
 
     items.extend([
         MenuItem {
@@ -84,7 +85,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             kind: MenuKind::Custom,
         },
         MenuItem {
-            key: "extra_services",
+            key: TextSetting::ExtraServices.as_str(),
             label: "Extra services",
             value: if config.extra_services.is_empty() {
                 "None".into()

--- a/tui/src/tui/screens/steps/desktop.rs
+++ b/tui/src/tui/screens/steps/desktop.rs
@@ -1,6 +1,6 @@
-use archinstall_zfs_core::config::types::{AudioServer, GlobalConfig, SeatAccess};
+use archinstall_zfs_core::config::types::GlobalConfig;
 
-use super::{MenuItem, MenuKind, radio_group};
+use super::{MenuItem, MenuKind, choice_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let sel = config.profile_selection.as_ref();
@@ -27,15 +27,10 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         },
     ];
 
-    items.extend(radio_group(
+    items.extend(choice_group(
         "seat_access",
         "Seat access",
-        &["None", "seatd", "polkit"],
-        match sel.and_then(|s| s.seat_access) {
-            None => 0,
-            Some(SeatAccess::Seatd) => 1,
-            Some(SeatAccess::Polkit) => 2,
-        },
+        sel.and_then(|s| s.seat_access),
     ));
 
     // GPU driver is only meaningful for graphical profiles. Hide the row
@@ -55,16 +50,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         });
     }
 
-    items.extend(radio_group(
-        "audio",
-        "Audio",
-        &["None", "pipewire", "pulseaudio"],
-        match config.audio {
-            None => 0,
-            Some(AudioServer::Pipewire) => 1,
-            Some(AudioServer::Pulseaudio) => 2,
-        },
-    ));
+    items.extend(choice_group("audio", "Audio", config.audio));
 
     items.extend([
         MenuItem {

--- a/tui/src/tui/screens/steps/disk.rs
+++ b/tui/src/tui/screens/steps/disk.rs
@@ -1,3 +1,4 @@
+use archinstall_zfs_core::config::edit::DeviceSetting;
 use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode};
 
 use super::{MenuItem, MenuKind};
@@ -9,7 +10,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     // Show disk picker for FullDisk mode
     if matches!(mode, Some(InstallationMode::FullDisk) | None) {
         items.push(MenuItem {
-            key: "disk",
+            key: DeviceSetting::Disk.as_str(),
             label: "Disk",
             value: config
                 .disk
@@ -26,7 +27,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         Some(InstallationMode::NewPool) | Some(InstallationMode::ExistingPool)
     ) {
         items.push(MenuItem {
-            key: "efi_partition",
+            key: DeviceSetting::EfiPartition.as_str(),
             label: "EFI partition",
             value: config
                 .efi_partition
@@ -38,7 +39,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     }
     if matches!(mode, Some(InstallationMode::NewPool)) {
         items.push(MenuItem {
-            key: "zfs_partition",
+            key: DeviceSetting::ZfsPartition.as_str(),
             label: "ZFS partition",
             value: config
                 .zfs_partition

--- a/tui/src/tui/screens/steps/mod.rs
+++ b/tui/src/tui/screens/steps/mod.rs
@@ -6,6 +6,8 @@ pub mod users;
 pub mod welcome;
 pub mod zfs;
 
+use archinstall_zfs_core::config::choices::Choice;
+
 // ── Shared types for all wizard steps ──────────────────
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -108,6 +110,17 @@ impl MenuItem {
 }
 
 /// Helper: emit a radio group header + options as a flat list of MenuItems.
+/// Build a radio group from a [`Choice`] enum, so the order, the labels and
+/// the selected index all come from one table rather than being spelled out
+/// here and inverted again in `pickers::apply_select`.
+pub fn choice_group<T: Choice>(
+    key: &'static str,
+    label: &'static str,
+    current: T,
+) -> Vec<MenuItem> {
+    radio_group(key, label, &T::labels(), current.index())
+}
+
 pub fn radio_group(
     key: &'static str,
     label: &'static str,

--- a/tui/src/tui/screens/steps/mod.rs
+++ b/tui/src/tui/screens/steps/mod.rs
@@ -7,6 +7,7 @@ pub mod welcome;
 pub mod zfs;
 
 use archinstall_zfs_core::config::choices::Choice;
+use archinstall_zfs_core::config::edit::ChoiceSetting;
 
 // ── Shared types for all wizard steps ──────────────────
 
@@ -114,11 +115,11 @@ impl MenuItem {
 /// the selected index all come from one table rather than being spelled out
 /// here and inverted again in `pickers::apply_select`.
 pub fn choice_group<T: Choice>(
-    key: &'static str,
+    setting: ChoiceSetting,
     label: &'static str,
     current: T,
 ) -> Vec<MenuItem> {
-    radio_group(key, label, &T::labels(), current.index())
+    radio_group(setting.as_str(), label, &T::labels(), current.index())
 }
 
 pub fn radio_group(

--- a/tui/src/tui/screens/steps/review.rs
+++ b/tui/src/tui/screens/steps/review.rs
@@ -82,7 +82,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             items.push(MenuItem {
                 key: "error",
                 label: "",
-                value: error.clone(),
+                value: error.to_string(),
                 kind: MenuKind::SectionHeader,
             });
         }

--- a/tui/src/tui/screens/steps/system.rs
+++ b/tui/src/tui/screens/steps/system.rs
@@ -1,4 +1,4 @@
-use archinstall_zfs_core::config::edit::{ChoiceSetting, TextSetting};
+use archinstall_zfs_core::config::edit::{ChoiceSetting, EditorSetting, TextSetting};
 use archinstall_zfs_core::config::types::GlobalConfig;
 
 use super::{MenuItem, MenuKind, radio_group};
@@ -26,19 +26,19 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             kind: MenuKind::Text,
         },
         MenuItem {
-            key: TextSetting::Locale.as_str(),
+            key: EditorSetting::Locale.as_str(),
             label: "Locale",
             value: config.locale.clone().unwrap_or("Not set".into()),
             kind: MenuKind::Custom,
         },
         MenuItem {
-            key: TextSetting::Timezone.as_str(),
+            key: EditorSetting::Timezone.as_str(),
             label: "Timezone",
             value: config.timezone.clone().unwrap_or("Not set".into()),
             kind: MenuKind::Custom,
         },
         MenuItem {
-            key: "keyboard",
+            key: EditorSetting::Keyboard.as_str(),
             label: "Keyboard layout",
             value: config.keyboard_layout.clone(),
             kind: MenuKind::Custom,

--- a/tui/src/tui/screens/steps/system.rs
+++ b/tui/src/tui/screens/steps/system.rs
@@ -1,3 +1,4 @@
+use archinstall_zfs_core::config::edit::{ChoiceSetting, TextSetting};
 use archinstall_zfs_core::config::types::GlobalConfig;
 
 use super::{MenuItem, MenuKind, radio_group};
@@ -19,19 +20,19 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             kind: MenuKind::Custom,
         },
         MenuItem {
-            key: "hostname",
+            key: TextSetting::Hostname.as_str(),
             label: "Hostname",
             value: config.hostname.clone().unwrap_or("Not set".into()),
             kind: MenuKind::Text,
         },
         MenuItem {
-            key: "locale",
+            key: TextSetting::Locale.as_str(),
             label: "Locale",
             value: config.locale.clone().unwrap_or("Not set".into()),
             kind: MenuKind::Custom,
         },
         MenuItem {
-            key: "timezone",
+            key: TextSetting::Timezone.as_str(),
             label: "Timezone",
             value: config.timezone.clone().unwrap_or("Not set".into()),
             kind: MenuKind::Custom,
@@ -51,14 +52,14 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     ];
 
     items.extend(radio_group(
-        "network",
+        ChoiceSetting::NetworkCopyIso.as_str(),
         "Network",
         &["Copy from ISO", "Manual"],
         if config.network_copy_iso { 0 } else { 1 },
     ));
 
     items.push(MenuItem {
-        key: "parallel_downloads",
+        key: TextSetting::ParallelDownloads.as_str(),
         label: "Parallel downloads",
         value: config.parallel_downloads.to_string(),
         kind: MenuKind::Text,

--- a/tui/src/tui/screens/steps/users.rs
+++ b/tui/src/tui/screens/steps/users.rs
@@ -1,3 +1,4 @@
+use archinstall_zfs_core::config::edit::TextSetting;
 use archinstall_zfs_core::config::types::GlobalConfig;
 
 use super::{MenuItem, MenuKind};
@@ -5,7 +6,7 @@ use super::{MenuItem, MenuKind};
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     vec![
         MenuItem {
-            key: "root_password",
+            key: TextSetting::RootPassword.as_str(),
             label: "Root password",
             value: if config.root_password.is_some() {
                 "Set".into()

--- a/tui/src/tui/screens/steps/welcome.rs
+++ b/tui/src/tui/screens/steps/welcome.rs
@@ -1,10 +1,11 @@
+use archinstall_zfs_core::config::edit::ChoiceSetting;
 use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode};
 
 use super::{MenuItem, choice_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     choice_group(
-        "installation_mode",
+        ChoiceSetting::InstallationMode,
         "Installation mode",
         config
             .installation_mode

--- a/tui/src/tui/screens/steps/welcome.rs
+++ b/tui/src/tui/screens/steps/welcome.rs
@@ -1,19 +1,13 @@
 use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode};
 
-use super::radio_group;
+use super::{MenuItem, choice_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
-    radio_group(
+    choice_group(
         "installation_mode",
         "Installation mode",
-        &["Full Disk", "New Pool", "Existing Pool"],
-        match config.installation_mode {
-            Some(InstallationMode::FullDisk) => 0,
-            Some(InstallationMode::NewPool) => 1,
-            Some(InstallationMode::ExistingPool) => 2,
-            None => usize::MAX, // nothing selected
-        },
+        config
+            .installation_mode
+            .unwrap_or(InstallationMode::FullDisk),
     )
 }
-
-use super::MenuItem;

--- a/tui/src/tui/screens/steps/zfs.rs
+++ b/tui/src/tui/screens/steps/zfs.rs
@@ -1,3 +1,4 @@
+use archinstall_zfs_core::config::edit::{ChoiceSetting, DeviceSetting, TextSetting};
 use archinstall_zfs_core::config::types::{
     GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode,
 };
@@ -13,7 +14,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
 
     let mut items = vec![
         MenuItem {
-            key: "pool_name",
+            key: TextSetting::PoolName.as_str(),
             label: "Pool name",
             value: config.pool_name.clone().unwrap_or("Not set".into()),
             kind: if matches!(mode, Some(InstallationMode::ExistingPool)) {
@@ -23,7 +24,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
             },
         },
         MenuItem {
-            key: "dataset_prefix",
+            key: TextSetting::DatasetPrefix.as_str(),
             label: "Dataset prefix",
             value: config.dataset_prefix.clone(),
             kind: MenuKind::Text,
@@ -31,20 +32,20 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     ];
 
     items.extend(choice_group(
-        "compression",
+        ChoiceSetting::Compression,
         "Compression",
         config.compression,
     ));
 
     items.extend(choice_group(
-        "encryption",
+        ChoiceSetting::Encryption,
         "Encryption",
         config.zfs_encryption_mode,
     ));
 
     if config.zfs_encryption_mode != ZfsEncryptionMode::None {
         items.push(MenuItem {
-            key: "encryption_password",
+            key: TextSetting::EncryptionPassword.as_str(),
             label: "Encryption password",
             value: if config.zfs_encryption_password.is_some() {
                 "Set".into()
@@ -55,11 +56,15 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         });
     }
 
-    items.extend(choice_group("swap_mode", "Swap", config.swap_mode));
+    items.extend(choice_group(
+        ChoiceSetting::SwapMode,
+        "Swap",
+        config.swap_mode,
+    ));
 
     if matches!(mode, Some(InstallationMode::FullDisk)) && has_swap_partition {
         items.push(MenuItem {
-            key: "swap_partition_size",
+            key: TextSetting::SwapPartitionSize.as_str(),
             label: "Swap size",
             value: config
                 .swap_partition_size
@@ -70,7 +75,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     }
     if !matches!(mode, Some(InstallationMode::FullDisk) | None) && has_swap_partition {
         items.push(MenuItem {
-            key: "swap_partition",
+            key: DeviceSetting::SwapPartition.as_str(),
             label: "Swap partition",
             value: config
                 .swap_partition
@@ -82,7 +87,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     }
 
     items.extend(choice_group(
-        "init_system",
+        ChoiceSetting::InitSystem,
         "Init system",
         config.init_system,
     ));

--- a/tui/src/tui/screens/steps/zfs.rs
+++ b/tui/src/tui/screens/steps/zfs.rs
@@ -1,8 +1,8 @@
 use archinstall_zfs_core::config::types::{
-    CompressionAlgo, GlobalConfig, InitSystem, InstallationMode, SwapMode, ZfsEncryptionMode,
+    GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode,
 };
 
-use super::{MenuItem, MenuKind, radio_group};
+use super::{MenuItem, MenuKind, choice_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let mode = config.installation_mode;
@@ -30,32 +30,16 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         },
     ];
 
-    items.extend(radio_group(
+    items.extend(choice_group(
         "compression",
         "Compression",
-        &["lz4", "zstd", "zstd-5", "zstd-10", "off"],
-        match config.compression {
-            CompressionAlgo::Lz4 => 0,
-            CompressionAlgo::Zstd => 1,
-            CompressionAlgo::Zstd5 => 2,
-            CompressionAlgo::Zstd10 => 3,
-            CompressionAlgo::Off => 4,
-        },
+        config.compression,
     ));
 
-    items.extend(radio_group(
+    items.extend(choice_group(
         "encryption",
         "Encryption",
-        &[
-            "No encryption",
-            "Encrypt entire pool",
-            "Encrypt base dataset only",
-        ],
-        match config.zfs_encryption_mode {
-            ZfsEncryptionMode::None => 0,
-            ZfsEncryptionMode::Pool => 1,
-            ZfsEncryptionMode::Dataset => 2,
-        },
+        config.zfs_encryption_mode,
     ));
 
     if config.zfs_encryption_mode != ZfsEncryptionMode::None {
@@ -71,22 +55,7 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         });
     }
 
-    items.extend(radio_group(
-        "swap_mode",
-        "Swap",
-        &[
-            "None",
-            "ZRAM",
-            "Swap partition",
-            "Swap partition (encrypted)",
-        ],
-        match config.swap_mode {
-            SwapMode::None => 0,
-            SwapMode::Zram => 1,
-            SwapMode::ZswapPartition => 2,
-            SwapMode::ZswapPartitionEncrypted => 3,
-        },
-    ));
+    items.extend(choice_group("swap_mode", "Swap", config.swap_mode));
 
     if matches!(mode, Some(InstallationMode::FullDisk)) && has_swap_partition {
         items.push(MenuItem {
@@ -112,14 +81,10 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         });
     }
 
-    items.extend(radio_group(
+    items.extend(choice_group(
         "init_system",
         "Init system",
-        &["dracut", "mkinitcpio"],
-        match config.init_system {
-            InitSystem::Dracut => 0,
-            InitSystem::Mkinitcpio => 1,
-        },
+        config.init_system,
     ));
 
     items

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::{
     Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
 };
 
+use archinstall_zfs_core::config::edit::{DeviceSetting, apply_device};
 use archinstall_zfs_core::config::types::GlobalConfig;
 
 use crate::tui::Action;
@@ -300,23 +301,23 @@ impl Wizard {
                     }
                 }
                 "disk" => {
-                    if let Some(disk) = pickers::pick_disk(terminal)? {
-                        self.config.disk = Some(disk);
+                    if let Some(path) = pickers::pick_disk(terminal)? {
+                        apply_device(&mut self.config, DeviceSetting::Disk, &path);
                     }
                 }
                 "efi_partition" => {
-                    if let Some(part) = pickers::pick_partition(terminal, "EFI partition")? {
-                        self.config.efi_partition = Some(part);
+                    if let Some(path) = pickers::pick_partition(terminal, "EFI partition")? {
+                        apply_device(&mut self.config, DeviceSetting::EfiPartition, &path);
                     }
                 }
                 "zfs_partition" => {
-                    if let Some(part) = pickers::pick_partition(terminal, "ZFS partition")? {
-                        self.config.zfs_partition = Some(part);
+                    if let Some(path) = pickers::pick_partition(terminal, "ZFS partition")? {
+                        apply_device(&mut self.config, DeviceSetting::ZfsPartition, &path);
                     }
                 }
                 "swap_partition" => {
-                    if let Some(part) = pickers::pick_partition(terminal, "Swap partition")? {
-                        self.config.swap_partition = Some(part);
+                    if let Some(path) = pickers::pick_partition(terminal, "Swap partition")? {
+                        apply_device(&mut self.config, DeviceSetting::SwapPartition, &path);
                     }
                 }
                 "kernel" => {

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -6,7 +6,9 @@ use ratatui::widgets::{
     Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
 };
 
-use archinstall_zfs_core::config::edit::{DeviceSetting, apply_device};
+use archinstall_zfs_core::config::edit::{
+    DeviceSetting, EditorSetting, ToggleSetting, apply_device, apply_toggle,
+};
 use archinstall_zfs_core::config::types::GlobalConfig;
 
 use crate::tui::Action;
@@ -281,104 +283,115 @@ impl Wizard {
                 "quit" => return Ok(Action::Quit),
                 _ => {}
             },
-            MenuKind::Custom => match key {
-                "timezone" => {
-                    if let Some(tz) = pickers::pick_timezone(terminal)? {
-                        self.config.timezone = Some(tz);
+            MenuKind::Custom => {
+                // Device rows open a picker and hand the chosen path to the
+                // shared apply; every other row opens its own editor.
+                if let Some(setting) = DeviceSetting::parse(key) {
+                    let picked = match setting {
+                        DeviceSetting::Disk => pickers::pick_disk(terminal)?,
+                        DeviceSetting::EfiPartition => {
+                            pickers::pick_partition(terminal, "EFI partition")?
+                        }
+                        DeviceSetting::ZfsPartition => {
+                            pickers::pick_partition(terminal, "ZFS partition")?
+                        }
+                        DeviceSetting::SwapPartition => {
+                            pickers::pick_partition(terminal, "Swap partition")?
+                        }
+                    };
+                    if let Some(path) = picked {
+                        apply_device(&mut self.config, setting, &path);
                     }
+                    return Ok(Action::Continue);
                 }
-                "locale" => {
-                    let current = self.config.locale.as_deref().unwrap_or("");
-                    if let Some(loc) = pickers::pick_locale(terminal, current)? {
-                        self.config.locale = Some(loc);
+
+                let Some(setting) = EditorSetting::parse(key) else {
+                    tracing::warn!(key, "row names no known setting");
+                    return Ok(Action::Continue);
+                };
+
+                match setting {
+                    EditorSetting::Timezone => {
+                        if let Some(tz) = pickers::pick_timezone(terminal)? {
+                            self.config.timezone = Some(tz);
+                        }
                     }
-                }
-                "keyboard" => {
-                    if let Some(km) =
-                        pickers::pick_keyboard(terminal, &self.config.keyboard_layout)?
-                    {
-                        self.config.keyboard_layout = km;
+                    EditorSetting::Locale => {
+                        let current = self.config.locale.as_deref().unwrap_or("");
+                        if let Some(loc) = pickers::pick_locale(terminal, current)? {
+                            self.config.locale = Some(loc);
+                        }
                     }
-                }
-                "disk" => {
-                    if let Some(path) = pickers::pick_disk(terminal)? {
-                        apply_device(&mut self.config, DeviceSetting::Disk, &path);
+                    EditorSetting::Keyboard => {
+                        if let Some(km) =
+                            pickers::pick_keyboard(terminal, &self.config.keyboard_layout)?
+                        {
+                            self.config.keyboard_layout = km;
+                        }
                     }
-                }
-                "efi_partition" => {
-                    if let Some(path) = pickers::pick_partition(terminal, "EFI partition")? {
-                        apply_device(&mut self.config, DeviceSetting::EfiPartition, &path);
+                    EditorSetting::Kernel => {
+                        if let Some((kernel, mode)) =
+                            pickers::pick_kernel(&self.config, terminal).await?
+                        {
+                            self.config.kernels = Some(vec![kernel]);
+                            self.config.zfs_module_mode = mode;
+                        }
                     }
-                }
-                "zfs_partition" => {
-                    if let Some(path) = pickers::pick_partition(terminal, "ZFS partition")? {
-                        apply_device(&mut self.config, DeviceSetting::ZfsPartition, &path);
+                    EditorSetting::Profile => {
+                        pickers::pick_profile(&mut self.config, terminal)?;
                     }
-                }
-                "swap_partition" => {
-                    if let Some(path) = pickers::pick_partition(terminal, "Swap partition")? {
-                        apply_device(&mut self.config, DeviceSetting::SwapPartition, &path);
+                    EditorSetting::DisplayManager => {
+                        let profile_default = self
+                            .config
+                            .profile_selection
+                            .as_ref()
+                            .and_then(|s| s.profile_def())
+                            .and_then(|p| p.default_display_manager());
+                        if let Some(result) =
+                            pickers::pick_display_manager(terminal, profile_default)?
+                            && let Some(sel) = self.config.profile_selection.as_mut()
+                        {
+                            sel.display_manager_override = result;
+                        }
                     }
-                }
-                "kernel" => {
-                    if let Some((kernel, mode)) =
-                        pickers::pick_kernel(&self.config, terminal).await?
-                    {
-                        self.config.kernels = Some(vec![kernel]);
-                        self.config.zfs_module_mode = mode;
+                    EditorSetting::GpuDriver => {
+                        let wayland_only = self
+                            .config
+                            .profile_selection
+                            .as_ref()
+                            .and_then(|s| s.profile_def())
+                            .map(|p| p.is_wayland_only())
+                            .unwrap_or(false);
+                        if let Some(driver) = pickers::pick_gpu_driver(terminal, wayland_only)? {
+                            self.config.gfx_driver = driver;
+                        }
                     }
-                }
-                "profile" => {
-                    pickers::pick_profile(&mut self.config, terminal)?;
-                }
-                "display_manager" => {
-                    let profile_default = self
-                        .config
-                        .profile_selection
-                        .as_ref()
-                        .and_then(|s| s.profile_def())
-                        .and_then(|p| p.default_display_manager());
-                    if let Some(result) = pickers::pick_display_manager(terminal, profile_default)?
-                        && let Some(sel) = self.config.profile_selection.as_mut()
-                    {
-                        sel.display_manager_override = result;
+                    EditorSetting::Users => {
+                        pickers::manage_users(&mut self.config, terminal)?;
                     }
-                }
-                "gpu_driver" => {
-                    let wayland_only = self
-                        .config
-                        .profile_selection
-                        .as_ref()
-                        .and_then(|s| s.profile_def())
-                        .map(|p| p.is_wayland_only())
-                        .unwrap_or(false);
-                    if let Some(driver) = pickers::pick_gpu_driver(terminal, wayland_only)? {
-                        self.config.gfx_driver = driver;
+                    EditorSetting::Packages => {
+                        if let Some(result) = super::package_picker::run_package_picker(
+                            terminal,
+                            &self.config.additional_packages,
+                            &self.config.aur_packages,
+                        )
+                        .await?
+                        {
+                            self.config.additional_packages = result.repo_packages;
+                            self.config.aur_packages = result.aur_packages;
+                        }
                     }
-                }
-                "users" => {
-                    pickers::manage_users(&mut self.config, terminal)?;
-                }
-                "packages" => {
-                    if let Some(result) = super::package_picker::run_package_picker(
-                        terminal,
-                        &self.config.additional_packages,
-                        &self.config.aur_packages,
-                    )
-                    .await?
-                    {
-                        self.config.additional_packages = result.repo_packages;
-                        self.config.aur_packages = result.aur_packages;
+                    EditorSetting::PoolName => {
+                        pickers::pick_existing_pool(&mut self.config, terminal).await?;
                     }
+                    // Offered by the graphical interface only.
+                    EditorSetting::OptionalPackages => {}
                 }
-                "pool_name" => {
-                    pickers::pick_existing_pool(&mut self.config, terminal).await?;
-                }
-                _ => {}
-            },
-            MenuKind::Toggle => {
-                pickers::apply_toggle(&mut self.config, key);
             }
+            MenuKind::Toggle => match ToggleSetting::parse(key) {
+                Some(setting) => apply_toggle(&mut self.config, setting),
+                None => tracing::warn!(key, "toggle names no known setting"),
+            },
             MenuKind::Select { options, current } => {
                 let label = item.label;
                 let result = run_select(terminal, label, options, *current)?;

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -210,7 +210,11 @@ impl Wizard {
                     }
                     let errors = self.config.validate_for_install();
                     if !errors.is_empty() {
-                        let msg = errors.join("\n");
+                        let msg = errors
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join("\n");
                         let lines: Vec<&str> = msg.lines().collect();
                         let _ = run_select(terminal, "Validation errors", &lines, 0);
                         return Ok(Action::Continue);


### PR DESCRIPTION
A follow-up review of the codebase found the wizard's plumbing was held
together by string keys and list positions: each configuration enum was written
out four times, the two interfaces had drifted apart on what an out-of-range
selection means, and the graphical one resolved a clicked disk by re-enumerating
the block devices. This replaces that plumbing with values the compiler checks,
and applies the same treatment to the remaining places where meaning was
carried by prose or by an integer.

- Derive each choice list from one table per enum, so both interfaces build
  their lists and resolve selections from the same source
- Select disks by path rather than by position, so a device list that changes
  between drawing and clicking cannot select a different disk than the one whose
  label was read
- Apply configuration edits in core, named by enum, instead of two copies that
  had already diverged on which settings they handled
- Dispatch row activation and toggles on enums too, so an interface that does
  not offer a setting says so rather than omitting it
- Report configuration problems as values with one rendering, so every
  interface words them identically and can point at the field
- Return a typed error from the installation, so cancellation is distinguished
  from failure by matching rather than by consulting the cancellation token or
  the words in a message
- Name the boot environment's datasets in one place instead of building them
  with format! in six modules
- Name the install view's phases rather than writing bare numbers
- Construct the installer only once its package handle exists, removing the
  optional state that every later method asserted with expect()
