### PR TITLE
Reuse downloaded packages and sources between test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ The xtask test suite boots a QEMU VM, runs the installer, reboots from the insta
 
 Installer logs are automatically pulled from the VM to `test-install.log` for analysis.
 
+Runs share a package and source cache on the host (`/var/tmp/archinstall-zfs-cache`, `--cache-dir` to move it, `--no-cache` to skip it), so the ~1 GB of packages and the ZFSBootMenu tarball are downloaded once rather than on every run. The installer picks the cache up from `ARCHINSTALL_ZFS_PKG_CACHE` and `ARCHINSTALL_ZFS_SRCDEST`, which also makes an installation from a prepared cache possible outside the tests.
+
 ---
 
 ## Troubleshooting

--- a/core/src/installer/aur.rs
+++ b/core/src/installer/aur.rs
@@ -1,3 +1,4 @@
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -142,6 +143,8 @@ fn setup_aur_environment(
     let output = chroot_cmd(runner, target, "useradd", &["-m", TEMP_USER])?;
     check_exit(&output, "create AUR temp user")?;
 
+    configure_source_cache(target)?;
+
     // Enable NOPASSWD sudo — removed again by cleanup_aur_environment.
     let sudoers_dir = target.join("etc/sudoers.d");
     std::fs::create_dir_all(&sudoers_dir)?;
@@ -152,6 +155,62 @@ fn setup_aur_environment(
         "AUR sudoers drop-in",
     )?;
 
+    Ok(())
+}
+
+/// Where sources copied into the target are kept, and what makepkg is told.
+const SOURCE_CACHE_DIR: &str = "var/cache/archinstall-zfs/sources";
+
+/// Give makepkg sources that were downloaded ahead of time, when any were
+/// provided.
+///
+/// `ARCHINSTALL_ZFS_SRCDEST` names a directory on the running system — a
+/// mounted share, a directory on the installation medium — holding files
+/// makepkg would otherwise fetch. They are copied into the target rather than
+/// mounted through: the build runs under arch-chroot, and the target's `/run`
+/// is a plain bind of the medium's, so anything mounted *inside* that `/run`
+/// is not carried across. Copying also spares the build user needing write
+/// access to whatever the sources came from.
+///
+/// makepkg still verifies the checksums the PKGBUILD declares, so a stale file
+/// costs a download rather than a wrong build.
+fn configure_source_cache(target: &Path) -> Result<()> {
+    let Some(source) = std::env::var_os("ARCHINSTALL_ZFS_SRCDEST").filter(|v| !v.is_empty()) else {
+        return Ok(());
+    };
+    let source = Path::new(&source);
+    if !source.is_dir() {
+        tracing::warn!(
+            path = %source.display(),
+            "no source cache at that path; makepkg will download instead"
+        );
+        return Ok(());
+    }
+
+    let dest = target.join(SOURCE_CACHE_DIR);
+    std::fs::create_dir_all(&dest)?;
+    // makepkg writes anything it still has to fetch here, as the build user.
+    std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o1777))?;
+
+    let mut copied = 0usize;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        std::fs::copy(entry.path(), dest.join(entry.file_name()))?;
+        copied += 1;
+    }
+
+    let conf_dir = target.join("etc/makepkg.conf.d");
+    std::fs::create_dir_all(&conf_dir)?;
+    write_file_with_mode(
+        &conf_dir.join("00-archinstall-zfs-srcdest.conf"),
+        format!("SRCDEST=/{SOURCE_CACHE_DIR}\n").as_bytes(),
+        0o644,
+        "makepkg source cache",
+    )?;
+    tracing::info!(files = copied, "building AUR packages from a source cache");
     Ok(())
 }
 
@@ -272,6 +331,53 @@ mod tests {
             combined.unwrap_err().to_string().contains("AUR install"),
             "the build error must be the one reported"
         );
+    }
+
+    #[test]
+    fn sources_are_copied_into_the_target_and_pointed_at() {
+        let medium = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        std::fs::write(medium.path().join("zfsbootmenu-v3.1.0.tar.gz"), b"tarball").unwrap();
+        std::fs::create_dir(medium.path().join("a-directory")).unwrap();
+
+        // SAFETY: single-threaded test; the variable is read straight after.
+        unsafe { std::env::set_var("ARCHINSTALL_ZFS_SRCDEST", medium.path()) };
+        let result = configure_source_cache(target.path());
+        unsafe { std::env::remove_var("ARCHINSTALL_ZFS_SRCDEST") };
+        result.unwrap();
+
+        let copied = target
+            .path()
+            .join(SOURCE_CACHE_DIR)
+            .join("zfsbootmenu-v3.1.0.tar.gz");
+        assert_eq!(std::fs::read(copied).unwrap(), b"tarball");
+        assert!(
+            !target
+                .path()
+                .join(SOURCE_CACHE_DIR)
+                .join("a-directory")
+                .exists(),
+            "only files are sources"
+        );
+
+        let conf = std::fs::read_to_string(
+            target
+                .path()
+                .join("etc/makepkg.conf.d/00-archinstall-zfs-srcdest.conf"),
+        )
+        .unwrap();
+        assert_eq!(conf, format!("SRCDEST=/{SOURCE_CACHE_DIR}\n"));
+    }
+
+    #[test]
+    fn without_a_source_cache_nothing_is_configured() {
+        let target = tempfile::tempdir().unwrap();
+
+        // SAFETY: single-threaded test.
+        unsafe { std::env::remove_var("ARCHINSTALL_ZFS_SRCDEST") };
+        configure_source_cache(target.path()).unwrap();
+
+        assert!(!target.path().join("etc/makepkg.conf.d").exists());
     }
 
     #[test]

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -85,7 +85,17 @@ impl AlpmContext {
 
         let target_str = target.to_string_lossy();
         let db_path = format!("{}/var/lib/pacman", target_str);
-        let cache_dir = format!("{}/var/cache/pacman/pkg/", target_str);
+        // A cache outside the target survives it, so a later installation can
+        // reuse what this one downloaded.
+        let cache_dir = match download_config.cache_dir.as_ref() {
+            Some(shared) => {
+                fs::create_dir_all(shared).wrap_err_with(|| {
+                    format!("failed to create package cache: {}", shared.display())
+                })?;
+                format!("{}/", shared.display())
+            }
+            None => format!("{}/var/cache/pacman/pkg/", target_str),
+        };
 
         let mut handle = Alpm::new(target_str.as_ref(), &db_path)
             .map_err(|e| eyre!("failed to init alpm for target: {e}"))?;

--- a/core/src/system/async_download.rs
+++ b/core/src/system/async_download.rs
@@ -32,6 +32,33 @@ pub struct DownloadConfig {
     pub connect_timeout: Duration,
     /// Idle timeout — abort if no data received for this long (default: 30s).
     pub idle_timeout: Duration,
+    /// Where downloaded packages are kept.
+    ///
+    /// `None` puts them in the target's own package cache, which is where a
+    /// normal installation wants them. Pointing this somewhere that outlives
+    /// the target — a mounted share, a directory on the installation medium —
+    /// lets an installation reuse what an earlier one downloaded, which is
+    /// what the virtual-machine tests do between runs and what an offline
+    /// installation from a prepared cache needs.
+    ///
+    /// Set from `ARCHINSTALL_ZFS_PKG_CACHE` when that is present.
+    pub cache_dir: Option<PathBuf>,
+}
+
+/// The package cache an operator asked for, if any.
+fn cache_dir_from_environment() -> Option<PathBuf> {
+    let path = cache_dir_from(std::env::var_os("ARCHINSTALL_ZFS_PKG_CACHE"))?;
+    tracing::info!(path = %path.display(), "using the package cache from the environment");
+    Some(path)
+}
+
+/// An unset variable and one set to nothing both mean "use the target's own
+/// cache" — an empty value is what a shell leaves behind when the setting is
+/// there but blank, and treating it as a path would put the cache in the
+/// current directory.
+fn cache_dir_from(value: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let value = value?;
+    (!value.is_empty()).then(|| PathBuf::from(value))
 }
 
 impl Default for DownloadConfig {
@@ -42,6 +69,7 @@ impl Default for DownloadConfig {
             backoff_base: Duration::from_secs(1),
             connect_timeout: Duration::from_secs(10),
             idle_timeout: Duration::from_secs(30),
+            cache_dir: cache_dir_from_environment(),
         }
     }
 }
@@ -986,6 +1014,18 @@ mod tests {
 
         let (_, _, _, bytes) = counters(&rx.borrow());
         assert_eq!(bytes, 30, "the abandoned attempt's bytes must not linger");
+    }
+
+    #[test]
+    fn an_unset_or_empty_cache_setting_means_the_target_cache() {
+        use std::ffi::OsString;
+
+        assert_eq!(cache_dir_from(None), None);
+        assert_eq!(cache_dir_from(Some(OsString::new())), None);
+        assert_eq!(
+            cache_dir_from(Some(OsString::from("/run/cache"))),
+            Some(PathBuf::from("/run/cache"))
+        );
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,7 +3,7 @@ mod qemu;
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::ExitCode;
+use std::process::{Command, ExitCode};
 use std::time::Duration;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -132,6 +132,15 @@ struct TestOpts {
     /// Place disk image and UEFI vars in /tmp (tmpfs) for faster I/O
     #[arg(long)]
     tmpfs: bool,
+
+    /// Directory on the host holding downloaded packages and sources, reused
+    /// across runs. Created if missing; --no-cache turns it off.
+    #[arg(long, default_value = "/var/tmp/archinstall-zfs-cache")]
+    cache_dir: PathBuf,
+
+    /// Download everything again instead of reusing the host cache.
+    #[arg(long)]
+    no_cache: bool,
 
     /// SSH port for ISO VM
     #[arg(long, default_value_t = 2222)]
@@ -320,6 +329,89 @@ fn detect_init_system(config: &Path) -> String {
     }
 }
 
+/// Prepare the directory shared into the guest, or `None` when caching is off.
+///
+/// Holds two things: the packages the installer downloads, which is the
+/// gigabyte that would otherwise be fetched again on every run, and the
+/// sources makepkg needs for the AUR builds.
+fn prepare_cache(opts: &TestOpts) -> Result<Option<PathBuf>, String> {
+    if opts.no_cache {
+        return Ok(None);
+    }
+
+    let dir = &opts.cache_dir;
+    for sub in ["pkg", "src"] {
+        fs::create_dir_all(dir.join(sub))
+            .map_err(|e| format!("cannot create cache {}: {e}", dir.join(sub).display()))?;
+    }
+    let dir = dir
+        .canonicalize()
+        .map_err(|e| format!("cannot resolve cache {}: {e}", dir.display()))?;
+
+    seed_aur_sources(&dir.join("src"));
+    Ok(Some(dir))
+}
+
+/// Download the ZFSBootMenu tarball so makepkg does not have to.
+///
+/// Best effort: makepkg fetches it itself if this fails, and verifies the
+/// checksum either way, so a stale or missing file costs a download rather
+/// than a wrong build. Worth doing because this one download comes from
+/// GitHub's archive service, which is what fails first when GitHub is
+/// unwell — twice in one afternoon, in the run that prompted this.
+fn seed_aur_sources(dir: &Path) {
+    let pkgbuild = match Command::new("curl")
+        .args([
+            "-fsSL",
+            "--max-time",
+            "30",
+            "https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=zfsbootmenu",
+        ])
+        .output()
+    {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).into_owned(),
+        _ => {
+            eprintln!("  Could not read the zfsbootmenu PKGBUILD; makepkg will download its own");
+            return;
+        }
+    };
+
+    let Some(version) = pkgbuild.lines().find_map(|l| l.strip_prefix("pkgver=")) else {
+        eprintln!("  No pkgver in the zfsbootmenu PKGBUILD; skipping the source cache");
+        return;
+    };
+    let version = version.trim();
+
+    // The name makepkg looks for, from the PKGBUILD's renamed source entry.
+    let filename = format!("zfsbootmenu-v{version}.tar.gz");
+    let target = dir.join(&filename);
+    if target.exists() {
+        return;
+    }
+
+    let url = format!("https://github.com/zbm-dev/zfsbootmenu/archive/v{version}.tar.gz");
+    let partial = dir.join(format!("{filename}.part"));
+    let fetched = Command::new("curl")
+        .args(["-fsSL", "--max-time", "180", "-o"])
+        .arg(&partial)
+        .arg(&url)
+        .status();
+
+    match fetched {
+        Ok(status) if status.success() => {
+            // Renamed only once complete, so an interrupted download is not
+            // mistaken for a cached one on the next run.
+            if fs::rename(&partial, &target).is_ok() {
+                eprintln!("  Cached {filename}");
+            }
+        }
+        _ => {
+            let _ = fs::remove_file(&partial);
+            eprintln!("  Could not cache {filename}; makepkg will download it");
+        }
+    }
+}
+
 fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
     check_prerequisites(&opts)?;
     let timeout = Duration::from_secs(opts.timeout);
@@ -334,7 +426,14 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
     // Boot ISO
     eprintln!("[2/4] Booting ISO VM on port {}", opts.iso_port);
     let iso = qemu::find_latest_iso();
-    let mut vm = QemuVm::boot_iso(&opts.disk, &opts.vars, &iso, opts.iso_port);
+    let cache = prepare_cache(&opts)?;
+    let mut vm = QemuVm::boot_iso(
+        &opts.disk,
+        &opts.vars,
+        &iso,
+        opts.iso_port,
+        cache.as_deref(),
+    );
     if !vm.wait_for_ssh(timeout) {
         return Err(format!("ISO VM not SSH-accessible within {timeout:?}"));
     }
@@ -346,8 +445,23 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
     vm.ssh_run("chmod +x /root/archinstall-zfs-rs")
         .map_err(|e| format!("chmod failed: {e}"))?;
 
+    let installer_command = match &cache {
+        Some(_) => {
+            let tag = qemu::CACHE_MOUNT_TAG;
+            let dir = qemu::CACHE_GUEST_DIR;
+            eprintln!("  Reusing the host cache at {}", opts.cache_dir.display());
+            format!(
+                "mkdir -p {dir} && \
+                 mount -t 9p -o trans=virtio,version=9p2000.L {tag} {dir} && \
+                 mkdir -p {dir}/pkg {dir}/src && \
+                 ARCHINSTALL_ZFS_PKG_CACHE={dir}/pkg ARCHINSTALL_ZFS_SRCDEST={dir}/src \
+                 /root/archinstall-zfs-rs --config /root/config.json --silent"
+            )
+        }
+        None => "/root/archinstall-zfs-rs --config /root/config.json --silent".to_string(),
+    };
     let output = vm
-        .ssh_run("/root/archinstall-zfs-rs --config /root/config.json --silent")
+        .ssh_run(&installer_command)
         .map_err(|e| format!("installer failed to execute: {e}"))?;
 
     // Pull installer logs from VM before shutdown (regardless of success/failure)

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -4,6 +4,14 @@ use std::time::{Duration, Instant};
 
 const SSH_TIMEOUT_SECS: u64 = 10;
 
+/// 9p tag the host cache is shared under, and where the guest mounts it.
+///
+/// Under /run on purpose: the installer bind-mounts the medium's /run into the
+/// target, so a path there is reachable from inside the chroot where makepkg
+/// runs, without the share having to know anything about the target.
+pub const CACHE_MOUNT_TAG: &str = "archzfscache";
+pub const CACHE_GUEST_DIR: &str = "/run/archzfs-cache";
+
 pub struct QemuVm {
     pid: Option<u32>,
     port: u16,
@@ -11,8 +19,26 @@ pub struct QemuVm {
 }
 
 impl QemuVm {
-    pub fn boot_iso(disk: &Path, uefi_vars: &Path, iso: &Path, port: u16) -> Self {
+    /// Boot the installation medium, with `cache` shared into the guest when
+    /// one is given.
+    ///
+    /// The share carries the package cache and the pre-downloaded sources, so
+    /// a run reuses what earlier runs fetched instead of pulling a gigabyte of
+    /// packages again.
+    pub fn boot_iso(
+        disk: &Path,
+        uefi_vars: &Path,
+        iso: &Path,
+        port: u16,
+        cache: Option<&Path>,
+    ) -> Self {
         let ovmf = find_ovmf_code();
+        let share = cache.map(|path| {
+            format!(
+                "local,path={},mount_tag={CACHE_MOUNT_TAG},security_model=mapped-xattr",
+                path.display()
+            )
+        });
         let mut child = Command::new("qemu-system-x86_64")
             .args([
                 "-enable-kvm",
@@ -49,6 +75,10 @@ impl QemuVm {
                 "-device",
                 "virtio-blk-pci,drive=disk0,serial=archzfs-test-disk",
             ])
+            .args(match &share {
+                Some(spec) => vec!["-virtfs", spec.as_str()],
+                None => vec![],
+            })
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()


### PR DESCRIPTION
Every virtual-machine test run started from a fresh disk and therefore
downloaded the same gigabyte again — 196 packages plus the ZFSBootMenu tarball.
Six runs in an afternoon is close to seven gigabytes, and the tarball comes from
GitHub's archive service, which is the first thing to fail when GitHub is having
a bad day. This shares a cache from the host so a second run downloads nothing.

- Let the package cache be pointed outside the target with
  ARCHINSTALL_ZFS_PKG_CACHE, which also makes installing from a prepared cache
  possible outside the tests
- Give makepkg pre-downloaded sources through ARCHINSTALL_ZFS_SRCDEST, copied
  into the target rather than mounted through, since the target's /run is a
  plain bind of the medium's and a share mounted inside it is not carried across
- Share a host directory into the test guest over 9p and point both settings at
  it; --cache-dir moves it, --no-cache skips it
- Fetch the ZFSBootMenu tarball once on the host, reading its version from the
  AUR PKGBUILD so it does not go stale silently

Testing: three consecutive runs — cold cache downloaded 968 MB, the two after it
downloaded nothing and makepkg reported "Found zfsbootmenu-v3.1.0.tar.gz"
instead of downloading it. All three installations passed.
