### PR TITLE
CachyOS support

### DIFF
--- a/assets/history_event-zfs-list-cacher.sh
+++ b/assets/history_event-zfs-list-cacher.sh
@@ -12,20 +12,42 @@
 # Installed by the installer and marked immutable to avoid overwrites by zfs package updates.
 
 import os
+import re
 import sys
 import subprocess
 import fcntl
+import syslog
 import tempfile
 
-# Set to True to trace every history event to /tmp/zed_debug.log. Off by
-# default: this hook runs on every ZFS history event, so leaving it enabled
-# grows an unrotated file in /tmp for the life of the system.
+# Logging goes to syslog/journald under the identifier "zfs-list-cacher"
+# (read it with `journalctl -t zfs-list-cacher`). One summary line is emitted
+# per history event. Per-step tracing is enabled by ZED_LIST_CACHER_DEBUG=1 in
+# /etc/zfs/zed.d/zed.rc — zed does not export zed.rc to non-shell zedlets, so
+# it is parsed here — or by flipping DEBUG below.
 DEBUG = False
+ZED_RC = '/etc/zfs/zed.d/zed.rc'
+
+def debug_enabled():
+    if DEBUG or os.environ.get('ZED_LIST_CACHER_DEBUG') == '1':
+        return True
+    try:
+        with open(ZED_RC) as f:
+            for line in f:
+                if re.match(r'\s*ZED_LIST_CACHER_DEBUG\s*=\s*["\']?1["\']?\s*$', line):
+                    return True
+    except OSError:
+        pass
+    return False
+
+syslog.openlog('zfs-list-cacher', facility=syslog.LOG_DAEMON)
+_DEBUG = debug_enabled()
 
 def log(message):
-    if DEBUG:
-        with open('/tmp/zed_debug.log', 'a') as log:
-            log.write(f"{message}\n")
+    if _DEBUG:
+        syslog.syslog(syslog.LOG_DEBUG, message)
+
+def info(message):
+    syslog.syslog(syslog.LOG_INFO, message)
 
 def get_current_root():
     """Find the current root ZFS dataset using multiple methods"""
@@ -149,14 +171,17 @@ def filter_datasets(datasets, current_be, boot_envs):
     return filtered
 
 def write_cache(datasets, cache_file, pool):
-    """Replace the cache file atomically, and only if the content changed."""
+    """Replace the cache file atomically, and only if the content changed.
+
+    Returns True when the file was rewritten, False when it was already current.
+    """
     new_content = ''.join('\t'.join(dataset) + '\n' for dataset in datasets)
 
     try:
         with open(cache_file, 'r') as f:
             if f.read() == new_content:
                 log("Cache content unchanged, leaving file alone")
-                return
+                return False
     except FileNotFoundError:
         log("No existing cache file, creating new one")
     except OSError as exc:
@@ -177,6 +202,7 @@ def write_cache(datasets, cache_file, pool):
             os.fsync(f.fileno())
         os.chmod(tmp_file, 0o644)
         os.replace(tmp_file, cache_file)
+        return True
     except BaseException:
         # Never leave a partial cache behind for zfs-mount-generator to read.
         try:
@@ -186,7 +212,7 @@ def write_cache(datasets, cache_file, pool):
         raise
 
 def main():
-    log("\n=== New ZED cache update started ===")
+    log("=== New ZED cache update started ===")
 
     if os.environ.get('ZEVENT_SUBCLASS') != 'history_event':
         log("Not a history event, exiting")
@@ -200,7 +226,7 @@ def main():
 
     cache_file = f"/etc/zfs/zfs-list.cache/{pool}"
     if not os.access(cache_file, os.W_OK):
-        log("Cache file not writable, exiting")
+        info(f"pool={pool}: {cache_file} missing or not writable, cache not maintained")
         sys.exit(0)
 
     # Lock a dedicated file rather than the cache itself: the cache is now
@@ -213,7 +239,7 @@ def main():
 
         current_root = get_current_root()
         if not current_root:
-            log("Could not determine current root dataset, exiting")
+            info(f"pool={pool}: could not determine the current root dataset, cache left unchanged")
             sys.exit(0)
 
         current_be = current_root.rsplit('/', 1)[0]
@@ -221,20 +247,25 @@ def main():
 
         all_datasets = get_dataset_props(pool)
         if all_datasets is None:
-            log("Could not enumerate datasets, leaving cache unchanged")
+            info(f"pool={pool}: could not enumerate datasets, cache left unchanged")
             sys.exit(0)
         log(f"Found {len(all_datasets)} total datasets")
 
         boot_envs = find_boot_environments(pool)
         if boot_envs is None:
-            log("Could not identify boot environments, leaving cache unchanged")
+            info(f"pool={pool}: could not identify boot environments, cache left unchanged")
             sys.exit(0)
         log(f"Identified boot environments: {boot_envs}")
 
         filtered_datasets = filter_datasets(all_datasets, current_be, boot_envs)
         log(f"Writing {len(filtered_datasets)} datasets to cache")
+        for dataset in filtered_datasets:
+            log(f"  keep {dataset[0]} mountpoint={dataset[1]} canmount={dataset[2]}")
 
-        write_cache(filtered_datasets, cache_file, pool)
+        changed = write_cache(filtered_datasets, cache_file, pool)
+        info(f"pool={pool} be={current_be} boot_envs={len(boot_envs)} "
+             f"datasets={len(filtered_datasets)}/{len(all_datasets)} "
+             f"cache={'rewritten' if changed else 'unchanged'}")
 
     finally:
         fcntl.flock(lock_file, fcntl.LOCK_UN)

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -116,23 +116,53 @@ fn install_zbm_pacman_hook(target: &Path) -> Result<()> {
 /// Install zfsbootmenu from AUR and run generate-zbm to build the EFI bundle.
 /// This replaces the old pre-built download approach with a locally built ZBM
 /// that uses the same kernel and ZFS modules as the installed system.
-pub async fn install_and_generate_zbm(
+/// Build ZFSBootMenu from the AUR, for distributions that do not package it.
+async fn install_zbm_from_aur(
     runner: std::sync::Arc<dyn CommandRunner>,
     target: &Path,
-    init_system: InitSystem,
     cancel: &tokio_util::sync::CancellationToken,
     download_config: crate::system::async_download::DownloadConfig,
 ) -> Result<()> {
-    // 1. Install zfsbootmenu from AUR (async: AUR dependency resolution)
-    tracing::info!("installing zfsbootmenu from AUR");
     crate::installer::aur::install_aur_packages(
-        runner.clone(),
+        runner,
         target,
         &["zfsbootmenu"],
         cancel,
         download_config,
     )
-    .await?;
+    .await
+}
+
+pub async fn install_and_generate_zbm(
+    runner: std::sync::Arc<dyn CommandRunner>,
+    target: &Path,
+    distro: &'static crate::distro::Distribution,
+    init_system: InitSystem,
+    cancel: &tokio_util::sync::CancellationToken,
+    download_config: crate::system::async_download::DownloadConfig,
+) -> Result<()> {
+    // 1. Install ZFSBootMenu, from the distribution's repositories when it
+    //    has it and from the AUR when it does not. Asking the AUR for a
+    //    package the repositories already satisfy resolves to nothing to
+    //    build, and nothing gets installed at all.
+    if let Some(package) = distro.zfsbootmenu_package {
+        tracing::info!(package, "installing ZFSBootMenu from the distribution");
+        let target_owned = target.to_path_buf();
+        let cancel_owned = cancel.clone();
+        let config = download_config.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::system::alpm_pacman::install_into_target(
+                &target_owned,
+                &[package],
+                &cancel_owned,
+                config,
+            )
+        })
+        .await??;
+    } else {
+        tracing::info!("building ZFSBootMenu from the AUR");
+        install_zbm_from_aur(runner.clone(), target, cancel, download_config.clone()).await?;
+    }
     if cancel.is_cancelled() {
         color_eyre::eyre::bail!("installation cancelled");
     }

--- a/core/src/config/edit.rs
+++ b/core/src/config/edit.rs
@@ -64,6 +64,7 @@ macro_rules! settings {
 settings! {
     /// A setting picked from a list of alternatives.
     ChoiceSetting {
+        Distribution => "distribution",
         InstallationMode => "installation_mode",
         Compression => "compression",
         Encryption => "encryption",
@@ -119,6 +120,8 @@ settings! {
     /// what lets both dispatch on a value the compiler checks instead of on a
     /// string literal repeated in two crates.
     EditorSetting {
+        // Also a choice: the row opens a list, and confirming one applies it.
+        Distribution => "distribution",
         Kernel => "kernel",
         Profile => "profile",
         OptionalPackages => "optional_packages",
@@ -153,6 +156,19 @@ pub fn apply_toggle(config: &mut GlobalConfig, setting: ToggleSetting) {
 /// nothing.
 pub fn apply_choice(config: &mut GlobalConfig, setting: ChoiceSetting, index: usize) {
     match setting {
+        ChoiceSetting::Distribution => {
+            let Some(distro) = crate::distro::ALL.get(index) else {
+                return;
+            };
+            if config.distribution != distro.name {
+                // Kernels belong to the distribution that ships them: an Arch
+                // name does not exist in CachyOS's repositories, and the other
+                // way round. Clearing them falls back to the new
+                // distribution's own default.
+                config.kernels = None;
+            }
+            config.distribution = distro.name.to_string();
+        }
         ChoiceSetting::InstallationMode => {
             let Some(mode) = InstallationMode::from_index(index) else {
                 return;
@@ -309,6 +325,46 @@ mod tests {
             DeviceSetting::parse,
         );
         check(TextSetting::ALL, TextSetting::as_str, TextSetting::parse);
+    }
+
+    #[test]
+    fn changing_distribution_drops_a_kernel_that_does_not_exist_in_it() {
+        let mut c = cfg();
+        c.kernels = Some(vec!["linux-lts".to_string()]);
+
+        let cachyos = crate::distro::ALL
+            .iter()
+            .position(|d| d.name == "cachyos")
+            .expect("cachyos is registered");
+        apply_choice(&mut c, ChoiceSetting::Distribution, cachyos);
+
+        assert_eq!(c.distribution, "cachyos");
+        assert!(
+            c.kernels.is_none(),
+            "an Arch kernel cannot be installed here"
+        );
+        assert_eq!(
+            c.primary_kernel(),
+            "linux-cachyos",
+            "the new distribution's own default takes over"
+        );
+    }
+
+    #[test]
+    fn reselecting_the_same_distribution_keeps_the_kernel() {
+        let mut c = cfg();
+        c.kernels = Some(vec!["linux-zen".to_string()]);
+        let arch = crate::distro::ALL
+            .iter()
+            .position(|d| d.name == "arch")
+            .expect("arch is registered");
+
+        apply_choice(&mut c, ChoiceSetting::Distribution, arch);
+
+        assert_eq!(
+            c.kernels.as_deref(),
+            Some(["linux-zen".to_string()].as_slice())
+        );
     }
 
     #[test]

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -147,6 +147,11 @@ impl std::fmt::Display for SwapMode {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GlobalConfig {
+    /// Which distribution to install, by registry name. Decides the base
+    /// packages, the repositories added for ZFS and the kernels on offer.
+    #[serde(default = "default_distribution")]
+    pub distribution: String,
+
     // Flow control
     pub installation_mode: Option<InstallationMode>,
     #[serde(default, alias = "disk_by_id")]
@@ -321,6 +326,10 @@ impl std::fmt::Display for AudioServer {
     }
 }
 
+fn default_distribution() -> String {
+    crate::distro::default().name.to_string()
+}
+
 fn default_dataset_prefix() -> String {
     "arch0".to_string()
 }
@@ -348,6 +357,7 @@ fn default_parallel_downloads() -> u32 {
 impl Default for GlobalConfig {
     fn default() -> Self {
         Self {
+            distribution: default_distribution(),
             installation_mode: None,
             disk: None,
             efi_partition: None,
@@ -389,6 +399,22 @@ impl Default for GlobalConfig {
 }
 
 impl GlobalConfig {
+    /// The distribution this configuration installs.
+    ///
+    /// An unknown name falls back to the default rather than failing: the
+    /// registry can lose an entry between versions, and refusing to start
+    /// over a name is worse than installing what the rest of the
+    /// configuration describes. Validation reports the name separately.
+    pub fn distribution(&self) -> &'static crate::distro::Distribution {
+        crate::distro::get(&self.distribution).unwrap_or_else(|| {
+            tracing::warn!(
+                name = self.distribution,
+                "unknown distribution; installing the default"
+            );
+            crate::distro::default()
+        })
+    }
+
     pub fn encryption_enabled(&self) -> bool {
         self.zfs_encryption_mode != ZfsEncryptionMode::None
     }

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -432,15 +432,28 @@ impl GlobalConfig {
     pub fn effective_kernels(&self) -> Vec<&str> {
         match &self.kernels {
             Some(k) if !k.is_empty() => k.iter().map(|s| s.as_str()).collect(),
-            _ => vec!["linux-lts"],
+            _ => vec![self.default_kernel()],
         }
     }
 
     pub fn primary_kernel(&self) -> &str {
         match &self.kernels {
             Some(k) if !k.is_empty() => k[0].as_str(),
-            _ => "linux-lts",
+            _ => self.default_kernel(),
         }
+    }
+
+    /// The kernel installed when the configuration names none.
+    ///
+    /// The distribution's first, because a kernel from another one does not
+    /// exist in its repositories — an Arch name would leave a CachyOS
+    /// installation with nothing to boot.
+    fn default_kernel(&self) -> &'static str {
+        self.distribution()
+            .kernels
+            .first()
+            .map(|kernel| kernel.name)
+            .unwrap_or("linux-lts")
     }
 }
 

--- a/core/src/config/validation.rs
+++ b/core/src/config/validation.rs
@@ -109,7 +109,11 @@ impl fmt::Display for ValidationError {
                  leading/trailing hyphen"
             ),
             Self::UnknownKernel(name) => {
-                let known: Vec<&str> = crate::kernel::AVAILABLE_KERNELS
+                // Listed for the default distribution: the message is built
+                // without one to hand, and every distribution's kernels are
+                // its own.
+                let known: Vec<&str> = crate::distro::default()
+                    .kernels
                     .iter()
                     .map(|k| k.name)
                     .collect();
@@ -194,7 +198,7 @@ impl GlobalConfig {
         }
 
         for kernel in self.kernels.iter().flatten() {
-            if crate::kernel::get_kernel_info(kernel).is_none() {
+            if crate::kernel::get_kernel_info(self.distribution(), kernel).is_none() {
                 errors.push(ValidationError::UnknownKernel(kernel.clone()));
             }
         }

--- a/core/src/distro.rs
+++ b/core/src/distro.rs
@@ -82,15 +82,23 @@ pub struct Distribution {
     /// Repositories to add, in the order they should appear. Order matters:
     /// pacman prefers the first repository that offers a package.
     pub repositories: RepositorySelection,
-    /// Value for pacman's `Architecture`, when the distribution needs one
-    /// other than the default. CachyOS serves packages built for a newer
-    /// instruction set, which pacman only accepts as `auto`.
-    pub architecture: Option<&'static str>,
+    /// Whether this distribution serves packages built for instruction sets
+    /// newer than the base architecture.
+    ///
+    /// pacman installs those only when told which architectures to accept.
+    /// CachyOS's own tooling writes `Architecture = auto` and relies on a
+    /// patched pacman to expand it; stock pacman expands `auto` to the output
+    /// of `uname -m` and rejects everything else, so the accepted
+    /// architectures are listed out instead.
+    pub optimised_builds: bool,
     /// The keyring `pacman-key --populate` is given.
     pub keyring: &'static str,
     /// The kernels this distribution offers, and where each one's ZFS module
     /// comes from.
     pub kernels: &'static [KernelInfo],
+    /// The package providing ZFSBootMenu, when the distribution has one.
+    /// `None` means building it from the AUR, which is what Arch needs.
+    pub zfsbootmenu_package: Option<&'static str>,
 }
 
 /// Where the ZFS module packages for Arch kernels come from.
@@ -150,12 +158,28 @@ pub const ARCH: Distribution = Distribution {
         "sof-firmware",
     ],
     repositories: RepositorySelection::Fixed(&[ARCHZFS]),
-    architecture: None,
+    optimised_builds: false,
     keyring: "archlinux",
     kernels: ARCH_KERNELS,
+    zfsbootmenu_package: None,
 };
 
 impl Distribution {
+    /// The architectures pacman should accept on this machine, when that
+    /// needs saying at all.
+    pub fn architectures(&self, isa: IsaLevel) -> Option<&'static str> {
+        if !self.optimised_builds {
+            return None;
+        }
+        match isa {
+            // Zen 4 packages are built as x86-64-v4, so both baselines answer
+            // with the same list.
+            IsaLevel::V4 | IsaLevel::Znver4 => Some("x86_64 x86_64_v3 x86_64_v4"),
+            IsaLevel::V3 => Some("x86_64 x86_64_v3"),
+            IsaLevel::Baseline => None,
+        }
+    }
+
     /// The repositories to add on a machine with this instruction set.
     ///
     /// Empty when the distribution has nothing to offer this processor:
@@ -174,22 +198,43 @@ impl Distribution {
     }
 }
 
-/// CachyOS serves its packages from its own mirror, addressed by repository
-/// name. Their mirrorlist package names the same mirrors and is installed as
-/// part of the system, but a `Include` of it cannot be used while installing:
-/// the file does not exist until the package is, and pacman refuses a
-/// configuration that includes a file it cannot read.
-const CACHYOS_SERVER: &str = "https://mirror.cachyos.org/repo/x86_64/$repo";
+/// Where CachyOS serves each build of its package set.
+///
+/// The directory is the instruction set the packages were built for, and it is
+/// not the repository's own name: the Zen 4 repositories live under the
+/// x86-64-v4 directory, and a path built from the repository name instead
+/// answers with the mirror's welcome page rather than a database — which
+/// pacman then reports as a corrupt signature.
+///
+/// Their mirrorlist writes these as `$arch_v3` and `$arch_v4`, variables only
+/// their patched pacman understands, so the paths are written out here.
+const CACHYOS_BASELINE_SERVERS: &[&str] = &[
+    "https://cdn77.cachyos.org/repo/x86_64/$repo",
+    "https://mirror.cachyos.org/repo/x86_64/$repo",
+];
+const CACHYOS_V3_SERVERS: &[&str] = &[
+    "https://cdn77.cachyos.org/repo/x86_64_v3/$repo",
+    "https://mirror.cachyos.org/repo/x86_64_v3/$repo",
+];
+const CACHYOS_V4_SERVERS: &[&str] = &[
+    "https://cdn77.cachyos.org/repo/x86_64_v4/$repo",
+    "https://mirror.cachyos.org/repo/x86_64_v4/$repo",
+];
 
-/// Their packages are signed with one key, which is trusted before the
-/// repositories are used — the same order their own installer script follows.
+/// Their packages are signed with one key, trusted before the repositories are
+/// used — the same order their own installer script follows.
 const CACHYOS_KEY: &str = "F3B607488DB35A47";
 
-/// One of CachyOS's repositories. They all share a server and a key.
-const fn cachyos_repo(name: &'static str) -> Repository {
+/// One of CachyOS's repositories. They share a key and differ in where they
+/// are served from.
+const fn cachyos_repo(name: &'static str, servers: &'static [&'static str]) -> Repository {
     Repository {
         name,
-        servers: &[CACHYOS_SERVER],
+        servers,
+        // Their mirrorlist cannot be included while installing: the file
+        // arrives with a package, and pacman refuses a configuration that
+        // includes a file it cannot read. The installed system gets those
+        // packages and can use them afterwards.
         mirrorlist: None,
         key_ids: &[CACHYOS_KEY],
         signatures: Signatures::Required,
@@ -197,24 +242,26 @@ const fn cachyos_repo(name: &'static str) -> Repository {
 }
 
 const CACHYOS_V3: &[Repository] = &[
-    cachyos_repo("cachyos-v3"),
-    cachyos_repo("cachyos-core-v3"),
-    cachyos_repo("cachyos-extra-v3"),
-    cachyos_repo("cachyos"),
+    cachyos_repo("cachyos-v3", CACHYOS_V3_SERVERS),
+    cachyos_repo("cachyos-core-v3", CACHYOS_V3_SERVERS),
+    cachyos_repo("cachyos-extra-v3", CACHYOS_V3_SERVERS),
+    cachyos_repo("cachyos", CACHYOS_BASELINE_SERVERS),
 ];
 
 const CACHYOS_V4: &[Repository] = &[
-    cachyos_repo("cachyos-v4"),
-    cachyos_repo("cachyos-core-v4"),
-    cachyos_repo("cachyos-extra-v4"),
-    cachyos_repo("cachyos"),
+    cachyos_repo("cachyos-v4", CACHYOS_V4_SERVERS),
+    cachyos_repo("cachyos-core-v4", CACHYOS_V4_SERVERS),
+    cachyos_repo("cachyos-extra-v4", CACHYOS_V4_SERVERS),
+    cachyos_repo("cachyos", CACHYOS_BASELINE_SERVERS),
 ];
 
+/// Zen 4 packages are served from the x86-64-v4 directory, not one named
+/// after the repository.
 const CACHYOS_ZNVER4: &[Repository] = &[
-    cachyos_repo("cachyos-znver4"),
-    cachyos_repo("cachyos-core-znver4"),
-    cachyos_repo("cachyos-extra-znver4"),
-    cachyos_repo("cachyos"),
+    cachyos_repo("cachyos-znver4", CACHYOS_V4_SERVERS),
+    cachyos_repo("cachyos-core-znver4", CACHYOS_V4_SERVERS),
+    cachyos_repo("cachyos-extra-znver4", CACHYOS_V4_SERVERS),
+    cachyos_repo("cachyos", CACHYOS_BASELINE_SERVERS),
 ];
 
 /// CachyOS builds a ZFS module for each of its kernels, version-locked to it.
@@ -270,9 +317,11 @@ pub const CACHYOS: Distribution = Distribution {
         v4: CACHYOS_V4,
         znver4: CACHYOS_ZNVER4,
     },
-    architecture: Some("auto"),
+    optimised_builds: true,
     keyring: "archlinux",
     kernels: CACHYOS_KERNELS,
+    // Theirs is packaged, so there is nothing to build.
+    zfsbootmenu_package: Some("zfsbootmenu"),
 };
 
 /// Every distribution the installer knows.
@@ -333,6 +382,55 @@ mod tests {
         // A processor below the baseline gets nothing, as with their own
         // tooling; add_repositories turns that into a refusal.
         assert!(CACHYOS.repositories(IsaLevel::Baseline).is_empty());
+    }
+
+    /// The directory a repository is served from is the instruction set, not
+    /// the repository name — getting this wrong answers with the mirror's
+    /// welcome page, which pacman reports as a corrupt database signature.
+    #[test]
+    fn repositories_are_served_from_the_directory_for_their_build() {
+        let dir_of = |repos: &'static [Repository], name: &str| {
+            repos
+                .iter()
+                .find(|r| r.name == name)
+                .and_then(|r| r.servers.first().copied())
+                .unwrap_or_default()
+        };
+
+        assert!(dir_of(CACHYOS_V3, "cachyos-v3").contains("/x86_64_v3/"));
+        assert!(dir_of(CACHYOS_V4, "cachyos-v4").contains("/x86_64_v4/"));
+        assert!(
+            dir_of(CACHYOS_ZNVER4, "cachyos-znver4").contains("/x86_64_v4/"),
+            "Zen 4 is served from the v4 directory"
+        );
+        // The unoptimised repository sits in the plain directory in every set.
+        for set in [CACHYOS_V3, CACHYOS_V4, CACHYOS_ZNVER4] {
+            assert!(dir_of(set, "cachyos").contains("/x86_64/"));
+        }
+    }
+
+    #[test]
+    fn accepted_architectures_match_what_the_packages_are_built_as() {
+        // Their packages carry x86_64_v3 and x86_64_v4; Zen 4 builds are
+        // stamped x86_64_v4 like the rest of that baseline.
+        assert_eq!(
+            CACHYOS.architectures(IsaLevel::V3),
+            Some("x86_64 x86_64_v3")
+        );
+        assert_eq!(
+            CACHYOS.architectures(IsaLevel::V4),
+            Some("x86_64 x86_64_v3 x86_64_v4")
+        );
+        assert_eq!(
+            CACHYOS.architectures(IsaLevel::Znver4),
+            CACHYOS.architectures(IsaLevel::V4)
+        );
+        assert_eq!(CACHYOS.architectures(IsaLevel::Baseline), None);
+
+        // A distribution without optimised builds says nothing about it.
+        for isa in [IsaLevel::V3, IsaLevel::V4, IsaLevel::Znver4] {
+            assert_eq!(ARCH.architectures(isa), None);
+        }
     }
 
     #[test]

--- a/core/src/distro.rs
+++ b/core/src/distro.rs
@@ -1,0 +1,165 @@
+//! What differs between the distributions this installer can install.
+//!
+//! Everything here used to be constants scattered through the installer: the
+//! repository to add for ZFS, the keys to trust for it, the argument to
+//! `pacman-key --populate`, the packages a base system starts from. Each was
+//! written for Arch, which was fine while Arch was the only answer.
+//!
+//! A distribution is data, so a second one is an entry rather than a branch.
+
+/// How much pacman verifies of what a repository serves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Signatures {
+    /// Packages and database are taken on trust.
+    Never,
+    /// Verified when a signature is present, accepted when it is not.
+    Optional,
+    /// Every package must carry a valid signature.
+    Required,
+}
+
+/// A repository added to pacman.conf beyond what the medium already carries.
+#[derive(Debug, Clone, Copy)]
+pub struct Repository {
+    pub name: &'static str,
+    /// Servers written into the repository's block. Empty when `mirrorlist`
+    /// supplies them instead.
+    pub servers: &'static [&'static str],
+    /// A mirrorlist to `Include`, for distributions that ship one as a
+    /// package. Its packages must be installed before the repository is
+    /// usable, which is what `bootstrap_packages` is for.
+    pub mirrorlist: Option<&'static str>,
+    /// Keys received and locally signed before the repository is used.
+    pub key_ids: &'static [&'static str],
+    pub signatures: Signatures,
+}
+
+impl Repository {
+    /// The block this repository contributes to pacman.conf.
+    pub fn pacman_conf_block(&self) -> String {
+        let mut block = format!("\n[{}]\n", self.name);
+        match self.signatures {
+            Signatures::Never => block.push_str("SigLevel = Never\n"),
+            Signatures::Optional => block.push_str("SigLevel = Optional TrustAll\n"),
+            Signatures::Required => block.push_str("SigLevel = Required DatabaseOptional\n"),
+        }
+        if let Some(mirrorlist) = self.mirrorlist {
+            block.push_str(&format!("Include = {mirrorlist}\n"));
+        }
+        for server in self.servers {
+            block.push_str(&format!("Server = {server}\n"));
+        }
+        block
+    }
+}
+
+/// A distribution the installer can install.
+#[derive(Debug, Clone, Copy)]
+pub struct Distribution {
+    /// Identifier used in configuration files.
+    pub name: &'static str,
+    pub display_name: &'static str,
+    /// What a base installation starts from, before kernels, initramfs and
+    /// microcode are added.
+    pub base_packages: &'static [&'static str],
+    /// Repositories to add, in the order they should appear. Order matters:
+    /// pacman prefers the first repository that offers a package.
+    pub repositories: &'static [Repository],
+    /// The keyring `pacman-key --populate` is given.
+    pub keyring: &'static str,
+}
+
+/// Where the ZFS module packages for Arch kernels come from.
+///
+/// KNOWN GAP: `Signatures::Never`. The archzfs experimental channel's signing
+/// is not reliable enough to gate installations on, so its packages are
+/// installed on the strength of the sync database's checksums alone, and the
+/// keys below go unused. Revisit together with the `.sig` fetch in
+/// `system::async_download` — the two have to change as one.
+const ARCHZFS: Repository = Repository {
+    name: "archzfs",
+    servers: &["https://github.com/archzfs/archzfs/releases/download/experimental"],
+    mirrorlist: None,
+    key_ids: &[
+        "3A9917BF0DED5C13F69AC68FABEC0A1208037BE9",
+        "DDF7DB817396A49B2A2723F7403BD972F75D9D76",
+    ],
+    signatures: Signatures::Never,
+};
+
+pub const ARCH: Distribution = Distribution {
+    name: "arch",
+    display_name: "Arch Linux",
+    base_packages: &[
+        "base",
+        "base-devel",
+        "linux-firmware",
+        "linux-firmware-marvell",
+        "sof-firmware",
+    ],
+    repositories: &[ARCHZFS],
+    keyring: "archlinux",
+};
+
+/// Every distribution the installer knows.
+pub const ALL: &[Distribution] = &[ARCH];
+
+/// Look a distribution up by the name a configuration file uses.
+pub fn get(name: &str) -> Option<&'static Distribution> {
+    ALL.iter().find(|distro| distro.name == name)
+}
+
+/// The distribution assumed when a configuration does not name one.
+pub fn default() -> &'static Distribution {
+    &ALL[0]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distributions_are_found_by_name() {
+        assert_eq!(get("arch").map(|d| d.display_name), Some("Arch Linux"));
+        assert!(get("plan9").is_none());
+        assert_eq!(default().name, "arch");
+    }
+
+    #[test]
+    fn names_are_unique() {
+        for (index, distro) in ALL.iter().enumerate() {
+            assert!(
+                !ALL[..index].iter().any(|other| other.name == distro.name),
+                "{} appears twice",
+                distro.name
+            );
+        }
+    }
+
+    #[test]
+    fn a_repository_with_servers_writes_them_out() {
+        let block = ARCHZFS.pacman_conf_block();
+
+        assert!(block.starts_with("\n[archzfs]\n"), "got: {block}");
+        assert!(block.contains("SigLevel = Never\n"));
+        assert!(block.contains("Server = https://github.com/archzfs/"));
+        assert!(!block.contains("Include ="), "no mirrorlist for this one");
+    }
+
+    #[test]
+    fn a_repository_with_a_mirrorlist_includes_it() {
+        let repo = Repository {
+            name: "cachyos",
+            servers: &[],
+            mirrorlist: Some("/etc/pacman.d/cachyos-mirrorlist"),
+            key_ids: &[],
+            signatures: Signatures::Required,
+        };
+
+        let block = repo.pacman_conf_block();
+
+        assert!(block.contains("Include = /etc/pacman.d/cachyos-mirrorlist\n"));
+        assert!(block.contains("SigLevel = Required DatabaseOptional\n"));
+        assert!(!block.contains("Server ="));
+    }
+}

--- a/core/src/distro.rs
+++ b/core/src/distro.rs
@@ -7,6 +7,8 @@
 //!
 //! A distribution is data, so a second one is an entry rather than a branch.
 
+use crate::kernel::KernelInfo;
+
 /// How much pacman verifies of what a repository serves.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Signatures {
@@ -67,6 +69,9 @@ pub struct Distribution {
     pub repositories: &'static [Repository],
     /// The keyring `pacman-key --populate` is given.
     pub keyring: &'static str,
+    /// The kernels this distribution offers, and where each one's ZFS module
+    /// comes from.
+    pub kernels: &'static [KernelInfo],
 }
 
 /// Where the ZFS module packages for Arch kernels come from.
@@ -87,6 +92,34 @@ const ARCHZFS: Repository = Repository {
     signatures: Signatures::Never,
 };
 
+/// Arch's own kernels, each with the archzfs module built for it.
+const ARCH_KERNELS: &[KernelInfo] = &[
+    KernelInfo {
+        name: "linux-lts",
+        display_name: "Linux LTS",
+        precompiled_package: Some("zfs-linux-lts"),
+        headers_package: "linux-lts-headers",
+    },
+    KernelInfo {
+        name: "linux",
+        display_name: "Linux",
+        precompiled_package: Some("zfs-linux"),
+        headers_package: "linux-headers",
+    },
+    KernelInfo {
+        name: "linux-zen",
+        display_name: "Linux Zen",
+        precompiled_package: Some("zfs-linux-zen"),
+        headers_package: "linux-zen-headers",
+    },
+    KernelInfo {
+        name: "linux-hardened",
+        display_name: "Linux Hardened",
+        precompiled_package: Some("zfs-linux-hardened"),
+        headers_package: "linux-hardened-headers",
+    },
+];
+
 pub const ARCH: Distribution = Distribution {
     name: "arch",
     display_name: "Arch Linux",
@@ -99,6 +132,7 @@ pub const ARCH: Distribution = Distribution {
     ],
     repositories: &[ARCHZFS],
     keyring: "archlinux",
+    kernels: ARCH_KERNELS,
 };
 
 /// Every distribution the installer knows.

--- a/core/src/distro.rs
+++ b/core/src/distro.rs
@@ -8,6 +8,7 @@
 //! A distribution is data, so a second one is an entry rather than a branch.
 
 use crate::kernel::KernelInfo;
+use crate::system::sysinfo::IsaLevel;
 
 /// How much pacman verifies of what a repository serves.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,6 +56,20 @@ impl Repository {
     }
 }
 
+/// Which repositories a distribution wants added.
+#[derive(Debug, Clone, Copy)]
+pub enum RepositorySelection {
+    /// The same everywhere.
+    Fixed(&'static [Repository]),
+    /// Chosen by what the processor supports, because the distribution serves
+    /// a different build of the same packages for each baseline.
+    ByIsaLevel {
+        v3: &'static [Repository],
+        v4: &'static [Repository],
+        znver4: &'static [Repository],
+    },
+}
+
 /// A distribution the installer can install.
 #[derive(Debug, Clone, Copy)]
 pub struct Distribution {
@@ -66,7 +81,11 @@ pub struct Distribution {
     pub base_packages: &'static [&'static str],
     /// Repositories to add, in the order they should appear. Order matters:
     /// pacman prefers the first repository that offers a package.
-    pub repositories: &'static [Repository],
+    pub repositories: RepositorySelection,
+    /// Value for pacman's `Architecture`, when the distribution needs one
+    /// other than the default. CachyOS serves packages built for a newer
+    /// instruction set, which pacman only accepts as `auto`.
+    pub architecture: Option<&'static str>,
     /// The keyring `pacman-key --populate` is given.
     pub keyring: &'static str,
     /// The kernels this distribution offers, and where each one's ZFS module
@@ -130,13 +149,134 @@ pub const ARCH: Distribution = Distribution {
         "linux-firmware-marvell",
         "sof-firmware",
     ],
-    repositories: &[ARCHZFS],
+    repositories: RepositorySelection::Fixed(&[ARCHZFS]),
+    architecture: None,
     keyring: "archlinux",
     kernels: ARCH_KERNELS,
 };
 
+impl Distribution {
+    /// The repositories to add on a machine with this instruction set.
+    ///
+    /// Empty when the distribution has nothing to offer this processor:
+    /// CachyOS's repositories start at x86-64-v3, and on anything older its
+    /// own tooling adds none either.
+    pub fn repositories(&self, isa: IsaLevel) -> &'static [Repository] {
+        match self.repositories {
+            RepositorySelection::Fixed(repos) => repos,
+            RepositorySelection::ByIsaLevel { v3, v4, znver4 } => match isa {
+                IsaLevel::Znver4 => znver4,
+                IsaLevel::V4 => v4,
+                IsaLevel::V3 => v3,
+                IsaLevel::Baseline => &[],
+            },
+        }
+    }
+}
+
+/// CachyOS serves its packages from its own mirror, addressed by repository
+/// name. Their mirrorlist package names the same mirrors and is installed as
+/// part of the system, but a `Include` of it cannot be used while installing:
+/// the file does not exist until the package is, and pacman refuses a
+/// configuration that includes a file it cannot read.
+const CACHYOS_SERVER: &str = "https://mirror.cachyos.org/repo/x86_64/$repo";
+
+/// Their packages are signed with one key, which is trusted before the
+/// repositories are used — the same order their own installer script follows.
+const CACHYOS_KEY: &str = "F3B607488DB35A47";
+
+/// One of CachyOS's repositories. They all share a server and a key.
+const fn cachyos_repo(name: &'static str) -> Repository {
+    Repository {
+        name,
+        servers: &[CACHYOS_SERVER],
+        mirrorlist: None,
+        key_ids: &[CACHYOS_KEY],
+        signatures: Signatures::Required,
+    }
+}
+
+const CACHYOS_V3: &[Repository] = &[
+    cachyos_repo("cachyos-v3"),
+    cachyos_repo("cachyos-core-v3"),
+    cachyos_repo("cachyos-extra-v3"),
+    cachyos_repo("cachyos"),
+];
+
+const CACHYOS_V4: &[Repository] = &[
+    cachyos_repo("cachyos-v4"),
+    cachyos_repo("cachyos-core-v4"),
+    cachyos_repo("cachyos-extra-v4"),
+    cachyos_repo("cachyos"),
+];
+
+const CACHYOS_ZNVER4: &[Repository] = &[
+    cachyos_repo("cachyos-znver4"),
+    cachyos_repo("cachyos-core-znver4"),
+    cachyos_repo("cachyos-extra-znver4"),
+    cachyos_repo("cachyos"),
+];
+
+/// CachyOS builds a ZFS module for each of its kernels, version-locked to it.
+/// The kernel itself cannot carry ZFS — the CDDL and the GPL do not permit
+/// distributing that — so this is the same shape as archzfs, under their
+/// names.
+const CACHYOS_KERNELS: &[KernelInfo] = &[
+    KernelInfo {
+        name: "linux-cachyos",
+        display_name: "CachyOS (BORE + sched-ext)",
+        precompiled_package: Some("linux-cachyos-zfs"),
+        headers_package: "linux-cachyos-headers",
+    },
+    KernelInfo {
+        name: "linux-cachyos-lts",
+        display_name: "CachyOS LTS",
+        precompiled_package: Some("linux-cachyos-lts-zfs"),
+        headers_package: "linux-cachyos-lts-headers",
+    },
+    KernelInfo {
+        name: "linux-cachyos-bore",
+        display_name: "CachyOS BORE",
+        precompiled_package: Some("linux-cachyos-bore-zfs"),
+        headers_package: "linux-cachyos-bore-headers",
+    },
+    KernelInfo {
+        name: "linux-cachyos-deckify",
+        display_name: "CachyOS Deckify",
+        precompiled_package: Some("linux-cachyos-deckify-zfs"),
+        headers_package: "linux-cachyos-deckify-headers",
+    },
+];
+
+pub const CACHYOS: Distribution = Distribution {
+    name: "cachyos",
+    display_name: "CachyOS",
+    base_packages: &[
+        "base",
+        "base-devel",
+        "linux-firmware",
+        "linux-firmware-marvell",
+        "sof-firmware",
+        // Their keyring and mirrorlists belong on the installed system, which
+        // is what lets it reach their repositories on its own afterwards.
+        "cachyos-keyring",
+        "cachyos-mirrorlist",
+        "cachyos-v3-mirrorlist",
+        "cachyos-v4-mirrorlist",
+        "cachyos-settings",
+    ],
+    repositories: RepositorySelection::ByIsaLevel {
+        v3: CACHYOS_V3,
+        v4: CACHYOS_V4,
+        znver4: CACHYOS_ZNVER4,
+    },
+    architecture: Some("auto"),
+    keyring: "archlinux",
+    kernels: CACHYOS_KERNELS,
+};
+
 /// Every distribution the installer knows.
-pub const ALL: &[Distribution] = &[ARCH];
+pub const ALL: &[Distribution] = &[ARCH, CACHYOS];
 
 /// Look a distribution up by the name a configuration file uses.
 pub fn get(name: &str) -> Option<&'static Distribution> {
@@ -167,6 +307,58 @@ mod tests {
                 "{} appears twice",
                 distro.name
             );
+        }
+    }
+
+    #[test]
+    fn cachyos_serves_a_different_build_per_processor() {
+        let v3 = CACHYOS.repositories(IsaLevel::V3);
+        let v4 = CACHYOS.repositories(IsaLevel::V4);
+        let zen = CACHYOS.repositories(IsaLevel::Znver4);
+
+        assert!(v3.iter().any(|r| r.name == "cachyos-v3"));
+        assert!(v4.iter().any(|r| r.name == "cachyos-v4"));
+        assert!(zen.iter().any(|r| r.name == "cachyos-znver4"));
+
+        // The unoptimised repository is in every set: it carries what is not
+        // rebuilt per baseline.
+        for set in [v3, v4, zen] {
+            assert!(
+                set.iter().any(|r| r.name == "cachyos"),
+                "plain repo missing"
+            );
+            assert_eq!(set.len(), 4);
+        }
+
+        // A processor below the baseline gets nothing, as with their own
+        // tooling; add_repositories turns that into a refusal.
+        assert!(CACHYOS.repositories(IsaLevel::Baseline).is_empty());
+    }
+
+    #[test]
+    fn a_fixed_selection_ignores_the_processor() {
+        for isa in [
+            IsaLevel::Baseline,
+            IsaLevel::V3,
+            IsaLevel::V4,
+            IsaLevel::Znver4,
+        ] {
+            assert_eq!(ARCH.repositories(isa).len(), 1);
+        }
+    }
+
+    #[test]
+    fn every_cachyos_kernel_has_its_own_zfs_module() {
+        for kernel in CACHYOS.kernels {
+            let module = kernel
+                .precompiled_package
+                .expect("CachyOS builds a module for each of its kernels");
+            assert_eq!(
+                module,
+                format!("{}-zfs", kernel.name),
+                "the module is named after the kernel it is built for"
+            );
+            assert_eq!(kernel.headers_package, format!("{}-headers", kernel.name));
         }
     }
 

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -332,6 +332,7 @@ async fn install(
     crate::bootmenu::install_and_generate_zbm(
         runner.clone(),
         &mountpoint,
+        config.distribution(),
         config.init_system,
         &cancel,
         download_config,

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -213,8 +213,12 @@ async fn install(
     }
     tracing::info!("UEFI boot detected");
 
-    for warning in
-        crate::kernel::scanner::validate_kernel_zfs_plan(&kernel, config.zfs_module_mode).await
+    for warning in crate::kernel::scanner::validate_kernel_zfs_plan(
+        config.distribution(),
+        &kernel,
+        config.zfs_module_mode,
+    )
+    .await
     {
         tracing::warn!("kernel compatibility: {warning}");
     }

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -226,10 +226,18 @@ async fn install(
         let runner = runner.clone();
         let kernel = kernel.clone();
         let zfs_mode = config.zfs_module_mode;
+        let distro = config.distribution();
         let cancel = cancel.clone();
         let download_config = download_config.clone();
         tokio::task::spawn_blocking(move || {
-            crate::zfs_setup::initialize_zfs(&*runner, &kernel, zfs_mode, &cancel, download_config)
+            crate::zfs_setup::initialize_zfs(
+                &*runner,
+                distro,
+                &kernel,
+                zfs_mode,
+                &cancel,
+                download_config,
+            )
         })
         .await??;
     }

--- a/core/src/installer/base.rs
+++ b/core/src/installer/base.rs
@@ -21,13 +21,7 @@ pub fn install_base(
         std::sync::Arc<tokio::sync::watch::Sender<crate::system::async_download::DownloadProgress>>,
     >,
 ) -> Result<TargetMounts> {
-    let mut packages: Vec<&str> = vec![
-        "base",
-        "base-devel",
-        "linux-firmware",
-        "linux-firmware-marvell",
-        "sof-firmware",
-    ];
+    let mut packages: Vec<&str> = config.distribution().base_packages.to_vec();
 
     // Add selected kernels
     packages.extend(config.effective_kernels());

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -12,7 +12,6 @@ pub mod users;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use alpm::SigLevel;
 use color_eyre::eyre::{Result, bail};
 use tokio_util::sync::CancellationToken;
 
@@ -280,14 +279,12 @@ impl Installer {
             self.isa,
         )?;
 
-        // Register archzfs repo in the live alpm handle and sync
-        let ctx = &mut self.alpm;
-        ctx.register_repo(
-            "archzfs",
-            &["https://github.com/archzfs/archzfs/releases/download/experimental"],
-            SigLevel::PACKAGE_OPTIONAL | SigLevel::DATABASE_OPTIONAL,
-        )?;
-        ctx.sync_databases(true)?;
+        // The repositories are already registered: they were written into
+        // pacman.conf before this handle was opened from it. Registering one
+        // again is an error, and doing it here used to be the only way the
+        // handle learned about archzfs at all — from a second copy of its
+        // address and a signature level that disagreed with the file's.
+        self.alpm.sync_databases(true)?;
 
         // zfs-utils is shared by every kernel's module package.
         self.install_target_packages(&["zfs-utils"])?;

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -95,6 +95,14 @@ pub fn perform_installation(request: InstallRequest) -> Result<Vec<String>> {
         bail!("installation cancelled");
     }
 
+    // The medium fetches the base system from the distribution's own
+    // repositories, so they have to be configured here rather than in the
+    // phase that installs ZFS: CachyOS's keyring and mirrorlists are part of
+    // its base, and they live in those repositories.
+    let isa = crate::system::sysinfo::detect_isa_level(&*runner);
+    let distro = config.distribution();
+    crate::system::pacman::add_repositories(&*runner, None, distro, isa)?;
+
     tracing::info!("Phase 4: Installing base system...");
     tracing::info!(target: "metrics", event = "phase_start", num = 4u32, name = "Installing base system");
     let target_mounts = base::install_base(
@@ -118,10 +126,9 @@ pub fn perform_installation(request: InstallRequest) -> Result<Vec<String>> {
     )?;
     alpm.sync_databases(false)?;
 
-    let isa = crate::system::sysinfo::detect_isa_level(&*runner);
     let mut installer = Installer {
         runner,
-        distro: config.distribution(),
+        distro,
         isa,
         config,
         target,

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -42,6 +42,8 @@ pub struct InstallRequest {
 struct Installer {
     runner: Arc<dyn CommandRunner>,
     config: GlobalConfig,
+    /// Resolved once: every phase that consults it wants the same answer.
+    distro: &'static crate::distro::Distribution,
     target: PathBuf,
     cancel: CancellationToken,
     download_progress_tx: Option<Arc<tokio::sync::watch::Sender<DownloadProgress>>>,
@@ -115,6 +117,7 @@ pub fn perform_installation(request: InstallRequest) -> Result<Vec<String>> {
 
     let mut installer = Installer {
         runner,
+        distro: config.distribution(),
         config,
         target,
         cancel,
@@ -258,7 +261,7 @@ impl Installer {
     /// initramfs phase can skip them and the user can be told.
     fn install_zfs_on_target(&mut self) -> Result<()> {
         // Edit pacman.conf and import GPG keys (still needs shell for pacman-key)
-        crate::system::pacman::add_archzfs_repo(&*self.runner, Some(&self.target))?;
+        crate::system::pacman::add_repositories(&*self.runner, Some(&self.target), self.distro)?;
 
         // Register archzfs repo in the live alpm handle and sync
         let ctx = &mut self.alpm;

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -285,7 +285,7 @@ impl Installer {
         let mut failures: Vec<(String, String)> = Vec::new();
 
         for kernel in &kernels {
-            let packages = crate::kernel::zfs_module_packages(kernel, mode);
+            let packages = crate::kernel::zfs_module_packages(self.distro, kernel, mode);
             if packages.is_empty() {
                 failures.push((kernel.clone(), "unknown kernel".to_string()));
                 continue;

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -44,6 +44,9 @@ struct Installer {
     config: GlobalConfig,
     /// Resolved once: every phase that consults it wants the same answer.
     distro: &'static crate::distro::Distribution,
+    /// What this machine's processor supports, which decides where a
+    /// distribution's packages come from.
+    isa: crate::system::sysinfo::IsaLevel,
     target: PathBuf,
     cancel: CancellationToken,
     download_progress_tx: Option<Arc<tokio::sync::watch::Sender<DownloadProgress>>>,
@@ -115,9 +118,11 @@ pub fn perform_installation(request: InstallRequest) -> Result<Vec<String>> {
     )?;
     alpm.sync_databases(false)?;
 
+    let isa = crate::system::sysinfo::detect_isa_level(&*runner);
     let mut installer = Installer {
         runner,
         distro: config.distribution(),
+        isa,
         config,
         target,
         cancel,
@@ -261,7 +266,12 @@ impl Installer {
     /// initramfs phase can skip them and the user can be told.
     fn install_zfs_on_target(&mut self) -> Result<()> {
         // Edit pacman.conf and import GPG keys (still needs shell for pacman-key)
-        crate::system::pacman::add_repositories(&*self.runner, Some(&self.target), self.distro)?;
+        crate::system::pacman::add_repositories(
+            &*self.runner,
+            Some(&self.target),
+            self.distro,
+            self.isa,
+        )?;
 
         // Register archzfs repo in the live alpm handle and sync
         let ctx = &mut self.alpm;

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -687,10 +687,13 @@ impl Installer {
     fn finalize_zfs(&self) -> Result<()> {
         let be = self.boot_environment();
 
-        // Enable ZFS services
+        // Enable ZFS services, and pin that choice against presets — a
+        // first boot or `systemctl preset-all` would otherwise re-enable
+        // zfs-mount.service from the package's own preset.
         for service in crate::zfs_setup::ZFS_SERVICES {
             services::enable_service(&*self.runner, &self.target, service)?;
         }
+        crate::zfs_target_files::write_zfs_preset(&self.target)?;
 
         // TRIM strategy is configured outside Installer — it doesn't depend
         // on Alpm and is async (zfskit set_property). See

--- a/core/src/kernel/mod.rs
+++ b/core/src/kernel/mod.rs
@@ -1,6 +1,7 @@
 use color_eyre::eyre::{Context, Result};
 
 use crate::config::types::ZfsModuleMode;
+use crate::distro::Distribution;
 
 pub mod scanner;
 
@@ -12,40 +13,18 @@ pub struct KernelInfo {
     pub headers_package: &'static str,
 }
 
-pub const AVAILABLE_KERNELS: &[KernelInfo] = &[
-    KernelInfo {
-        name: "linux-lts",
-        display_name: "Linux LTS",
-        precompiled_package: Some("zfs-linux-lts"),
-        headers_package: "linux-lts-headers",
-    },
-    KernelInfo {
-        name: "linux",
-        display_name: "Linux",
-        precompiled_package: Some("zfs-linux"),
-        headers_package: "linux-headers",
-    },
-    KernelInfo {
-        name: "linux-zen",
-        display_name: "Linux Zen",
-        precompiled_package: Some("zfs-linux-zen"),
-        headers_package: "linux-zen-headers",
-    },
-    KernelInfo {
-        name: "linux-hardened",
-        display_name: "Linux Hardened",
-        precompiled_package: Some("zfs-linux-hardened"),
-        headers_package: "linux-hardened-headers",
-    },
-];
-
-pub fn get_kernel_info(name: &str) -> Option<&'static KernelInfo> {
-    AVAILABLE_KERNELS.iter().find(|k| k.name == name)
+/// Look up one of a distribution's kernels by package name.
+pub fn get_kernel_info(distro: &'static Distribution, name: &str) -> Option<&'static KernelInfo> {
+    distro.kernels.iter().find(|k| k.name == name)
 }
 
-pub fn get_zfs_packages(kernel: &str, mode: ZfsModuleMode) -> Vec<String> {
+pub fn get_zfs_packages(
+    distro: &'static Distribution,
+    kernel: &str,
+    mode: ZfsModuleMode,
+) -> Vec<String> {
     let mut packages = vec!["zfs-utils".to_string()];
-    packages.extend(zfs_module_packages(kernel, mode));
+    packages.extend(zfs_module_packages(distro, kernel, mode));
     packages
 }
 
@@ -61,8 +40,12 @@ pub fn get_zfs_packages(kernel: &str, mode: ZfsModuleMode) -> Vec<String> {
 /// several kernels can each have their own. `zfs-dkms` is the exception: it
 /// conflicts with every precompiled package, which is why DKMS is a
 /// system-wide choice rather than a per-kernel fallback.
-pub fn zfs_module_packages(kernel: &str, mode: ZfsModuleMode) -> Vec<String> {
-    let Some(info) = get_kernel_info(kernel) else {
+pub fn zfs_module_packages(
+    distro: &'static Distribution,
+    kernel: &str,
+    mode: ZfsModuleMode,
+) -> Vec<String> {
+    let Some(info) = get_kernel_info(distro, kernel) else {
         return Vec::new();
     };
 
@@ -77,8 +60,8 @@ pub fn zfs_module_packages(kernel: &str, mode: ZfsModuleMode) -> Vec<String> {
     }
 }
 
-pub fn supports_precompiled(kernel: &str) -> bool {
-    get_kernel_info(kernel)
+pub fn supports_precompiled(distro: &'static Distribution, kernel: &str) -> bool {
+    get_kernel_info(distro, kernel)
         .and_then(|k| k.precompiled_package)
         .is_some()
 }
@@ -249,19 +232,23 @@ mod tests {
 
     #[test]
     fn test_get_kernel_info() {
-        let info = get_kernel_info("linux-lts").unwrap();
+        let info = get_kernel_info(crate::distro::default(), "linux-lts").unwrap();
         assert_eq!(info.display_name, "Linux LTS");
         assert_eq!(info.precompiled_package, Some("zfs-linux-lts"));
     }
 
     #[test]
     fn test_unknown_kernel() {
-        assert!(get_kernel_info("linux-custom").is_none());
+        assert!(get_kernel_info(crate::distro::default(), "linux-custom").is_none());
     }
 
     #[test]
     fn test_get_zfs_packages_precompiled() {
-        let pkgs = get_zfs_packages("linux-lts", ZfsModuleMode::Precompiled);
+        let pkgs = get_zfs_packages(
+            crate::distro::default(),
+            "linux-lts",
+            ZfsModuleMode::Precompiled,
+        );
         assert!(pkgs.contains(&"zfs-utils".to_string()));
         assert!(pkgs.contains(&"zfs-linux-lts".to_string()));
         assert!(!pkgs.contains(&"zfs-dkms".to_string()));
@@ -269,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_get_zfs_packages_dkms() {
-        let pkgs = get_zfs_packages("linux", ZfsModuleMode::Dkms);
+        let pkgs = get_zfs_packages(crate::distro::default(), "linux", ZfsModuleMode::Dkms);
         assert!(pkgs.contains(&"zfs-utils".to_string()));
         assert!(pkgs.contains(&"zfs-dkms".to_string()));
         assert!(pkgs.contains(&"linux-headers".to_string()));
@@ -277,9 +264,12 @@ mod tests {
 
     #[test]
     fn test_supports_precompiled() {
-        assert!(supports_precompiled("linux-lts"));
-        assert!(supports_precompiled("linux"));
-        assert!(!supports_precompiled("linux-custom"));
+        assert!(supports_precompiled(crate::distro::default(), "linux-lts"));
+        assert!(supports_precompiled(crate::distro::default(), "linux"));
+        assert!(!supports_precompiled(
+            crate::distro::default(),
+            "linux-custom"
+        ));
     }
 
     // Integration test: only runs on Arch with synced pacman DB

--- a/core/src/kernel/scanner.rs
+++ b/core/src/kernel/scanner.rs
@@ -4,6 +4,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use crate::config::types::ZfsModuleMode;
+use crate::distro::Distribution;
 
 /// Result of compatibility check for a single kernel.
 #[derive(Debug, Clone)]
@@ -43,10 +44,10 @@ impl CompatibilityResult {
 /// Scan all known kernels for ZFS compatibility using libalpm.
 /// Queries all packages in a single alpm session to avoid DB lock contention,
 /// then runs DKMS range checks concurrently (HTTP requests).
-pub async fn scan_all_kernels() -> Vec<CompatibilityResult> {
+pub async fn scan_all_kernels(distro: &'static Distribution) -> Vec<CompatibilityResult> {
     // Collect all packages we need to query across all kernels
     let mut all_pkg_names: Vec<&str> = vec!["zfs-dkms", "zfs-utils"];
-    for info in super::AVAILABLE_KERNELS {
+    for info in distro.kernels {
         all_pkg_names.push(info.name);
         if let Some(pre) = info.precompiled_package {
             all_pkg_names.push(pre);
@@ -67,7 +68,8 @@ pub async fn scan_all_kernels() -> Vec<CompatibilityResult> {
         }
         Err(e) => {
             tracing::warn!(error = %e, "alpm query failed, returning fail-open results");
-            return super::AVAILABLE_KERNELS
+            return distro
+                .kernels
                 .iter()
                 .map(|info| CompatibilityResult {
                     kernel_name: info.name.to_string(),
@@ -83,7 +85,8 @@ pub async fn scan_all_kernels() -> Vec<CompatibilityResult> {
     };
 
     // Run DKMS range checks concurrently (they do HTTP requests)
-    let futures: Vec<_> = super::AVAILABLE_KERNELS
+    let futures: Vec<_> = distro
+        .kernels
         .iter()
         .map(|info| scan_kernel_with_versions(info, &versions))
         .collect();
@@ -116,8 +119,8 @@ async fn scan_kernel_with_versions(
 }
 
 /// Scan a single kernel (public API for validate_kernel_zfs_plan).
-pub async fn scan_kernel(kernel: &str) -> CompatibilityResult {
-    let info = match super::get_kernel_info(kernel) {
+pub async fn scan_kernel(distro: &'static Distribution, kernel: &str) -> CompatibilityResult {
+    let info = match super::get_kernel_info(distro, kernel) {
         Some(i) => i,
         None => {
             return CompatibilityResult {
@@ -164,17 +167,19 @@ pub async fn scan_kernel(kernel: &str) -> CompatibilityResult {
 /// Validate a kernel/ZFS plan before installation.
 /// Returns a list of warnings (empty = no issues).
 pub async fn validate_kernel_zfs_plan(
+    distro: &'static Distribution,
     kernel: &str,
     mode: crate::config::types::ZfsModuleMode,
 ) -> Vec<String> {
     let mut warnings = Vec::new();
 
-    let info = match super::get_kernel_info(kernel) {
+    let info = match super::get_kernel_info(distro, kernel) {
         Some(i) => i,
         None => {
             warnings.push(format!(
                 "Unsupported kernel: {kernel}. Supported: {}",
-                super::AVAILABLE_KERNELS
+                distro
+                    .kernels
                     .iter()
                     .map(|k| k.name)
                     .collect::<Vec<_>>()
@@ -193,7 +198,7 @@ pub async fn validate_kernel_zfs_plan(
     }
 
     // Run the full compatibility scan
-    let result = scan_kernel(kernel).await;
+    let result = scan_kernel(distro, kernel).await;
     match mode {
         crate::config::types::ZfsModuleMode::Precompiled => {
             if !result.precompiled_compatible {
@@ -523,7 +528,7 @@ mod tests {
         let versions: HashMap<String, String> = [("linux-lts".into(), "6.12.41-2".into())]
             .into_iter()
             .collect();
-        let info = crate::kernel::get_kernel_info("linux-lts").unwrap();
+        let info = crate::kernel::get_kernel_info(crate::distro::default(), "linux-lts").unwrap();
         let (ok, _ver, warnings) = check_precompiled_compat(info, &versions);
         assert!(!ok);
         assert!(warnings.iter().any(|w| w.contains("not found in repos")));
@@ -639,7 +644,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_plan_invalid_kernel() {
-        let warnings = validate_kernel_zfs_plan("linux-invalid", ZfsModuleMode::Precompiled).await;
+        let warnings = validate_kernel_zfs_plan(
+            crate::distro::default(),
+            "linux-invalid",
+            ZfsModuleMode::Precompiled,
+        )
+        .await;
         assert!(!warnings.is_empty());
         assert!(warnings[0].contains("Unsupported kernel"));
     }
@@ -648,7 +658,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_scan_unknown_kernel() {
-        let result = scan_kernel("linux-nonexistent").await;
+        let result = scan_kernel(crate::distro::default(), "linux-nonexistent").await;
         assert!(!result.dkms_compatible);
         assert!(!result.precompiled_compatible);
         assert!(result.dkms_warnings[0].contains("Unknown kernel"));
@@ -728,7 +738,7 @@ mod tests {
         if !std::path::Path::new("/var/lib/pacman/sync").exists() {
             return;
         }
-        let result = scan_kernel("linux-lts").await;
+        let result = scan_kernel(crate::distro::default(), "linux-lts").await;
         // Should at least not crash and return meaningful data
         assert_eq!(result.kernel_name, "linux-lts");
         tracing::info!(?result, "scan result for linux-lts");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod dataset_layout;
 pub mod demo;
 pub mod disk;
+pub mod distro;
 pub mod install;
 pub mod installer;
 pub mod kernel;

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -457,6 +457,20 @@ impl AlpmContext {
     }
 }
 
+/// Install packages from the target's own repositories, for the phases that
+/// run outside the installer's own package handle.
+pub fn install_into_target(
+    target: &Path,
+    packages: &[&str],
+    cancel: &CancellationToken,
+    download_config: DownloadConfig,
+) -> Result<()> {
+    let target_conf = target.join("etc/pacman.conf");
+    let mut ctx = AlpmContext::for_target(target, &target_conf, download_config)?;
+    ctx.sync_databases(false)?;
+    ctx.install_packages(packages, cancel, None)
+}
+
 // ── Target preparation ───────────────────────────────
 
 fn prepare_target_dirs(target: &Path) -> Result<()> {

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use alpm::{Alpm, DownloadEvent, LogLevel, SigLevel, TransFlag};
+use alpm::{Alpm, DownloadEvent, LogLevel, TransFlag};
 use color_eyre::eyre::{Context, Result, bail, eyre};
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
@@ -280,25 +280,6 @@ impl AlpmContext {
             duration_ms = batch_duration_ms,
         );
 
-        Ok(())
-    }
-
-    /// Dynamically register an additional repo (e.g., archzfs after config edit).
-    pub fn register_repo(
-        &mut self,
-        name: &str,
-        servers: &[&str],
-        siglevel: SigLevel,
-    ) -> Result<()> {
-        let db = self
-            .handle
-            .register_syncdb_mut(name, siglevel)
-            .map_err(|e| eyre!("failed to register repo '{name}': {e}"))?;
-        for &server in servers {
-            db.add_server(server)
-                .map_err(|e| eyre!("failed to add server to '{name}': {e}"))?;
-        }
-        tracing::info!(name, "registered additional repo");
         Ok(())
     }
 

--- a/core/src/system/pacman.rs
+++ b/core/src/system/pacman.rs
@@ -3,136 +3,126 @@ use std::path::Path;
 use color_eyre::eyre::Result;
 
 use super::cmd::CommandRunner;
+use crate::distro::{Distribution, Repository};
 
-/// KNOWN GAP: `SigLevel = Never` means archzfs packages — kernel modules —
-/// are installed without signature verification, with only the sync DB's
-/// sha256 standing behind them. The key import below therefore has no effect
-/// on what actually gets installed today. This is deliberate for now: the
-/// experimental archzfs release channel's signing is not reliable enough to
-/// gate installs on, and a failed key fetch would otherwise make the
-/// installer unusable. Revisit together with `register_repo`'s SigLevel in
-/// `installer::install_zfs_on_target` and the missing `.sig` fetch in
-/// `system::async_download` — the three have to change as one.
-const ARCHZFS_REPO_BLOCK: &str = "\n[archzfs]\nSigLevel = Never\nServer = https://github.com/archzfs/archzfs/releases/download/experimental\n";
-
-const ARCHZFS_KEY_IDS: &[&str] = &[
-    "3A9917BF0DED5C13F69AC68FABEC0A1208037BE9",
-    "DDF7DB817396A49B2A2723F7403BD972F75D9D76",
-];
-
+/// Tried in order until one answers with the key.
 const KEYSERVERS: &[&str] = &[
     "hkps://keyserver.ubuntu.com",
     "hkps://pgp.mit.edu",
-    "hkps://pool.sks-keyservers.net",
     "hkps://keys.openpgp.org",
 ];
 
-pub fn add_archzfs_repo(runner: &dyn CommandRunner, target: Option<&Path>) -> Result<()> {
+/// Add a distribution's repositories to pacman.conf and trust their keys.
+///
+/// `target` selects which pacman.conf: the medium's own when `None`, the
+/// installed system's when given.
+pub fn add_repositories(
+    runner: &dyn CommandRunner,
+    target: Option<&Path>,
+    distro: &Distribution,
+) -> Result<()> {
     let pacman_conf = match target {
         Some(t) => t.join("etc/pacman.conf"),
         None => std::path::PathBuf::from("/etc/pacman.conf"),
     };
 
-    // Rewrite or append [archzfs] block
-    let content = std::fs::read_to_string(&pacman_conf)?;
-    if content.contains("[archzfs]") {
-        let new_content = rewrite_archzfs_block(&content);
-        std::fs::write(&pacman_conf, new_content)?;
-        tracing::info!("updated existing archzfs repo block");
-    } else {
-        let mut new_content = content;
-        new_content.push_str(ARCHZFS_REPO_BLOCK);
-        std::fs::write(&pacman_conf, new_content)?;
-        tracing::info!(path = %pacman_conf.display(), "added archzfs repo to pacman.conf");
+    let mut content = std::fs::read_to_string(&pacman_conf)?;
+    for repo in distro.repositories {
+        // Rewritten rather than appended when already present, so re-running
+        // an installation does not stack duplicate blocks.
+        content = replace_repo_block(&content, repo);
+        tracing::info!(repo = repo.name, path = %pacman_conf.display(), "repository configured");
     }
+    std::fs::write(&pacman_conf, content)?;
 
-    // Initialize keyring
-    let init_result = if let Some(t) = target {
-        let r = crate::system::cmd::chroot_cmd(runner, t, "pacman-key", &["--init"]);
-        if let Ok(ref output) = r
-            && output.success()
-        {
-            crate::system::cmd::chroot_cmd(runner, t, "pacman-key", &["--populate", "archlinux"])
-        } else {
-            r
-        }
-    } else {
-        let r = runner.run("pacman-key", &["--init"]);
-        if let Ok(ref output) = r
-            && output.success()
-        {
-            runner.run("pacman-key", &["--populate", "archlinux"])
-        } else {
-            r
-        }
-    };
-    if let Ok(ref output) = init_result
-        && !output.success()
-    {
-        tracing::warn!(
-            "pacman-key init/populate had issues: {}",
-            output.stderr.trim()
-        );
-    }
-
-    // Import archzfs signing keys
-    for key_id in ARCHZFS_KEY_IDS {
-        let mut received = false;
-        for server in KEYSERVERS {
-            let output = if let Some(t) = target {
-                crate::system::cmd::chroot_cmd(
-                    runner,
-                    t,
-                    "pacman-key",
-                    &["--keyserver", server, "-r", key_id],
-                )
-            } else {
-                runner.run("pacman-key", &["--keyserver", server, "-r", key_id])
-            };
-            if output.is_ok() && output.as_ref().unwrap().success() {
-                tracing::info!(key = key_id, server, "received archzfs key");
-                received = true;
-                break;
-            }
-        }
-        if !received {
-            tracing::warn!(key = key_id, "failed to receive key from any keyserver");
-        }
-
-        // Locally sign the key
-        let _ = if let Some(t) = target {
-            crate::system::cmd::chroot_cmd(runner, t, "pacman-key", &["--lsign-key", key_id])
-        } else {
-            runner.run("pacman-key", &["--lsign-key", key_id])
-        };
+    init_keyring(runner, target, distro.keyring);
+    for repo in distro.repositories {
+        trust_repository_keys(runner, target, repo);
     }
 
     // Database sync is handled by the caller via AlpmContext::sync_databases()
     Ok(())
 }
 
-fn rewrite_archzfs_block(content: &str) -> String {
-    let mut result = String::new();
-    let mut in_archzfs_block = false;
+/// Populate the keyring the distribution's packages are signed against.
+fn init_keyring(runner: &dyn CommandRunner, target: Option<&Path>, keyring: &str) {
+    let run = |args: &[&str]| match target {
+        Some(t) => crate::system::cmd::chroot_cmd(runner, t, "pacman-key", args),
+        None => runner.run("pacman-key", args),
+    };
 
-    for line in content.lines() {
-        if line.trim() == "[archzfs]" {
-            in_archzfs_block = true;
+    let initialised = run(&["--init"]);
+    let result = match &initialised {
+        Ok(output) if output.success() => run(&["--populate", keyring]),
+        _ => initialised,
+    };
+    if let Ok(output) = &result
+        && !output.success()
+    {
+        tracing::warn!(
+            keyring,
+            "pacman-key init/populate had issues: {}",
+            output.stderr.trim()
+        );
+    }
+}
+
+/// Receive and locally sign the keys a repository's packages are signed with.
+fn trust_repository_keys(runner: &dyn CommandRunner, target: Option<&Path>, repo: &Repository) {
+    let run = |args: &[&str]| match target {
+        Some(t) => crate::system::cmd::chroot_cmd(runner, t, "pacman-key", args),
+        None => runner.run("pacman-key", args),
+    };
+
+    for key_id in repo.key_ids {
+        let received =
+            KEYSERVERS
+                .iter()
+                .any(|server| match run(&["--keyserver", server, "-r", key_id]) {
+                    Ok(output) if output.success() => {
+                        tracing::info!(repo = repo.name, key = key_id, server, "received key");
+                        true
+                    }
+                    _ => false,
+                });
+        if !received {
+            tracing::warn!(
+                repo = repo.name,
+                key = key_id,
+                "failed to receive key from any keyserver"
+            );
             continue;
         }
-        if in_archzfs_block {
-            if line.starts_with('[') {
-                in_archzfs_block = false;
-                result.push_str(line);
-                result.push('\n');
-            }
+        let _ = run(&["--lsign-key", key_id]);
+    }
+}
+
+/// Replace a repository's block, or append it when the file has none.
+fn replace_repo_block(content: &str, repo: &Repository) -> String {
+    let header = format!("[{}]", repo.name);
+    let mut result = String::new();
+    let mut inside = false;
+
+    for line in content.lines() {
+        if line.trim() == header {
+            inside = true;
             continue;
+        }
+        if inside {
+            // The block runs until the next section header.
+            if line.starts_with('[') {
+                inside = false;
+            } else {
+                continue;
+            }
         }
         result.push_str(line);
         result.push('\n');
     }
 
-    result.push_str(ARCHZFS_REPO_BLOCK);
+    // Appended either way: an existing block was dropped above, and where a
+    // repository sits only matters against ones offering the same packages.
+    result.push_str(&repo.pacman_conf_block());
     result
 }
 
@@ -170,6 +160,55 @@ pub fn set_parallel_downloads(target: Option<&Path>, count: u32) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::distro::Signatures;
+
+    const REPO: Repository = Repository {
+        name: "archzfs",
+        servers: &["https://example.invalid/archzfs"],
+        mirrorlist: None,
+        key_ids: &[],
+        signatures: Signatures::Never,
+    };
+
+    #[test]
+    fn a_repository_is_added_once() {
+        let conf = "[options]\nHoldPkg = pacman\n\n[core]\nInclude = /etc/pacman.d/mirrorlist\n";
+
+        let once = replace_repo_block(conf, &REPO);
+        let twice = replace_repo_block(&once, &REPO);
+
+        assert_eq!(once.matches("[archzfs]").count(), 1);
+        assert_eq!(
+            twice.matches("[archzfs]").count(),
+            1,
+            "re-running an installation must not stack blocks: {twice}"
+        );
+    }
+
+    #[test]
+    fn rewriting_replaces_the_old_settings() {
+        // What a previous version of this installer left behind.
+        let conf = "[options]\n\n[archzfs]\nSigLevel = Optional\nServer = https://old.invalid\n\n[core]\nInclude = /etc/pacman.d/mirrorlist\n";
+
+        let result = replace_repo_block(conf, &REPO);
+
+        assert!(!result.contains("https://old.invalid"), "got: {result}");
+        assert!(result.contains("https://example.invalid/archzfs"));
+        assert!(result.contains("SigLevel = Never"));
+        // Untouched sections survive.
+        assert!(result.contains("[core]"));
+        assert!(result.contains("Include = /etc/pacman.d/mirrorlist"));
+    }
+
+    #[test]
+    fn other_sections_keep_their_settings() {
+        let conf = "[options]\nParallelDownloads = 5\n\n[extra]\nSigLevel = Required\n";
+
+        let result = replace_repo_block(conf, &REPO);
+
+        assert!(result.contains("ParallelDownloads = 5"));
+        assert!(result.contains("[extra]\nSigLevel = Required"));
+    }
 
     #[test]
     fn test_set_parallel_downloads() {

--- a/core/src/system/pacman.rs
+++ b/core/src/system/pacman.rs
@@ -1,9 +1,10 @@
 use std::path::Path;
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, bail};
 
 use super::cmd::CommandRunner;
 use crate::distro::{Distribution, Repository};
+use crate::system::sysinfo::IsaLevel;
 
 /// Tried in order until one answers with the key.
 const KEYSERVERS: &[&str] = &[
@@ -20,14 +21,28 @@ pub fn add_repositories(
     runner: &dyn CommandRunner,
     target: Option<&Path>,
     distro: &Distribution,
+    isa: IsaLevel,
 ) -> Result<()> {
+    let repositories = distro.repositories(isa);
+    if repositories.is_empty() {
+        bail!(
+            "{} has no repositories for this processor: its packages start at x86-64-v3",
+            distro.display_name
+        );
+    }
+
     let pacman_conf = match target {
         Some(t) => t.join("etc/pacman.conf"),
         None => std::path::PathBuf::from("/etc/pacman.conf"),
     };
 
     let mut content = std::fs::read_to_string(&pacman_conf)?;
-    for repo in distro.repositories {
+    if let Some(architecture) = distro.architecture {
+        // Packages built for a newer instruction set are only accepted when
+        // pacman is told to work the architecture out for itself.
+        content = set_option(&content, "Architecture", architecture);
+    }
+    for repo in repositories {
         // Rewritten rather than appended when already present, so re-running
         // an installation does not stack duplicate blocks.
         content = replace_repo_block(&content, repo);
@@ -36,7 +51,7 @@ pub fn add_repositories(
     std::fs::write(&pacman_conf, content)?;
 
     init_keyring(runner, target, distro.keyring);
-    for repo in distro.repositories {
+    for repo in repositories {
         trust_repository_keys(runner, target, repo);
     }
 
@@ -126,6 +141,41 @@ fn replace_repo_block(content: &str, repo: &Repository) -> String {
     result
 }
 
+/// Set a key in pacman.conf's `[options]`, adding it when absent.
+///
+/// Both keys this is used for appear only in that section, so a line-based
+/// replacement is enough and does not need a full parser.
+fn set_option(content: &str, key: &str, value: &str) -> String {
+    let line = format!("{key} = {value}");
+    let mut replaced = false;
+    let mut result: Vec<String> = content
+        .lines()
+        .map(|existing| {
+            let trimmed = existing.trim_start().trim_start_matches('#');
+            if trimmed.starts_with(&format!("{key} ")) || trimmed.starts_with(&format!("{key}=")) {
+                replaced = true;
+                line.clone()
+            } else {
+                existing.to_string()
+            }
+        })
+        .collect();
+
+    if !replaced {
+        // Straight after [options], which every pacman.conf opens with.
+        let at = result
+            .iter()
+            .position(|l| l.trim() == "[options]")
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        result.insert(at, line);
+    }
+
+    let mut out = result.join("\n");
+    out.push('\n');
+    out
+}
+
 pub fn set_parallel_downloads(target: Option<&Path>, count: u32) -> Result<()> {
     let pacman_conf = match target {
         Some(t) => t.join("etc/pacman.conf"),
@@ -169,6 +219,41 @@ mod tests {
         key_ids: &[],
         signatures: Signatures::Never,
     };
+
+    #[test]
+    fn an_option_is_replaced_in_place() {
+        let conf = "[options]\nArchitecture = x86_64\nParallelDownloads = 5\n\n[core]\n";
+
+        let result = set_option(conf, "Architecture", "auto");
+
+        assert!(result.contains("Architecture = auto"));
+        assert!(!result.contains("Architecture = x86_64"));
+        assert!(result.contains("ParallelDownloads = 5"), "others untouched");
+    }
+
+    #[test]
+    fn a_commented_option_is_taken_over() {
+        let conf = "[options]\n#Architecture = auto\n\n[core]\n";
+
+        let result = set_option(conf, "Architecture", "auto");
+
+        assert_eq!(result.matches("Architecture").count(), 1);
+        assert!(!result.contains('#'));
+    }
+
+    #[test]
+    fn a_missing_option_is_added_under_options() {
+        let conf = "[options]\nHoldPkg = pacman\n\n[core]\nSigLevel = Required\n";
+
+        let result = set_option(conf, "Architecture", "auto");
+
+        let lines: Vec<&str> = result.lines().collect();
+        assert_eq!(lines[0], "[options]");
+        assert_eq!(
+            lines[1], "Architecture = auto",
+            "must land inside [options]"
+        );
+    }
 
     #[test]
     fn a_repository_is_added_once() {

--- a/core/src/system/pacman.rs
+++ b/core/src/system/pacman.rs
@@ -37,10 +37,8 @@ pub fn add_repositories(
     };
 
     let mut content = std::fs::read_to_string(&pacman_conf)?;
-    if let Some(architecture) = distro.architecture {
-        // Packages built for a newer instruction set are only accepted when
-        // pacman is told to work the architecture out for itself.
-        content = set_option(&content, "Architecture", architecture);
+    if let Some(architectures) = distro.architectures(isa) {
+        content = set_option(&content, "Architecture", architectures);
     }
     for repo in repositories {
         // Rewritten rather than appended when already present, so re-running

--- a/core/src/system/sysinfo.rs
+++ b/core/src/system/sysinfo.rs
@@ -106,3 +106,60 @@ mod tests {
         assert_eq!(CpuVendor::Unknown.microcode_package(), None);
     }
 }
+
+/// Instruction-set baseline a processor supports, as far as it matters for
+/// choosing packages.
+///
+/// CachyOS rebuilds the Arch package set for these baselines and serves each
+/// from its own repositories, so which repositories apply is a property of the
+/// machine rather than of the configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IsaLevel {
+    /// Below x86-64-v3. No optimised repositories apply.
+    Baseline,
+    V3,
+    V4,
+    /// AMD Zen 4 and later, which get their own build.
+    Znver4,
+}
+
+/// Ask the dynamic loader and the compiler what this processor supports.
+///
+/// The loader knows the baselines and is always installed; gcc is asked only
+/// about Zen 4, is not always present on an installation medium, and its
+/// absence simply means the answer falls back to a baseline that is still
+/// correct, just less specific. This mirrors what CachyOS's own repository
+/// script checks.
+pub fn detect_isa_level(runner: &dyn crate::system::cmd::CommandRunner) -> IsaLevel {
+    let supports = |level: &str| {
+        runner
+            .run("/lib/ld-linux-x86-64.so.2", &["--help"])
+            .map(|out| {
+                out.stdout
+                    .contains(&format!("{level} (supported, searched)"))
+            })
+            .unwrap_or(false)
+    };
+
+    let znver4 = runner
+        .run("gcc", &["-march=native", "-Q", "--help=target"])
+        .map(|out| {
+            out.stdout
+                .lines()
+                .filter(|line| line.contains("march"))
+                .any(|line| line.contains("znver4") || line.contains("znver5"))
+        })
+        .unwrap_or(false);
+
+    let level = if znver4 {
+        IsaLevel::Znver4
+    } else if supports("x86-64-v4") {
+        IsaLevel::V4
+    } else if supports("x86-64-v3") {
+        IsaLevel::V3
+    } else {
+        IsaLevel::Baseline
+    };
+    tracing::info!(?level, "detected instruction set baseline");
+    level
+}

--- a/core/src/zfs_setup.rs
+++ b/core/src/zfs_setup.rs
@@ -165,6 +165,7 @@ pub fn install_zfs_on_host(
 /// Matches Python initialize_zfs() from kmod_setup.py.
 pub fn initialize_zfs(
     runner: &dyn CommandRunner,
+    distro: &crate::distro::Distribution,
     kernel: &str,
     mode: ZfsModuleMode,
     cancel: &tokio_util::sync::CancellationToken,
@@ -187,7 +188,7 @@ pub fn initialize_zfs(
     tracing::info!("preparing live system for ZFS support");
 
     // 4. Add archzfs repo on host
-    crate::system::pacman::add_archzfs_repo(runner, None)?;
+    crate::system::pacman::add_repositories(runner, None, distro)?;
 
     // 5. Increase cowspace
     increase_cowspace(runner)?;
@@ -262,6 +263,7 @@ mod tests {
 
         initialize_zfs(
             &runner,
+            crate::distro::default(),
             "linux-lts",
             ZfsModuleMode::Precompiled,
             &tokio_util::sync::CancellationToken::new(),

--- a/core/src/zfs_setup.rs
+++ b/core/src/zfs_setup.rs
@@ -188,7 +188,8 @@ pub fn initialize_zfs(
     tracing::info!("preparing live system for ZFS support");
 
     // 4. Add archzfs repo on host
-    crate::system::pacman::add_repositories(runner, None, distro)?;
+    let isa = crate::system::sysinfo::detect_isa_level(runner);
+    crate::system::pacman::add_repositories(runner, None, distro, isa)?;
 
     // 5. Increase cowspace
     increase_cowspace(runner)?;

--- a/core/src/zfs_setup.rs
+++ b/core/src/zfs_setup.rs
@@ -15,6 +15,58 @@ pub const ZFS_SERVICES: &[&str] = &[
     "zfs-zed.service",
 ];
 
+/// Units the installed system must keep disabled.
+///
+/// * `zfs-mount.service` runs `zfs mount -a`, which mounts every `canmount=on`
+///   dataset in the pool — including the other boot environments' `/home`,
+///   `/root`, … — inside the running one. Mounting is done by
+///   `zfs-mount-generator` from `zfs-list.cache`, which the ZED hook restricts
+///   to the booted BE.
+/// * `zfs-import-cache.service` needs `/etc/zfs/zpool.cache`; pools are created
+///   with `cachefile=none` and imported by `zfs-import-scan.service` instead.
+/// * `zfs-share.service` exports NFS/SMB shares nobody configured.
+pub const ZFS_DISABLED_SERVICES: &[&str] = &[
+    "zfs-mount.service",
+    "zfs-share.service",
+    "zfs-import-cache.service",
+];
+
+/// Where the preset policy is installed on the target. The `00-` prefix makes
+/// it sort before the ZFS package's `50-zfs.preset`; presets are matched first
+/// line wins across `/etc` and `/usr/lib`, so this file overrides it.
+pub const ZFS_PRESET_PATH: &str = "etc/systemd/system-preset/00-zfs-mount-generator.preset";
+
+/// The `systemd.preset(5)` policy matching [`ZFS_SERVICES`] and
+/// [`ZFS_DISABLED_SERVICES`].
+///
+/// `systemctl enable` at install time decides the state once; presets decide
+/// it again whenever systemd is asked to — `systemctl preset-all`, a package's
+/// post-install `systemctl preset`, and every "first boot" (a missing, empty or
+/// `uninitialized` `/etc/machine-id`). The stock `50-zfs.preset` enables
+/// `zfs-mount.service` and disables `zfs-import-scan.service`, so any of those
+/// events would silently undo the installer's choices. Pinning the policy here
+/// keeps them in force.
+pub fn zfs_preset_policy() -> String {
+    let mut out = String::from(
+        "# Written by archinstall_zfs. Mounting is handled by zfs-mount-generator from\n\
+         # /etc/zfs/zfs-list.cache; zfs-mount.service would also mount the datasets of\n\
+         # other boot environments sharing this pool. The pool has cachefile=none, so\n\
+         # it is imported by scanning. Sorts before the package's 50-zfs.preset; the\n\
+         # first matching line wins.\n",
+    );
+    for unit in ZFS_DISABLED_SERVICES {
+        out.push_str("disable ");
+        out.push_str(unit);
+        out.push('\n');
+    }
+    for unit in ZFS_SERVICES {
+        out.push_str("enable ");
+        out.push_str(unit);
+        out.push('\n');
+    }
+    out
+}
+
 pub fn load_zfs_module(runner: &dyn CommandRunner) -> Result<bool> {
     let output = runner.run("modprobe", &["zfs"])?;
     Ok(output.success())
@@ -219,6 +271,42 @@ pub fn initialize_zfs(
 mod tests {
     use super::*;
     use crate::system::cmd::tests::{CannedResponse, RecordingRunner};
+
+    /// The preset is derived from the same lists the installer enables from,
+    /// so it can only disagree with `systemctl enable` if a unit lands in both
+    /// lists — presets are "first match wins", and that would decide silently.
+    #[test]
+    fn zfs_preset_policy_matches_the_service_lists() {
+        for unit in ZFS_DISABLED_SERVICES {
+            assert!(
+                !ZFS_SERVICES.contains(unit),
+                "{unit} is both enabled and disabled"
+            );
+        }
+
+        let policy = zfs_preset_policy();
+        let directives: Vec<&str> = policy.lines().filter(|l| !l.starts_with('#')).collect();
+        assert_eq!(
+            directives.len(),
+            ZFS_SERVICES.len() + ZFS_DISABLED_SERVICES.len()
+        );
+        for unit in ZFS_DISABLED_SERVICES {
+            assert!(directives.contains(&format!("disable {unit}").as_str()));
+        }
+        for unit in ZFS_SERVICES {
+            assert!(directives.contains(&format!("enable {unit}").as_str()));
+        }
+    }
+
+    /// These two are the whole point: the package's 50-zfs.preset says the
+    /// opposite for both of them.
+    #[test]
+    fn zfs_preset_policy_overrides_the_package_defaults() {
+        let policy = zfs_preset_policy();
+        assert!(policy.contains("disable zfs-mount.service\n"));
+        assert!(policy.contains("enable zfs-import-scan.service\n"));
+        assert!(ZFS_PRESET_PATH.starts_with("etc/systemd/system-preset/00-"));
+    }
 
     #[test]
     fn test_load_zfs_module() {

--- a/core/src/zfs_target_files.rs
+++ b/core/src/zfs_target_files.rs
@@ -152,6 +152,21 @@ pub fn install_zed_cache_hook(runner: &dyn CommandRunner, target: &Path) -> Resu
     Ok(())
 }
 
+/// Install the systemd preset that pins the ZFS unit policy on the target.
+/// See [`crate::zfs_setup::zfs_preset_policy`] for why enabling the units
+/// once is not enough.
+pub fn write_zfs_preset(target: &Path) -> Result<()> {
+    let path = target.join(crate::zfs_setup::ZFS_PRESET_PATH);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .wrap_err_with(|| format!("failed to create preset dir: {}", parent.display()))?;
+    }
+    fs::write(&path, crate::zfs_setup::zfs_preset_policy())
+        .wrap_err_with(|| format!("failed to write ZFS preset: {}", path.display()))?;
+    tracing::info!(path = %path.display(), "installed ZFS systemd preset");
+    Ok(())
+}
+
 pub fn copy_misc_files(
     runner: &dyn CommandRunner,
     target: &Path,
@@ -227,6 +242,19 @@ mod tests {
     #[test]
     fn test_rewrite_cache_mountpoints_empty_input() {
         assert_eq!(rewrite_cache_mountpoints("", Path::new("/mnt")), "");
+    }
+
+    #[test]
+    fn test_write_zfs_preset() {
+        let dir = tempfile::tempdir().unwrap();
+        write_zfs_preset(dir.path()).unwrap();
+
+        let path = dir
+            .path()
+            .join("etc/systemd/system-preset/00-zfs-mount-generator.preset");
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, crate::zfs_setup::zfs_preset_policy());
+        assert!(content.ends_with('\n'));
     }
 
     #[test]

--- a/docs/zfs-root-install-guide.md
+++ b/docs/zfs-root-install-guide.md
@@ -798,6 +798,36 @@ done
 Note what is **absent**: `zfs-import-cache.service` (we chose `cachefile=none`) and
 `zfs-mount.service` (mounting is handled by `zfs-mount-generator`).
 
+`zfs-mount.service` is not merely redundant — it is harmful on a multi-BE pool.
+It runs `zfs mount -a`, which mounts *every* `canmount=on` dataset in the pool,
+including the other boot environments' `/home`, `/root`, `/var/lib/docker`… It
+creates their mountpoint directories inside the running BE and, where a
+directory is empty, succeeds. `overlay=off` only stops the ones that collide with
+something already mounted.
+
+**Disabling it once is not enough.** The distro's preset (`50-zfs.preset` ships
+`enable zfs-mount.service`) is re-applied by `systemd-preset` on every "first
+boot" — and a system whose `/etc/machine-id` is missing, empty or still reads
+`uninitialized` is on its first boot *every time*, because the ID is only
+committed once a boot completes. An installation that never got that far
+re-enables the service on each attempt. Pin the decision so presets cannot undo
+it, and give the target a machine ID before its first boot:
+
+```bash
+cat > /mnt/etc/systemd/system-preset/00-zfs-mount-generator.preset <<'EOF'
+disable zfs-mount.service
+disable zfs-share.service
+disable zfs-import-cache.service
+enable zfs-import-scan.service
+EOF
+systemd-machine-id-setup --root=/mnt      # refuses to touch "uninitialized": rm it first
+```
+
+Preset files are read in lexical order across `/etc` and `/usr/lib`, first match
+wins, so `00-` beats the distro's `50-zfs.preset`. The installer writes this file
+from the same lists it enables units from (`zfs_setup::zfs_preset_policy`,
+installed by `zfs_target_files::write_zfs_preset`), so the two cannot drift apart.
+
 ### `zfs-list.cache` and the boot-environment-aware ZED hook
 
 `zfs-mount-generator(8)` is a systemd generator that runs *before* the pool is

--- a/docs/zfs-root-install-guide.md
+++ b/docs/zfs-root-install-guide.md
@@ -379,6 +379,57 @@ cannot mount '/home': directory is not empty
 (`dataset_layout::mount_datasets_ordered` propagates it). A loud failure you can
 fix beats a silent one you discover months later.
 
+#### Early writers — who fills a mountpoint before it is mounted
+
+`overlay=off` only *detects* pollution; it does not prevent it. Until a child
+dataset is mounted, its mountpoint is an ordinary directory on the parent dataset
+(`/root` lives on `zroot/arch0/root`), and anything root-owned that runs before
+`local-fs.target` can drop files there. On an installed system the window is small
+but real, and it is not empty:
+
+* **systemd generators** run inside PID 1 *before any unit exists*, so no
+  `Before=`/`After=` ordering can put a mount ahead of them. A real case:
+  flatpak's `system-environment-generators/60-flatpak-system-only` (flatpak 1.18)
+  runs `flatpak --print-updated-env`, which creates `$XDG_CACHE_HOME` — with no
+  `HOME` set that resolves to `/root/.cache` — on every boot. With `overlay=on` this
+  was hidden for months; with `overlay=off` it is
+  `root.mount: … directory is not empty`. Fix: an `/etc/systemd/system-environment-generators/`
+  override of the same name that exports `XDG_CACHE_HOME=/run/flatpak-envgen-cache`
+  before exec'ing the original command (or mask it with a `/dev/null` symlink).
+* Units with `DefaultDependencies=no` that start alongside `sysinit.target`.
+* Post-mount writers that only matter once the mount has already failed:
+  systemd's own `tmpfiles.d/provision.conf` (`/root/.ssh`), a display manager's X
+  server running as root (`/root/.cache/mesa_shader_cache`).
+
+Diagnosing this from the journal is misleading: journald is restarted after
+switch-root, so every message from the generator phase carries the same
+timestamp. Use the file system and the manager's own clocks instead:
+
+```sh
+stat -c '%w %n' /root/.cache                  # birth time of the stray entry
+systemctl show -p GeneratorsStartTimestampMonotonic \
+                 -p GeneratorsFinishTimestampMonotonic
+systemctl show '*' -p Id,InactiveExitTimestampMonotonic   # per-unit start times
+# then strace the suspects with HOME unset, as PID 1 runs them:
+env -i PATH=/usr/bin strace -f -e trace=%file /usr/lib/systemd/system-environment-generators/NAME
+```
+
+The general defence is to make the underlying directories themselves refuse
+writes: `chattr +i` on the parent dataset's mountpoint directories. Mounting over
+an immutable directory works, `mkdir`/`creat` inside it fails with `EPERM`, and the
+flag lives in the inode, so it survives snapshots, rollbacks, clones into new BEs
+and `zfs send`. On a running system the parent's view is reachable through a bind
+mount:
+
+```sh
+mount --bind / /mnt/parent
+chattr +i /mnt/parent/{root,home,vm,var/lib/docker}    # must be empty first
+umount /mnt/parent
+```
+
+Remember to `chattr -i` before deleting or moving a mountpoint, and that each BE
+has its own set of directories on its own root dataset.
+
 ### `canmount=noauto` on `.../root`
 
 This is the property that makes multiple boot environments possible. Every BE's
@@ -1295,6 +1346,18 @@ Constant everywhere:
 The one genuinely distro-shaped decision is **`rootprefix`**, because it depends on
 which initramfs generator parses the command line, not on the distro name. Get it
 from the initramfs you actually built, not from the distro's reputation.
+
+Gentoo specifics learned the hard way:
+
+* `sys-apps/systemd` is built **without** `USE=cryptsetup` by default. Then there is
+  no `systemd-cryptsetup` and no `systemd-cryptsetup-generator`, `/etc/crypttab` is
+  silently ignored, and an `fstab` swap on `/dev/mapper/cryptswap` stalls boot for
+  the 90 s device timeout. Set `sys-apps/systemd cryptsetup` in `package.use`
+  before the first boot (and use `nofail,x-systemd.device-timeout=15s` on the swap
+  line regardless).
+* The `50-zfs.preset` / first-boot trap from [§14](#zfs-services) applies verbatim.
+* `sys-fs/zfs dist-kernel` in `package.use` keeps the module and the dracut image in
+  step with `gentoo-kernel` upgrades.
 
 ---
 

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -251,8 +251,17 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     vec![
         section_header("System"),
+        // Before the kernel row on purpose: which kernels exist is the
+        // distribution's answer, so choosing one first is the order that makes
+        // sense on screen.
         ci(
-            "kernel",
+            EditorSetting::Distribution.as_str(),
+            "Distribution",
+            c.distribution().display_name,
+            ItemType::Select,
+        ),
+        ci(
+            EditorSetting::Kernel.as_str(),
             "Kernel",
             &format!(
                 "{} [{}]",

--- a/slint-ui/src/controllers/welcome.rs
+++ b/slint-ui/src/controllers/welcome.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 use archinstall_zfs_core::config::types::GlobalConfig;
+use archinstall_zfs_core::distro::Distribution;
 use archinstall_zfs_core::kernel::scanner::CompatibilityResult;
 use slint::{ComponentHandle, SharedString};
 
@@ -15,9 +16,16 @@ use crate::ui::{App, WelcomeState};
 /// Cached results of the background kernel compatibility scan. The wizard's
 /// "Kernel" item activation reads this to populate the kernel select popup
 /// without re-scanning every time.
+/// Scan results together with the distribution they describe.
+type ScannedKernels = (&'static str, Vec<CompatibilityResult>);
+
 #[derive(Clone, Default)]
 pub struct KernelScan {
-    inner: Arc<Mutex<Option<Vec<CompatibilityResult>>>>,
+    /// Results, and the distribution they describe. Kept together because the
+    /// kernel list is paired with these by position: results from one
+    /// distribution against another's kernels would mark the wrong ones
+    /// compatible.
+    inner: Arc<Mutex<Option<ScannedKernels>>>,
 }
 
 impl KernelScan {
@@ -25,19 +33,29 @@ impl KernelScan {
         Self::default()
     }
 
-    pub fn is_some(&self) -> bool {
-        self.inner.lock().unwrap().is_some()
+    /// Whether a scan for `distro` has completed.
+    pub fn has(&self, distro: &Distribution) -> bool {
+        matches!(*self.inner.lock().unwrap(), Some((name, _)) if name == distro.name)
     }
 
-    /// Borrow the cached results for the duration of `f`. `None` if the scan
-    /// hasn't completed yet.
-    pub fn with<R>(&self, f: impl FnOnce(Option<&[CompatibilityResult]>) -> R) -> R {
+    /// Borrow the cached results for `distro` for the duration of `f`. `None`
+    /// when nothing has been scanned yet, or when what was scanned describes a
+    /// different distribution.
+    pub fn with<R>(
+        &self,
+        distro: &Distribution,
+        f: impl FnOnce(Option<&[CompatibilityResult]>) -> R,
+    ) -> R {
         let guard = self.inner.lock().unwrap();
-        f(guard.as_deref())
+        let results = match guard.as_ref() {
+            Some((name, results)) if *name == distro.name => Some(results.as_slice()),
+            _ => None,
+        };
+        f(results)
     }
 
-    pub(super) fn store(&self, results: Vec<CompatibilityResult>) {
-        *self.inner.lock().unwrap() = Some(results);
+    pub(super) fn store(&self, distro: &Distribution, results: Vec<CompatibilityResult>) {
+        *self.inner.lock().unwrap() = Some((distro.name, results));
     }
 }
 
@@ -58,8 +76,9 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &Kernel
             {
                 start_zfs_init(&app, &cfg.borrow());
             }
-            if !kscan.is_some() {
-                start_kernel_scan(&kscan, cfg.borrow().distribution());
+            let distro = cfg.borrow().distribution();
+            if !kscan.has(distro) {
+                start_kernel_scan(&kscan, distro);
             }
         }
     });
@@ -181,7 +200,7 @@ fn start_kernel_scan(
                 "kernel scan result"
             );
         }
-        cache.store(results);
+        cache.store(distro, results);
         tracing::info!("kernel compatibility scan complete");
     });
 }

--- a/slint-ui/src/controllers/welcome.rs
+++ b/slint-ui/src/controllers/welcome.rs
@@ -110,6 +110,7 @@ fn start_zfs_init(app: &App, config: &GlobalConfig) {
     let weak = app.as_weak();
     let kernel = config.primary_kernel().to_string();
     let zfs_mode = config.zfs_module_mode;
+    let distro = config.distribution();
 
     tokio::task::spawn_blocking(move || {
         let runner: Arc<dyn archinstall_zfs_core::system::cmd::CommandRunner> =
@@ -134,6 +135,7 @@ fn start_zfs_init(app: &App, config: &GlobalConfig) {
 
         let result = archinstall_zfs_core::zfs_setup::initialize_zfs(
             &*runner,
+            distro,
             &kernel,
             zfs_mode,
             &cancel,

--- a/slint-ui/src/controllers/welcome.rs
+++ b/slint-ui/src/controllers/welcome.rs
@@ -59,7 +59,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &Kernel
                 start_zfs_init(&app, &cfg.borrow());
             }
             if !kscan.is_some() {
-                start_kernel_scan(&kscan);
+                start_kernel_scan(&kscan, cfg.borrow().distribution());
             }
         }
     });
@@ -98,7 +98,7 @@ fn run_initial_checks(
         if !demo && !(zfs_mod && zfs_utils) {
             start_zfs_init(app, &config.borrow());
         }
-        start_kernel_scan(kernel_scan);
+        start_kernel_scan(kernel_scan, config.borrow().distribution());
     }
 }
 
@@ -159,15 +159,15 @@ fn start_zfs_init(app: &App, config: &GlobalConfig) {
 }
 
 /// Start kernel compatibility scan in background, store results in shared state.
-fn start_kernel_scan(scan_cache: &KernelScan) {
+fn start_kernel_scan(
+    scan_cache: &KernelScan,
+    distro: &'static archinstall_zfs_core::distro::Distribution,
+) {
     let cache = scan_cache.clone();
     tokio::task::spawn(async move {
         tracing::info!("scanning kernel compatibility...");
-        let results = archinstall_zfs_core::kernel::scanner::scan_all_kernels().await;
-        for (info, result) in archinstall_zfs_core::kernel::AVAILABLE_KERNELS
-            .iter()
-            .zip(&results)
-        {
+        let results = archinstall_zfs_core::kernel::scanner::scan_all_kernels(distro).await;
+        for (info, result) in distro.kernels.iter().zip(&results) {
             let pre = if result.precompiled_compatible {
                 "OK"
             } else {

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -133,11 +133,11 @@ fn setup_select_confirmed(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_
         }
 
         if key == "kernel_select" {
-            let kernels = cfg.borrow().distribution().kernels;
-            if let Some(info) = kernels.get(idx as usize) {
+            let distro = cfg.borrow().distribution();
+            if let Some(info) = distro.kernels.get(idx as usize) {
                 let mut c = cfg.borrow_mut();
                 c.kernels = Some(vec![info.name.to_string()]);
-                let auto_mode = kscan.with(|cached| {
+                let auto_mode = kscan.with(distro, |cached| {
                     cached
                         .and_then(|results| results.get(idx as usize))
                         .and_then(|r| r.best_mode())
@@ -453,13 +453,30 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
     };
 
     match setting {
+        EditorSetting::Distribution => {
+            let names: Vec<&str> = archinstall_zfs_core::distro::ALL
+                .iter()
+                .map(|distro| distro.display_name)
+                .collect();
+            let current = archinstall_zfs_core::distro::ALL
+                .iter()
+                .position(|distro| distro.name == config.distribution)
+                .unwrap_or(0);
+            show_select(
+                app,
+                ChoiceSetting::Distribution.as_str(),
+                "Distribution",
+                &names,
+                current as i32,
+            );
+        }
         EditorSetting::Kernel => {
             // Use the cached scan results if available; otherwise block-scan now.
             let fresh: Vec<archinstall_zfs_core::kernel::scanner::CompatibilityResult>;
             let distro = config.distribution();
-            let options = if let Some(opts) =
-                kernel_scan.with(|cached| cached.map(|r| build_kernel_options(distro, r)))
-            {
+            let options = if let Some(opts) = kernel_scan.with(distro, |cached| {
+                cached.map(|r| build_kernel_options(distro, r))
+            }) {
                 opts
             } else {
                 let rt = tokio::runtime::Handle::current();

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -133,7 +133,7 @@ fn setup_select_confirmed(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_
         }
 
         if key == "kernel_select" {
-            let kernels = archinstall_zfs_core::kernel::AVAILABLE_KERNELS;
+            let kernels = cfg.borrow().distribution().kernels;
             if let Some(info) = kernels.get(idx as usize) {
                 let mut c = cfg.borrow_mut();
                 c.kernels = Some(vec![info.name.to_string()]);
@@ -399,9 +399,11 @@ fn setup_password_strength(app: &App) {
 
 /// Format the cached/fresh kernel scan results as user-facing strings.
 fn build_kernel_options(
+    distro: &'static archinstall_zfs_core::distro::Distribution,
     results: &[archinstall_zfs_core::kernel::scanner::CompatibilityResult],
 ) -> Vec<String> {
-    archinstall_zfs_core::kernel::AVAILABLE_KERNELS
+    distro
+        .kernels
         .iter()
         .zip(results.iter())
         .map(|(info, result)| {
@@ -454,18 +456,23 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
         EditorSetting::Kernel => {
             // Use the cached scan results if available; otherwise block-scan now.
             let fresh: Vec<archinstall_zfs_core::kernel::scanner::CompatibilityResult>;
-            let options =
-                if let Some(opts) = kernel_scan.with(|cached| cached.map(build_kernel_options)) {
-                    opts
-                } else {
-                    let rt = tokio::runtime::Handle::current();
-                    fresh = rt.block_on(archinstall_zfs_core::kernel::scanner::scan_all_kernels());
-                    build_kernel_options(&fresh)
-                };
+            let distro = config.distribution();
+            let options = if let Some(opts) =
+                kernel_scan.with(|cached| cached.map(|r| build_kernel_options(distro, r)))
+            {
+                opts
+            } else {
+                let rt = tokio::runtime::Handle::current();
+                fresh = rt.block_on(archinstall_zfs_core::kernel::scanner::scan_all_kernels(
+                    distro,
+                ));
+                build_kernel_options(distro, &fresh)
+            };
 
             let opt_refs: Vec<&str> = options.iter().map(|s| s.as_str()).collect();
             let current_kernel = config.primary_kernel();
-            let current_idx = archinstall_zfs_core::kernel::AVAILABLE_KERNELS
+            let current_idx = distro
+                .kernels
                 .iter()
                 .position(|k| k.name == current_kernel)
                 .unwrap_or(0);

--- a/tui/src/tui/screens/pickers.rs
+++ b/tui/src/tui/screens/pickers.rs
@@ -220,14 +220,14 @@ pub async fn pick_kernel(
     config: &GlobalConfig,
     terminal: &mut ratatui::DefaultTerminal,
 ) -> Result<Option<(String, ZfsModuleMode)>> {
-    use archinstall_zfs_core::kernel::AVAILABLE_KERNELS;
     use archinstall_zfs_core::kernel::scanner::scan_all_kernels;
 
-    let results = scan_all_kernels().await;
+    let distro = config.distribution();
+    let results = scan_all_kernels(distro).await;
 
     let mut options = Vec::new();
     let mut selectable: Vec<(usize, &str, ZfsModuleMode)> = Vec::new();
-    for (i, (info, result)) in AVAILABLE_KERNELS.iter().zip(&results).enumerate() {
+    for (i, (info, result)) in distro.kernels.iter().zip(&results).enumerate() {
         let ver = result.kernel_version.as_deref().unwrap_or("?");
         if let Some(mode) = result.best_mode() {
             options.push(format!(

--- a/tui/src/tui/screens/steps/system.rs
+++ b/tui/src/tui/screens/steps/system.rs
@@ -5,8 +5,15 @@ use super::{MenuItem, MenuKind, radio_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let mut items = vec![
+        // Before the kernel: which kernels exist depends on the answer here.
         MenuItem {
-            key: "kernel",
+            key: EditorSetting::Distribution.as_str(),
+            label: "Distribution",
+            value: config.distribution().display_name.to_string(),
+            kind: MenuKind::Custom,
+        },
+        MenuItem {
+            key: EditorSetting::Kernel.as_str(),
             label: "Kernel",
             value: format!(
                 "{} [{}]",

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -7,7 +7,8 @@ use ratatui::widgets::{
 };
 
 use archinstall_zfs_core::config::edit::{
-    DeviceSetting, EditorSetting, ToggleSetting, apply_device, apply_toggle,
+    ChoiceSetting, DeviceSetting, EditorSetting, ToggleSetting, apply_choice, apply_device,
+    apply_toggle,
 };
 use archinstall_zfs_core::config::types::GlobalConfig;
 
@@ -339,6 +340,20 @@ impl Wizard {
                         {
                             self.config.kernels = Some(vec![kernel]);
                             self.config.zfs_module_mode = mode;
+                        }
+                    }
+                    EditorSetting::Distribution => {
+                        let names: Vec<&str> = archinstall_zfs_core::distro::ALL
+                            .iter()
+                            .map(|distro| distro.display_name)
+                            .collect();
+                        let current = archinstall_zfs_core::distro::ALL
+                            .iter()
+                            .position(|distro| distro.name == self.config.distribution)
+                            .unwrap_or(0);
+                        let result = run_select(terminal, "Distribution", &names, current)?;
+                        if let Some(index) = result.selected {
+                            apply_choice(&mut self.config, ChoiceSetting::Distribution, index);
                         }
                     }
                     EditorSetting::Profile => {

--- a/xtask/configs/cachyos.json
+++ b/xtask/configs/cachyos.json
@@ -1,0 +1,32 @@
+{
+    "installation_mode": "full_disk",
+    "disk": "/dev/disk/by-id/virtio-archzfs-test-disk",
+    "pool_name": "testpool",
+    "dataset_prefix": "arch0",
+    "init_system": "dracut",
+    "zfs_module_mode": "precompiled",
+    "zfs_encryption_mode": "none",
+    "compression": "lz4",
+    "swap_mode": "zram",
+    "hostname": "cachyos-test",
+    "locale": "en_US.UTF-8 UTF-8",
+    "keyboard_layout": "us",
+    "timezone": "UTC",
+    "ntp": true,
+    "root_password": "test",
+    "kernels": [
+        "linux-cachyos-lts"
+    ],
+    "additional_packages": [
+        "openssh"
+    ],
+    "aur_packages": [],
+    "network_copy_iso": true,
+    "parallel_downloads": 10,
+    "zrepl_enabled": false,
+    "bluetooth": false,
+    "extra_services": [
+        "sshd"
+    ],
+    "distribution": "cachyos"
+}


### PR DESCRIPTION
Closes #47. CachyOS is an Arch derivative with its own repositories — rebuilds
of the Arch package set for newer instruction sets — its own keyring, and its
own kernels, each with a matching ZFS module. The installer knew Arch as the
only answer, and knew it as constants scattered through the code.

- Describe a distribution as data: base packages, repositories, keyring
- Move the kernel table into the distribution, since kernels are its own
- Add CachyOS: repositories chosen by what the processor supports, its kernels
  and their ZFS modules, ZFSBootMenu from its repository rather than the AUR
- Choose the distribution in both wizards, ahead of the kernel because which
  kernels exist is the distribution's answer
- Take repositories from pacman.conf rather than a second copy in the code

Three findings are worth recording, because each failure pointed somewhere other
than its cause and each shaped the code:

| reported | actual |
|---|---|
| `invalid or corrupted database (PGP signature)` | wrong repository path: their mirror answers 200 with a welcome page for anything that does not exist, and pacman was handed HTML as a signature |
| `package architecture is not valid` | `Architecture = auto` is expanded to the instruction set only by their patched pacman; stock pacman expands it to `uname -m`, so the accepted architectures are listed out instead |
| `generate-zbm: No such file or directory` | they package ZFSBootMenu, so asking the AUR for it resolves to nothing to build and nothing is installed |

Their repositories also have to be configured before the base system is
installed rather than alongside ZFS, because their keyring and mirrorlists are
part of that base and live in those repositories. That in turn made an
already-registered repository collide with the explicit registration that
followed, which only the Arch path could show: CachyOS has no archzfs entry to
collide with.

Testing: Arch and CachyOS each installed and booted in a virtual machine,
6.18.44-1-lts and 6.18.42-1-cachyos-lts on ZFS, thirteen of thirteen health
checks both times.

Not covered, and visible from the diff: only the x86-64-v3 path has been
exercised on hardware — the v4 and Zen 4 repository paths and architecture lists
come from their mirrorlists, are checked against the mirror and covered by unit
tests. Of the four CachyOS kernels only linux-cachyos-lts has been installed;
the rest follow the same name/-zfs/-headers pattern, which a test pins. The
wizard rows have not been clicked through.
