### PR TITLE
Fix live installer networking, KMS input and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test-install.log
 # `echo 'use flake' > .envrc && direnv allow`; not a project convention).
 .envrc
 .direnv/
+__pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,24 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,7 +186,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -215,7 +197,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -232,12 +214,6 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arboard"
@@ -336,17 +312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,12 +330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
-name = "as-slice"
-version = "0.2.1"
+name = "ash"
+version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "stable_deref_trait",
+ "libloading",
 ]
 
 [[package]]
@@ -532,65 +497,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_enums"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3091d68264354f211516b91dce6f71046e444fab1867716035f736667243affb"
-dependencies = [
- "derive_utils",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror 2.0.20",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom 8.0.0",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "aws-lc-rs"
@@ -635,6 +545,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bincode"
@@ -685,6 +601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+dependencies = [
+ "bit-vec 0.9.1",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,10 +622,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bit_field"
-version = "0.10.3"
+name = "bit-vec"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -715,15 +640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "bitstream-io"
-version = "4.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
-dependencies = [
- "no_std_io2",
 ]
 
 [[package]]
@@ -784,12 +700,6 @@ dependencies = [
  "bytes",
  "cfg_aliases",
 ]
-
-[[package]]
-name = "built"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
@@ -1073,6 +983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset"
 version = "0.2.1"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1156,11 +1075,11 @@ dependencies = [
 [[package]]
 name = "const-field-offset-macro"
 version = "0.2.1"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1226,15 +1145,6 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "libc",
-]
-
-[[package]]
-name = "core_maths"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
-dependencies = [
- "libm",
 ]
 
 [[package]]
@@ -1581,17 +1491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_utils"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc05a5d33db20c784f873e84934ad94bb209a090987ac5f62fede2c178234f23"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,26 +1663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,7 +1675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1835,23 +1714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.74.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "num-complex",
- "pulp",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,12 +1749,6 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
-name = "fax"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -2014,21 +1870,20 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
 dependencies = [
  "log",
  "slotmap",
  "tinyvec",
- "ttf-parser",
 ]
 
 [[package]]
 name = "fontique"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e04c4750a17111ebd77c3e0aea00476ce33f59235bc4d9e7f0aded5033ad3fc"
+checksum = "6688bc1294fe7117d788937b6c53480169b29c566954af490830d4c09da9516a"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -2038,7 +1893,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.40.2",
+ "read-fonts",
  "roxmltree",
  "smallvec",
  "windows",
@@ -2238,15 +2093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,9 +2166,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glow"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+checksum = "263218b0ba2b0715c3370fb04674f5f8aa331594b521c94ff0a8e4a8472d1386"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2397,6 +2243,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.20",
+ "windows",
+]
+
+[[package]]
 name = "grid"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,9 +2264,9 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2429,18 +2289,19 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
 [[package]]
 name = "harfrust"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
- "read-fonts 0.40.2",
+ "read-fonts",
  "smallvec",
 ]
 
@@ -2601,7 +2462,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2623,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-linuxkms"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "calloop 0.14.4",
  "cfg_aliases",
@@ -2634,6 +2495,7 @@ dependencies = [
  "i-slint-core",
  "i-slint-renderer-skia",
  "input",
+ "libseat",
  "memmap2",
  "nix 0.31.3",
  "raw-window-handle",
@@ -2643,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-selector"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "cfg-if",
  "cfg_aliases",
@@ -2659,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-testing"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "cfg_aliases",
  "i-slint-common",
@@ -2671,13 +2533,12 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-winit"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "arboard",
  "block2 0.6.2",
  "cfg-if",
  "cfg_aliases",
- "derive_more",
  "futures",
  "glutin",
  "glutin-winit",
@@ -2710,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "derive_more",
  "fontique",
@@ -2720,13 +2581,13 @@ dependencies = [
  "icu_provider",
  "pulldown-cmark",
  "resvg",
- "skrifa 0.43.2",
+ "skrifa",
 ]
 
 [[package]]
 name = "i-slint-compiler"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "annotate-snippets",
  "by_address",
@@ -2734,9 +2595,10 @@ dependencies = [
  "derive_more",
  "i-slint-common",
  "icu_normalizer",
+ "icu_properties",
  "image",
- "itertools 0.14.0",
- "linked_hash_set",
+ "indexmap",
+ "itertools 0.15.0",
  "lyon_extra",
  "lyon_path",
  "num_enum",
@@ -2746,7 +2608,7 @@ dependencies = [
  "resvg",
  "rowan",
  "rspolib",
- "skrifa 0.43.2",
+ "skrifa",
  "smol_str 0.3.6",
  "strum",
  "swash",
@@ -2758,9 +2620,8 @@ dependencies = [
 [[package]]
 name = "i-slint-core"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
- "auto_enums",
  "bitflags 2.13.1",
  "cfg-if",
  "chrono",
@@ -2790,7 +2651,7 @@ dependencies = [
  "resvg",
  "rgb",
  "scopeguard",
- "skrifa 0.43.2",
+ "skrifa",
  "slab",
  "strum",
  "swash",
@@ -2803,30 +2664,31 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "web-time",
+ "wgpu",
  "windows",
 ]
 
 [[package]]
 name = "i-slint-core-macros"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "quote",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "i-slint-renderer-skia"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
+ "ash",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "clru",
  "const-field-offset",
- "derive_more",
  "glow",
  "glutin",
  "i-slint-common",
@@ -2841,21 +2703,24 @@ dependencies = [
  "objc2-quartz-core 0.3.2",
  "pin-weak",
  "raw-window-handle",
- "raw-window-metal",
- "read-fonts 0.40.2",
+ "read-fonts",
  "scoped-tls-hkt",
  "skia-safe",
  "softbuffer",
+ "spin_on",
  "unicode-segmentation",
  "vtable",
+ "wgpu",
+ "wgpu-hal",
  "windows",
+ "windows-core",
  "write-fonts",
 ]
 
 [[package]]
 name = "i-slint-renderer-software"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "bytemuck",
  "clru",
@@ -2863,10 +2728,9 @@ dependencies = [
  "euclid",
  "i-slint-common",
  "i-slint-core",
- "integer-sqrt",
  "lyon_path",
  "num-traits",
- "skrifa 0.43.2",
+ "skrifa",
  "swash",
  "zeno",
 ]
@@ -3099,18 +2963,9 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
  "moxcms",
  "num-traits",
  "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
- "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -3127,15 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
-
-[[package]]
-name = "imgref"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "indenter"
@@ -3195,26 +3044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-sqrt"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,6 +3080,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -3408,26 +3246,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lebe"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
-dependencies = [
- "arbitrary",
- "cc",
-]
 
 [[package]]
 name = "libloading"
@@ -3458,6 +3280,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "libseat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6656c69b6e0366ffb83faa232f3e4fda5fc91161722d140f2c95ce2e90b1ef31"
+dependencies = [
+ "errno",
+ "libseat-sys",
+ "log",
+]
+
+[[package]]
+name = "libseat-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a484fa48be5f62a8d3ffed767779d0ab808cfead91de98ef4362d469097dfb"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,21 +3323,6 @@ name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3541,15 +3368,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
 
 [[package]]
 name = "lru"
@@ -3634,16 +3452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
-]
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
 ]
 
 [[package]]
@@ -3752,7 +3560,45 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "naga"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "libm",
+ "log",
+ "naga-types",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.20",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3792,12 +3638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,7 +3669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33e42c05118e18f29f55eefa2fbfd98a06b0c7a1a829bdb0f328137d358c6013"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "futures",
  "futures-timer",
@@ -3840,15 +3680,6 @@ dependencies = [
  "uuid",
  "zbus",
  "zvariant",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3871,12 +3702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3891,27 +3716,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "bytemuck",
- "num-traits",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3929,26 +3734,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -4224,6 +4009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.13.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -4261,6 +4047,7 @@ dependencies = [
  "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
 ]
@@ -4407,7 +4194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4514,9 +4301,9 @@ checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "parley"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0478b47dd9885a5e0a4f1c0782ffc42bf6ee8c41dea0917d7a9bcee3e6585fc"
+checksum = "22d2ff88bd3f7d68d1d9b09c7e6209f9a8e8c05088295140a2bcf2e9b17038c5"
 dependencies = [
  "fontique",
  "harfrust",
@@ -4527,29 +4314,17 @@ dependencies = [
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa 0.43.2",
+ "skrifa",
 ]
 
 [[package]]
 name = "parley_data"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a649e01a1acc917247ee147b56b8a1fa91824acf7117bd003b4204306d601255"
+checksum = "1567535334d6ba2d3cde19221ba9a7bd0fabb3cbd99046ddfb10ae061cfcc889"
 dependencies = [
  "icu_properties",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "percent-encoding"
@@ -4803,6 +4578,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4820,13 +4604,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
+name = "presser"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -4861,19 +4642,6 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
-dependencies = [
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "pulldown-cmark"
@@ -4882,55 +4650,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.13.1",
- "getopts",
  "memchr",
- "pulldown-cmark-escape",
  "unicase",
 ]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "pulp"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
-dependencies = [
- "bytemuck",
- "cfg-if",
- "libm",
- "num-complex",
- "paste",
- "pulp-wasm-simd-flag",
- "raw-cpuid",
- "reborrow",
- "version_check",
-]
-
-[[package]]
-name = "pulp-wasm-simd-flag"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "quick-error"
@@ -5001,7 +4729,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5036,16 +4764,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -5056,29 +4774,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "rand_core"
@@ -5094,6 +4793,12 @@ checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "ratatui"
@@ -5210,65 +4915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools 0.14.0",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.5",
- "rand_chacha",
- "simd_helpers",
- "thiserror 2.0.20",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5308,17 +4954,6 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.40.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
-dependencies = [
- "bytemuck",
- "font-types",
- "once_cell",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
@@ -5327,12 +4962,6 @@ dependencies = [
  "font-types",
  "once_cell",
 ]
-
-[[package]]
-name = "reborrow"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -5391,12 +5020,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -5436,10 +5071,11 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
 dependencies = [
+ "bytemuck",
  "gif",
  "image-webp",
  "log",
@@ -5476,12 +5112,13 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+checksum = "14b574c58582fa59fa43a2feb6608b8744184659f08a2e0117e4b8224d95ed61"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
+ "memoffset",
  "rustc-hash 1.1.0",
  "text-size",
 ]
@@ -5558,7 +5195,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5615,7 +5252,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5641,24 +5278,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "rustybuzz"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
-dependencies = [
- "bitflags 2.13.1",
- "bytemuck",
- "core_maths",
- "log",
- "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
 
 [[package]]
 name = "ryu"
@@ -5929,15 +5548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5960,9 +5570,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
+checksum = "eb325787c91b3f6c34a7c6f2b8a2297b20292d733ca53a08c233e5028aec49af"
 dependencies = [
  "bindgen",
  "cc",
@@ -5977,23 +5587,13 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
+checksum = "c61cb643dac43067f3eb76c866635a74377ac0abca0ff2590674e1e295514c3d"
 dependencies = [
  "bitflags 2.13.1",
  "skia-bindings",
  "windows",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
-dependencies = [
- "bytemuck",
- "read-fonts 0.40.2",
 ]
 
 [[package]]
@@ -6003,7 +5603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
- "read-fonts 0.41.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -6015,9 +5615,10 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slint"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "const-field-offset",
+ "i-slint-backend-linuxkms",
  "i-slint-backend-selector",
  "i-slint-common",
  "i-slint-core",
@@ -6035,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "slint-build"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "derive_more",
  "fontique",
@@ -6047,7 +5648,7 @@ dependencies = [
 [[package]]
 name = "slint-macros"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -6142,7 +5743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6184,6 +5785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076e103ed41b9864aa838287efe5f4e3a7a0362dd00671ae62a212e5e4612da2"
 dependencies = [
  "pin-utils",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -6268,7 +5878,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2499c2d826531388872b2268718aed907a39bd785ab0dcfe57fab26283f92e"
 dependencies = [
- "skrifa 0.44.0",
+ "skrifa",
  "yazi",
  "zeno",
 ]
@@ -6413,7 +6023,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6426,7 +6036,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6457,7 +6067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "fancy-regex 0.11.0",
  "filedescriptor",
@@ -6545,20 +6155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
 ]
 
 [[package]]
@@ -6950,9 +6546,6 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-dependencies = [
- "core_maths",
-]
 
 [[package]]
 name = "typed-index-collections"
@@ -6996,7 +6589,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7012,18 +6605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7034,12 +6615,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -7114,26 +6689,26 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "data-url",
  "flate2",
  "fontdb",
+ "harfrust",
  "imagesize",
  "kurbo",
  "log",
  "pico-args",
  "roxmltree",
- "rustybuzz",
  "simplecss",
  "siphasher",
+ "skrifa",
  "strict-num",
  "svgtypes",
  "tiny-skia-path 0.12.0",
- "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -7167,17 +6742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7192,7 +6756,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vtable"
 version = "0.5.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -7203,11 +6767,11 @@ dependencies = [
 [[package]]
 name = "vtable-macro"
 version = "0.5.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=1d33287ec016e2e971912bfd648c1838a2c38032#1d33287ec016e2e971912bfd648c1838a2c38032"
+source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7554,6 +7118,152 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "log",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "naga",
+ "naga-types",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.20",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f3d319a40d39d00b1ecc2c33b89fe21d4e6fe01859df3500a3a8ecccd6b68"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.10.0",
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "gpu-allocator",
+ "hashbrown 0.17.1",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "naga-types",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "static_assertions",
+ "thiserror 2.0.20",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "log",
+ "naga-types",
+ "raw-window-handle",
+ "static_assertions",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7575,7 +7285,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8023,15 +7733,15 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.49.2"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f3a5b8704f80b1cbe2fa5590b8aeda7e4b7c715de0a4266674a2f899fcf2a8"
+checksum = "cae90d1d9f6d1d36ef116b0b1e651a6d7c12ba925439d4d06ff9adc94662a3d8"
 dependencies = [
  "font-types",
  "indexmap",
  "kurbo",
  "log",
- "read-fonts 0.40.2",
+ "read-fonts",
 ]
 
 [[package]]
@@ -8138,12 +7848,6 @@ dependencies = [
  "minijinja",
  "serde_json",
 ]
-
-[[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yazi"
@@ -8370,15 +8074,6 @@ name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "zune-jpeg"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,7 @@ sublime_fuzzy.workspace = true
 sysinfo = "0.39.6"
 tar = "0.4.46"
 thiserror = "2.0.20"
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "io-util", "fs", "sync", "time", "process"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "io-util", "fs", "sync", "time", "process", "net"] }
 tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -203,8 +203,10 @@ async fn install(
     // ── Phase 0: Pre-installation checks ───────────────────────
     tracing::info!("Phase 0: Pre-installation checks");
 
-    if !crate::system::net::check_internet() {
-        bail!("No internet connectivity. Connect to the network and retry.");
+    if !crate::system::net::check_internet().await {
+        bail!(
+            "Could not verify internet access via ping.archlinux.org. Check your connection, DNS or captive portal and retry."
+        );
     }
     tracing::info!("Internet connectivity OK");
 

--- a/core/src/installer/aur.rs
+++ b/core/src/installer/aur.rs
@@ -175,10 +175,14 @@ const SOURCE_CACHE_DIR: &str = "var/cache/archinstall-zfs/sources";
 /// makepkg still verifies the checksums the PKGBUILD declares, so a stale file
 /// costs a download rather than a wrong build.
 fn configure_source_cache(target: &Path) -> Result<()> {
-    let Some(source) = std::env::var_os("ARCHINSTALL_ZFS_SRCDEST").filter(|v| !v.is_empty()) else {
+    let source = std::env::var_os("ARCHINSTALL_ZFS_SRCDEST");
+    configure_source_cache_from(target, source.as_deref().map(Path::new))
+}
+
+fn configure_source_cache_from(target: &Path, source: Option<&Path>) -> Result<()> {
+    let Some(source) = source.filter(|path| !path.as_os_str().is_empty()) else {
         return Ok(());
     };
-    let source = Path::new(&source);
     if !source.is_dir() {
         tracing::warn!(
             path = %source.display(),
@@ -340,11 +344,7 @@ mod tests {
         std::fs::write(medium.path().join("zfsbootmenu-v3.1.0.tar.gz"), b"tarball").unwrap();
         std::fs::create_dir(medium.path().join("a-directory")).unwrap();
 
-        // SAFETY: single-threaded test; the variable is read straight after.
-        unsafe { std::env::set_var("ARCHINSTALL_ZFS_SRCDEST", medium.path()) };
-        let result = configure_source_cache(target.path());
-        unsafe { std::env::remove_var("ARCHINSTALL_ZFS_SRCDEST") };
-        result.unwrap();
+        configure_source_cache_from(target.path(), Some(medium.path())).unwrap();
 
         let copied = target
             .path()
@@ -373,9 +373,7 @@ mod tests {
     fn without_a_source_cache_nothing_is_configured() {
         let target = tempfile::tempdir().unwrap();
 
-        // SAFETY: single-threaded test.
-        unsafe { std::env::remove_var("ARCHINSTALL_ZFS_SRCDEST") };
-        configure_source_cache(target.path()).unwrap();
+        configure_source_cache_from(target.path(), None).unwrap();
 
         assert!(!target.path().join("etc/makepkg.conf.d").exists());
     }

--- a/core/src/system/net.rs
+++ b/core/src/system/net.rs
@@ -1,12 +1,83 @@
-use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
 
-/// Check internet connectivity by attempting a TCP connection to a well-known
-/// DNS server (Cloudflare 1.1.1.1:53). No TLS or HTTP involved — works on
-/// minimal ISOs without root certificates.
-pub fn check_internet() -> bool {
-    let addr: SocketAddr = ([1, 1, 1, 1], 53).into();
-    TcpStream::connect_timeout(&addr, Duration::from_secs(5)).is_ok()
+/// Arch's connectivity endpoint, also used by its NetworkManager package.
+pub const CONNECTIVITY_URL: &str = "http://ping.archlinux.org/nm-check.txt";
+const EXPECTED_RESPONSE: &[u8] = b"NetworkManager is online\n";
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, thiserror::Error)]
+enum ProbeError {
+    #[error("connectivity request failed: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("connectivity endpoint returned HTTP {0}")]
+    Status(reqwest::StatusCode),
+    #[error("unexpected connectivity response (possible captive portal)")]
+    UnexpectedResponse,
+}
+
+/// Verify Arch's HTTP response rather than access to an external DNS server.
+/// DNS resolution and connection fallback support both IPv4 and IPv6. Plain
+/// HTTP works before the live ISO has synchronized its clock; redirects and
+/// captive-portal pages must not be mistaken for a successful check.
+pub async fn check_internet() -> bool {
+    match probe(CONNECTIVITY_URL, PROBE_TIMEOUT).await {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(url = CONNECTIVITY_URL, ?error, "Internet check failed");
+            false
+        }
+    }
+}
+
+/// Allow address assignment, routes and DNS to settle after Wi-Fi association.
+/// The budget covers requests and delays; dropping the future cancels retries.
+pub async fn wait_for_internet(budget: Duration) -> bool {
+    wait_for_probe(budget, check_internet).await
+}
+
+async fn wait_for_probe<F, Fut>(budget: Duration, mut check: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    tokio::time::timeout(budget, async {
+        loop {
+            if check().await {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .unwrap_or(false)
+}
+
+async fn probe(url: &str, timeout: Duration) -> Result<(), ProbeError> {
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(timeout)
+        .build()?;
+    probe_with_client(&client, url).await
+}
+
+async fn probe_with_client(client: &reqwest::Client, url: &str) -> Result<(), ProbeError> {
+    let mut response = client.get(url).send().await?;
+    if response.status() != reqwest::StatusCode::OK {
+        return Err(ProbeError::Status(response.status()));
+    }
+
+    // Bound memory even if a portal returns a large or endless HTML document.
+    let mut body = Vec::with_capacity(EXPECTED_RESPONSE.len());
+    while let Some(chunk) = response.chunk().await? {
+        if body.len() + chunk.len() > EXPECTED_RESPONSE.len() {
+            return Err(ProbeError::UnexpectedResponse);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    if body != EXPECTED_RESPONSE {
+        return Err(ProbeError::UnexpectedResponse);
+    }
+    Ok(())
 }
 
 pub fn is_uefi() -> bool {
@@ -17,8 +88,130 @@ pub fn is_uefi() -> bool {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_check_internet_does_not_panic() {
-        let _ = check_internet();
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn server(
+        address: &str,
+        response: &'static str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind(address).await.unwrap();
+        let url = format!("http://{}/nm-check.txt", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let len = socket.read(&mut request).await.unwrap();
+            assert!(request[..len].starts_with(b"GET /nm-check.txt HTTP/1.1\r\n"));
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        (url, task)
+    }
+
+    const ONLINE: &str = "HTTP/1.1 200 OK\r\nContent-Length: 25\r\nConnection: close\r\n\r\nNetworkManager is online\n";
+
+    #[tokio::test]
+    async fn accepts_arch_response_over_ipv4() {
+        let (url, task) = server("127.0.0.1:0", ONLINE).await;
+        probe(&url, PROBE_TIMEOUT).await.unwrap();
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn accepts_arch_response_over_ipv6() {
+        // Some CI runners and live systems explicitly disable IPv6.
+        let availability = TcpListener::bind("[::1]:0").await;
+        if let Err(error) = availability {
+            eprintln!("IPv6 loopback unavailable, skipping IPv6 probe: {error}");
+            return;
+        }
+        drop(availability);
+        let (url, task) = server("[::1]:0", ONLINE).await;
+        probe(&url, PROBE_TIMEOUT).await.unwrap();
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_ipv4_when_ipv6_is_unreachable() {
+        let (url, task) = server("127.0.0.1:0", ONLINE).await;
+        let port = reqwest::Url::parse(&url).unwrap().port().unwrap();
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .timeout(PROBE_TIMEOUT)
+            .resolve_to_addrs(
+                "probe.test",
+                &[
+                    std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port)),
+                    std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port)),
+                ],
+            )
+            .build()
+            .unwrap();
+        probe_with_client(&client, &format!("http://probe.test:{port}/nm-check.txt"))
+            .await
+            .unwrap();
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_portals_redirects_and_server_errors() {
+        for response in [
+            "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nLogin",
+            "HTTP/1.1 200 OK\r\nContent-Length: 26\r\n\r\nNetworkManager is online\n!",
+            "HTTP/1.1 302 Found\r\nLocation: /login\r\nContent-Length: 0\r\n\r\n",
+            "HTTP/1.1 503 Unavailable\r\nContent-Length: 25\r\n\r\nNetworkManager is online\n",
+            "HTTP/1.1 204 No Content\r\n\r\n",
+        ] {
+            let (url, task) = server("127.0.0.1:0", response).await;
+            assert!(probe(&url, PROBE_TIMEOUT).await.is_err());
+            task.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn bounds_time_waiting_for_response_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/nm-check.txt", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            assert!(socket.read(&mut request).await.unwrap() > 0);
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 25\r\n\r\n")
+                .await
+                .unwrap();
+            std::future::pending::<()>().await;
+        });
+        let result = probe(&url, Duration::from_millis(100)).await;
+        assert!(matches!(result, Err(ProbeError::Request(error)) if error.is_timeout()));
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn reports_connection_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/nm-check.txt", listener.local_addr().unwrap());
+        drop(listener);
+        assert!(matches!(
+            probe(&url, PROBE_TIMEOUT).await,
+            Err(ProbeError::Request(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn retries_until_network_is_ready() {
+        let mut attempts = 0;
+        let online = wait_for_probe(Duration::from_secs(3), || {
+            attempts += 1;
+            std::future::ready(attempts == 2)
+        })
+        .await;
+        assert!(online);
+        assert_eq!(attempts, 2);
+    }
+
+    #[tokio::test]
+    async fn retry_budget_cancels_a_pending_probe() {
+        let online = wait_for_probe(Duration::from_millis(20), std::future::pending::<bool>).await;
+        assert!(!online);
     }
 }

--- a/core/src/system/wifi/iwd.rs
+++ b/core/src/system/wifi/iwd.rs
@@ -173,9 +173,9 @@ pub async fn scan_networks() -> Result<Vec<WifiNetwork>, WifiError> {
 /// Connect to `ssid` by triggering iwd's connect flow and providing
 /// `passphrase` via a registered one-shot agent.
 ///
-/// For open networks `passphrase` may be `None`. For secured networks
-/// `passphrase` must be `Some(...)`; omitting it returns
-/// `WifiError::PassphraseRequired`.
+/// Saved networks reuse iwd's credentials when `passphrase` is `None`.
+/// Unknown secured networks require a passphrase. An already-connected
+/// network is left connected, including when it was joined through iwctl.
 ///
 /// Returns once iwd reports the connect call complete — success means
 /// the station reached the Connected state at layer 2. Callers that
@@ -189,13 +189,24 @@ pub async fn connect(ssid: &str, passphrase: Option<String>) -> Result<(), WifiE
         .await?
         .ok_or_else(|| WifiError::NetworkNotFound(ssid.to_string()))?;
 
+    if network.connected().await.map_err(WifiError::Dbus)? {
+        return Ok(());
+    }
+
     let security: Security = network
         .network_type()
         .await
         .map(Security::from)
         .unwrap_or(Security::Open);
 
-    if security.requires_passphrase() && passphrase.is_none() {
+    if security.requires_passphrase()
+        && passphrase.is_none()
+        && network
+            .known_network()
+            .await
+            .map_err(WifiError::Dbus)?
+            .is_none()
+    {
         return Err(WifiError::PassphraseRequired(ssid.to_string()));
     }
 

--- a/core/src/system/wifi/mock.rs
+++ b/core/src/system/wifi/mock.rs
@@ -30,7 +30,7 @@
 //! requires a passphrase; the mock treats any non-empty string as
 //! correct and any empty or missing string as `PassphraseRequired`.
 
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use futures::stream;
@@ -42,7 +42,7 @@ use super::{KnownNetworkInfo, Security, StationState, StationStateStream, WifiEr
 /// Global mutable state for the mock backend. A single `Mutex<State>`
 /// is fine because the installer has exactly one wifi client and we
 /// never hit any lock contention worth measuring.
-static STATE: Mutex<State> = Mutex::new(State::new());
+static STATE: LazyLock<Mutex<State>> = LazyLock::new(|| Mutex::new(State::new()));
 
 struct State {
     connected_ssid: Option<String>,
@@ -53,10 +53,10 @@ struct State {
 }
 
 impl State {
-    const fn new() -> Self {
+    fn new() -> Self {
         Self {
             connected_ssid: None,
-            known: Vec::new(),
+            known: vec!["HomeNetwork".into()],
         }
     }
 }
@@ -66,10 +66,7 @@ fn canned_networks() -> Vec<WifiNetwork> {
         let g = STATE.lock().unwrap();
         g.known.clone()
     };
-    // Preseed HomeNetwork as known on every scan so the first run
-    // after process start already shows the Known badge without
-    // needing a previous connect.
-    let is_known = |ssid: &str| ssid == "HomeNetwork" || known.iter().any(|s| s == ssid);
+    let is_known = |ssid: &str| known.iter().any(|s| s == ssid);
 
     vec![
         WifiNetwork {
@@ -220,22 +217,15 @@ pub async fn watch_station_state() -> Result<StationStateStream, WifiError> {
 
 pub async fn list_known_networks() -> Result<Vec<KnownNetworkInfo>, WifiError> {
     let g = STATE.lock().unwrap();
-    // Always include HomeNetwork (seeded) plus anything connected in
-    // this process's lifetime.
-    let mut out = vec![KnownNetworkInfo {
-        ssid: "HomeNetwork".into(),
-        security: Security::Psk,
-        hidden: false,
-    }];
-    for ssid in &g.known {
-        if ssid != "HomeNetwork" {
-            out.push(KnownNetworkInfo {
-                ssid: ssid.clone(),
-                security: Security::Psk,
-                hidden: false,
-            });
-        }
-    }
+    let mut out: Vec<_> = g
+        .known
+        .iter()
+        .map(|ssid| KnownNetworkInfo {
+            ssid: ssid.clone(),
+            security: Security::Psk,
+            hidden: false,
+        })
+        .collect();
     out.sort_by(|a, b| a.ssid.cmp(&b.ssid));
     Ok(out)
 }

--- a/core/tests/wifi_iwd.rs
+++ b/core/tests/wifi_iwd.rs
@@ -1,0 +1,153 @@
+//! Exercise the real iwd backend on a private D-Bus, without host Wi-Fi changes.
+#![cfg(feature = "wifi-iwd")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use archinstall_zfs_core::system::wifi::{self, WifiError};
+use zbus::zvariant::OwnedObjectPath;
+
+fn path(name: &str) -> OwnedObjectPath {
+    format!("/net/connman/iwd/{name}").try_into().unwrap()
+}
+
+struct Station;
+
+#[zbus::interface(name = "net.connman.iwd.Station")]
+impl Station {
+    fn get_ordered_networks(&self) -> Vec<(OwnedObjectPath, i16)> {
+        ["Saved", "Unknown", "Open", "Connected"]
+            .into_iter()
+            .map(|name| (path(name), -5000))
+            .collect()
+    }
+}
+
+struct Network {
+    name: &'static str,
+    calls: Arc<AtomicUsize>,
+}
+
+#[zbus::interface(name = "net.connman.iwd.Network")]
+impl Network {
+    fn connect(&self) {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[zbus(property)]
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    #[zbus(property, name = "Type")]
+    fn security(&self) -> &str {
+        if self.name == "Open" { "open" } else { "psk" }
+    }
+
+    #[zbus(property)]
+    fn connected(&self) -> bool {
+        self.name == "Connected"
+    }
+
+    #[zbus(property)]
+    fn known_network(&self) -> zbus::fdo::Result<OwnedObjectPath> {
+        if self.name == "Saved" || self.name == "Connected" {
+            Ok(path("profile"))
+        } else {
+            Err(zbus::fdo::Error::UnknownProperty("KnownNetwork".into()))
+        }
+    }
+}
+
+struct KnownNetwork;
+
+#[zbus::interface(name = "net.connman.iwd.KnownNetwork")]
+impl KnownNetwork {
+    #[zbus(property)]
+    fn name(&self) -> &str {
+        "Saved"
+    }
+}
+
+struct AgentManager;
+
+#[zbus::interface(name = "net.connman.iwd.AgentManager")]
+impl AgentManager {
+    fn register_agent(&self, _agent: OwnedObjectPath) {}
+    fn unregister_agent(&self, _agent: OwnedObjectPath) {}
+}
+
+#[test]
+fn saved_and_connected_networks_do_not_require_a_new_password() {
+    // Set the bus address only in a child process. Changing the process-wide
+    // environment inside a concurrent Rust test runner would be unsafe.
+    let output = std::process::Command::new("dbus-run-session")
+        .args([
+            "--",
+            "sh",
+            "-c",
+            "DBUS_SYSTEM_BUS_ADDRESS=\"$DBUS_SESSION_BUS_ADDRESS\" exec \"$@\"",
+            "sh",
+        ])
+        .arg(std::env::current_exe().unwrap())
+        .args(["--exact", "private_bus_worker", "--ignored", "--nocapture"])
+        .env("AZFS_TEST_PRIVATE_BUS", "1")
+        .output()
+        .expect("dbus-run-session is required for iwd integration tests");
+    assert!(
+        output.status.success(),
+        "private iwd test failed:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[tokio::test]
+#[ignore = "run by the parent test in a private D-Bus session"]
+async fn private_bus_worker() {
+    assert_eq!(std::env::var("AZFS_TEST_PRIVATE_BUS").as_deref(), Ok("1"));
+    tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        let calls: Vec<_> = (0..4).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+        let mut builder = zbus::connection::Builder::system()
+            .unwrap()
+            .name("net.connman.iwd")
+            .unwrap()
+            .serve_at("/", zbus::fdo::ObjectManager)
+            .unwrap()
+            .serve_at(path("station"), Station)
+            .unwrap()
+            .serve_at("/net/connman/iwd", AgentManager)
+            .unwrap()
+            .serve_at(path("profile"), KnownNetwork)
+            .unwrap();
+        for (name, calls) in ["Saved", "Unknown", "Open", "Connected"]
+            .into_iter()
+            .zip(&calls)
+        {
+            builder = builder
+                .serve_at(
+                    path(name),
+                    Network {
+                        name,
+                        calls: calls.clone(),
+                    },
+                )
+                .unwrap();
+        }
+        let _service = builder.build().await.unwrap();
+
+        wifi::connect("Saved", None).await.unwrap();
+        assert_eq!(calls[0].load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            wifi::connect("Unknown", None).await,
+            Err(WifiError::PassphraseRequired(_))
+        ));
+        assert_eq!(calls[1].load(Ordering::SeqCst), 0);
+        wifi::connect("Open", None).await.unwrap();
+        assert_eq!(calls[2].load(Ordering::SeqCst), 1);
+        wifi::connect("Connected", None).await.unwrap();
+        assert_eq!(calls[3].load(Ordering::SeqCst), 0);
+    })
+    .await
+    .expect("iwd test timed out");
+}

--- a/gen_iso/profile/packages.x86_64.j2
+++ b/gen_iso/profile/packages.x86_64.j2
@@ -85,7 +85,7 @@ libusb-compat
 linux-atm
 linux-firmware
 {% if kernel == "linux" %}
-broadcom-wl
+broadcom-wl-dkms
 b43-fwcutter
 {% endif %}
 {% if use_precompiled_zfs %}
@@ -94,9 +94,10 @@ zfs-utils
 {% else %}
 zfs-dkms
 zfs-utils
-{% if include_headers %}
-{{ headers }}
 {% endif %}
+{# Broadcom also needs headers when ZFS uses a precompiled module. #}
+{% if include_headers or kernel == "linux" %}
+{{ headers }}
 {% endif %}
 linux-firmware-marvell
 livecd-sounds

--- a/slint-ui/Cargo.toml
+++ b/slint-ui/Cargo.toml
@@ -44,10 +44,7 @@ clap.workspace = true
 color-eyre.workspace = true
 crossbeam-channel = "0.5.16"
 nix.workspace = true
-slint = { git = "https://github.com/okhsunrog/slint.git", rev = "1d33287ec016e2e971912bfd648c1838a2c38032", default-features = false, features = [
-    "std",
-    "compat-1-2",
-] }
+slint = { git = "https://github.com/okhsunrog/slint.git", rev = "d6b44e120", default-features = false, features = ["std", "compat-1-2"], version = "1.18.0" }
 sublime_fuzzy.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros"] }
 tokio-util.workspace = true
@@ -58,4 +55,4 @@ zfskit = "0.2.0"
 zxcvbn.workspace = true
 
 [build-dependencies]
-slint-build = { git = "https://github.com/okhsunrog/slint.git", rev = "1d33287ec016e2e971912bfd648c1838a2c38032" }
+slint-build = { git = "https://github.com/okhsunrog/slint.git", rev = "d6b44e120", version = "1.18.0" }

--- a/slint-ui/README.md
+++ b/slint-ui/README.md
@@ -1,0 +1,72 @@
+# Graphical installer development
+
+Use the deterministic preview to review the installer without root, ZFS, disks,
+iwd, NetworkManager, or internet access. The preview uses the real components and
+editing controllers with simulated inventory and installation callbacks.
+
+```sh
+SLINT_EMIT_DEBUG_INFO=1 cargo build -p archinstall-zfs-slint \
+  --no-default-features --features desktop-mock,slint/mcp
+SLINT_BACKEND=headless SLINT_MCP_PORT=9315 target/debug/azfs \
+  --preview welcome --preview-size 1280x800
+```
+
+Omit `SLINT_BACKEND=headless` to interact in a desktop window. To reproduce a
+1920×1080 display with a 200% UI scale, use `--preview-size 1920x1080 --ui-scale 2`.
+
+Preview scenes: `welcome`, `offline`, `disk`, `new-pool`, `existing-pool`, `zfs`,
+`system`, `users`, `desktop`, `review`, `install`, `done`, `failed`, `cancelled`,
+`inspect` (simulated pool import, export, and selection), and `invalid` (an
+incomplete configuration for validation checks).
+The three simulated drives include NVMe, SATA, and removable USB, with long serials
+and persistent paths. Each drive has two simulated partitions. The wizard starts
+with a configured user, KDE Plasma, packages, and services; edits remain interactive.
+Wi-Fi uses the existing mock backend, including known, secured, open, and enterprise
+networks. Installation advances through simulated phases and supports cancellation.
+
+`--preview` is accepted only by a `desktop-mock` build and conflicts with `--config`,
+`--secrets`, `--silent`, and `--demo`. It replaces system probes, storage enumeration,
+package searches, installation, and reboot. No installation or storage commands are
+started. Logs are still written to `/tmp`.
+
+Capture all scenes at four display configurations:
+
+```sh
+uv run slint-ui/scripts/review.py --output /tmp/azfs-ui-review
+```
+
+The output contains PNG screenshots, JSON element trees, process logs, and an
+`index.html` gallery. Open the images and inspect them; successful capture does not
+establish that a layout is correct. Use `--scenes disk review` or
+`--sizes 800x600@1 1920x1080@2` to narrow a repeat run.
+
+Run repeatable interaction checks at 800×600 and 1920×1080 with 200% scale:
+
+```sh
+uv run slint-ui/scripts/interactions.py --output /tmp/azfs-ui-interactions
+```
+
+These cover editing, focus recovery, keyboard scrolling, Wi-Fi credentials,
+forget/reconnect/disconnect, enterprise errors, pool inspection, installation
+progress, completion, and cancellation. All input values are disposable fixtures.
+
+For additional interaction checks, use Slint MCP's `get_element_tree`, `click_element`,
+`set_element_value`, and `dispatch_key_event`. Check password entry, Wi-Fi connect,
+verification, success, disconnect, forget, and unsupported enterprise networks.
+Check keyboard navigation and every popup at the smallest supported window size.
+
+The preview exercises desktop rendering. Validate input isolation and cursor
+rendering separately with the default LinuxKMS build in a VM or on the target
+machine. Start it from an actual VT shell to test that GUI keystrokes cannot reach
+the shell after exit.
+
+The KMS backend disables VT keyboard translation while rendering and restores it
+on exit. A small installer supervisor also flushes input and restores keyboard
+and display modes when the GUI process aborts or receives SIGKILL. It forwards
+SIGINT, SIGTERM, SIGHUP, and SIGQUIT to the GUI. Run this before starting any threads.
+The supervisor must remain alive for crash recovery; SIGKILL of both processes
+cannot run userspace cleanup.
+
+Libinput uses neutral pointer acceleration by default. Override it with
+`SLINT_LIBINPUT_ACCEL_SPEED=0.3` (finite values from -1 to 1). Test the resulting
+feel on the target mouse or touchpad; headless rendering cannot validate it.

--- a/slint-ui/UI_REVIEW.md
+++ b/slint-ui/UI_REVIEW.md
@@ -1,0 +1,58 @@
+# UI and LinuxKMS review — 2026-09-09
+
+The original LinuxKMS build reproduced the reported console input leak in an
+UEFI QEMU guest: text entered while the GUI was running became a shell command
+after the GUI closed. A disposable marker-file command was used, never a real
+credential.
+
+The updated backend disables VT keyboard translation while libinput owns input.
+The installer supervisor also recovers the VT after abnormal GUI termination.
+The same guest checks cover normal exit, SIGKILL of the GUI child, and SIGTERM of
+the supervisor. No marker command reached the shell; UTF-8 keyboard mode was
+restored, and a separate command entered after exit still worked.
+
+The Slint branch `feat/renderer-skia-software-linuxkms` was rebased onto upstream
+`12acf1a25ad09d5384c14fc7330d4040790e729e`. Its resulting revision is
+`d6b44e120`. Cursor damage is now registered before Skia determines the partial
+rendering clip. A real software-Skia pixel regression test compares incremental
+frames against full repaint during movement, edge clipping, fractional positions,
+and hiding. It fails with the old damage ordering and passes with the fix.
+
+The installer changes address:
+
+- Icon centering, welcome status rows, and network indicator alignment.
+- A compact connection-success view with Done as the primary action and a
+  consistently positioned Close button. Disconnect is in network management.
+- Cancellation and stale async results during network scanning, disconnect, and
+  forgetting saved networks. Mock forget now removes the saved profile.
+- Consistent disk model, capacity, device-node, serial, and persistent-path rows.
+- Wizard content width, sidebar spacing, footer alignment, focus restoration,
+  keyboard scrolling, and wrapped validation messages.
+- Package-search activation, pool action alignment, and installation progress
+  positioned above the log.
+- Password-strength scoring moved off the UI thread, with debouncing and stale
+  result checks after editing, clearing, and reopening dialogs.
+
+`scripts/review.py` captures the actual Slint components for all preview scenes
+at 800×600 and 1280×800 with scale 1, and 1920×1080 with scales 1.5 and 2.
+Window metadata is saved and the actual scale is asserted: the headless backend
+requires an explicit scale-change event, unlike desktop backends.
+
+`scripts/interactions.py` drives editing, filtering, keyboard navigation, all
+network transitions, pool import/export, installation completion/cancellation,
+and invalid-configuration blocking. It saves screenshots of the intermediate
+states for visual inspection. The preview replaces hardware and installation
+operations while retaining the real editing and validation logic.
+
+Run `just check` for the repository's formatting, clippy, tests, feature checks,
+and dependency audit. The lockfile upgrades h2 to 0.4.16, resolving the advisory
+that failed main's audit job. Audit still reports non-fatal third-party
+maintenance/yank warnings; they are not suppressed.
+The final test run also exposed two AUR cache tests racing through a shared
+environment variable. They now pass explicit cache paths without mutating the
+process environment; the full workspace tests pass with parallel execution.
+
+The VM does not reproduce the physical Synaptics touchpad. Pointer acceleration
+now starts at libinput's neutral speed and supports an environment override;
+the resulting feel and physical display-driver behavior still require testing
+on the laptop. These checks do not constitute a complete disk installation test.

--- a/slint-ui/scripts/interactions.py
+++ b/slint-ui/scripts/interactions.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env -S uv run
+"""Exercise actual UI callbacks on preview fixtures and save review screenshots."""
+import argparse
+from pathlib import Path
+import time
+
+from review import Preview
+
+
+def system(p):
+    p.click('Button', 'Hostname')
+    p.fill(0, 'arch-workstation-long-name')
+    p.screenshot('hostname')
+    p.click('Button', 'OK')
+    p.click('Button', 'Kernel')
+    p.screenshot('kernel')
+    p.click('ListItem', 'linux — compatible')
+    p.click('Button', 'Locale')
+    p.fill(0, 'ru_RU')
+    p.screenshot('locale-filter')
+    p.click('ListItem', 'ru_RU.UTF-8')
+    p.key('5')
+    p.wait('Text', '4 / 6')
+
+
+def users(p):
+    p.click('Button', 'Root password')
+    p.fill(0, 'short')
+    time.sleep(.5)
+    p.screenshot('root-password-weak')
+    p.fill(0, 'a long preview passphrase for testing')
+    p.fill(0, '')
+    time.sleep(.5)
+    assert p.element('Text', 'Very weak') is None
+    assert p.element('Text', 'Very strong') is None
+    p.screenshot('root-password-cleared')
+    p.click('Button', 'Cancel')
+    p.click('Button', 'User accounts')
+    p.screenshot('users-dialog')
+    p.fill(0, 'previewuser')
+    p.fill(1, 'a long preview passphrase for testing')
+    time.sleep(.5)
+    p.screenshot('users-filled')
+    p.click('Button', 'Add user')
+    p.wait('Text', 'previewuser')
+    p.screenshot('users-added')
+    p.click('Button', 'Done')
+
+
+def desktop(p):
+    p.click('Button', 'Profile')
+    p.screenshot('profile')
+    p.click('ListItem', 'KDE Plasma')
+    p.click('Button', 'Optional packages')
+    p.screenshot('optional-packages')
+    p.click('Button', 'Done')
+    for _ in range(9):
+        p.key('j')
+    p.screenshot('desktop-scrolled')
+    p.click('Button', 'Extra packages')
+    p.fill(0, 'fire')
+    p.wait('Text', 'firefox')
+    p.screenshot('packages')
+    p.click('Button', 'Done')
+    p.click('Button', 'Extra services')
+    p.fill(0, 'cups')
+    p.click('Button', 'Add')
+    p.wait('Text', 'cups')
+    p.screenshot('services-added')
+    p.click('Button', 'Done')
+
+
+def wifi(p):
+    p.click('Button', 'Network settings')
+    p.wait('ListItem', 'HomeNetwork')
+    p.screenshot('wifi-picking')
+    p.click('Button', 'Forget HomeNetwork')
+    time.sleep(2)
+    p.click('ListItem', 'HomeNetwork')
+    p.wait('Button', 'Connect')  # forgotten network must ask for a password
+    p.screenshot('wifi-forgotten-auth')
+    p.click('Button', 'Cancel')
+    p.click('Button', 'Rescan')
+    p.wait('ListItem', 'Neighbour 5G')
+    p.click('ListItem', 'Neighbour 5G')
+    p.fill(0, 'preview-only-passphrase')
+    p.screenshot('wifi-password')
+    p.click('Button', 'Connect')
+    p.screenshot('wifi-connecting')
+    p.wait('Button', 'Other networks')
+    assert p.element('Button', 'Disconnect') is None
+    p.screenshot('wifi-connected')
+    p.click('Button', 'Done')
+    assert p.element('Groupbox', 'Network management') is None
+    p.click('Button', 'Network settings')
+    p.wait('Button', 'Disconnect')
+    p.screenshot('wifi-management')
+    p.click('Button', 'Disconnect')
+    p.wait('ListItem', 'CorpNet')
+    p.click('ListItem', 'CorpNet')
+    p.wait('Button', 'Back')
+    p.screenshot('wifi-enterprise-error')
+    p.click('Button', 'Back')
+    p.click('ListItem', 'Neighbour 5G')  # saved profile must skip auth
+    p.wait('Button', 'Other networks')
+    p.key('\n')
+    assert p.element('Groupbox', 'Network management') is None
+
+
+def inspect(p):
+    p.click('Button', 'Import read-only')
+    p.wait('Text', 'read-only demo import')
+    p.screenshot('pool-imported')
+    p.click('Button', 'Export')
+    p.wait('Button', 'Import read-only')
+    p.click('Button', 'Use')
+    assert p.element('Button', 'Refresh') is None
+
+
+def install(p):
+    p.click('Button', 'Install')
+    p.wait('Button', 'Cancel installation')
+    p.screenshot('installation-started')
+    p.wait('Button', 'Reboot')
+    p.screenshot('installation-complete')
+
+
+def cancel(p):
+    p.click('Button', 'Cancel installation')
+    p.wait('Text', 'Cancelled')
+    p.screenshot('installation-cancelled')
+
+
+def invalid(p):
+    p.click('Button', 'Install')
+    p.wait('Text', 'Validation:')
+    assert p.element('Button', 'Cancel installation') is None
+    p.screenshot('validation-blocks-installation')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, default=Path('target/debug/azfs'))
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--sizes', nargs='+', default=['800x600@1', '1920x1080@2'])
+    flows = ['system', 'users', 'desktop', 'wifi', 'inspect', 'install', 'cancel', 'invalid']
+    parser.add_argument('--flows', nargs='+', choices=flows, default=flows)
+    args = parser.parse_args()
+    for spec in args.sizes:
+        size, scale = spec.split('@')
+        for flow in args.flows:
+            output = args.output / spec / flow
+            output.mkdir(parents=True, exist_ok=True)
+            scene = {'wifi': 'offline', 'install': 'review', 'cancel': 'install'}.get(flow, flow)
+            p = Preview(args.binary.resolve(), scene, size, scale, output)
+            try:
+                p.ready()
+                globals()[flow](p)
+                print(f'PASS {spec} {flow}', flush=True)
+            except Exception:
+                p.screenshot('failure')
+                raise
+            finally:
+                p.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/slint-ui/scripts/review.py
+++ b/slint-ui/scripts/review.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env -S uv run
+"""Capture the real Slint UI on deterministic fixtures; never starts an install.
+
+Build with SLINT_EMIT_DEBUG_INFO=1 and desktop-mock,slint/mcp first.
+Run: uv run slint-ui/scripts/review.py --output /tmp/azfs-ui-review
+"""
+import argparse
+import base64
+import html
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+SCENES = 'welcome offline disk new-pool existing-pool zfs system users desktop review install done failed cancelled inspect invalid'.split()
+
+class Preview:
+    def __init__(self, binary, scene, size, scale, output):
+        self.output = output
+        self.label = f'{scene}-{size}-{scale}x'
+        self.scale = float(scale)
+        with socket.socket() as sock:
+            sock.bind(('127.0.0.1', 0))
+            self.port = sock.getsockname()[1]
+        self.log = (output / f'{self.label}.log').open('w')
+        env = dict(os.environ, SLINT_BACKEND='headless', SLINT_MCP_PORT=str(self.port))
+        self.process = subprocess.Popen([str(binary), '--preview', scene, '--preview-size', size, '--ui-scale', scale], env=env, stdout=self.log, stderr=subprocess.STDOUT)
+
+    def call(self, name, **arguments):
+        request = urllib.request.Request(f'http://127.0.0.1:{self.port}/mcp', data=json.dumps({'jsonrpc':'2.0', 'id':1, 'method':'tools/call', 'params': {'name':name, 'arguments':arguments}}).encode(), headers={'Content-Type':'application/json', 'Accept':'application/json, text/event-stream'})
+        response = json.load(urllib.request.urlopen(request, timeout=5))
+        if 'error' in response or response.get('result', {}).get('isError'):
+            raise RuntimeError(response)
+        return response['result']['content']
+
+    def data(self, name, **args):
+        return next(json.loads(c['text']) for c in self.call(name, **args) if c['type']=='text')
+
+    def ready(self):
+        end = time.monotonic() + 20
+        while time.monotonic() < end:
+            if self.process.poll() is not None:
+                raise RuntimeError(f'{self.label} exited: see {self.log.name}')
+            try:
+                self.window = self.data('list_windows')['windowHandles'][0]
+                properties = self.data('get_window_properties', windowHandle=self.window)
+                self.root = properties['rootElementHandle']
+                assert abs(properties['scaleFactor'] - self.scale) < .001, properties
+                (self.output / f'{self.label}-window.json').write_text(json.dumps(properties, indent=2))
+                return
+            except (urllib.error.URLError, IndexError, TimeoutError):
+                time.sleep(.1)
+        raise TimeoutError(f'{self.label}: MCP did not start')
+
+    def screenshot(self, label=None):
+        label = label or self.label
+        image = next(c for c in self.call('take_screenshot', windowHandle=self.window, imageMimeType='image/png') if c['type']=='image')
+        (self.output / f'{label}.png').write_bytes(base64.b64decode(image['data']))
+        tree = self.tree()
+        assert not tree.get('truncated'), 'Element tree was truncated'
+        (self.output / f'{label}.json').write_text(json.dumps(tree, indent=2))
+        return label
+
+    def element(self, role, label):
+        tree = self.tree()
+        return next((e for e in tree['elements'] if e.get('accessibleRole') == role and e.get('accessibleLabel','').startswith(label)), None)
+
+    def tree(self):
+        return self.data('get_element_tree', elementHandle=self.root, maxElements=2000)
+
+    def fill(self, index, value):
+        inputs = [e for e in self.tree()['elements'] if e.get('accessibleRole') == 'TextInput']
+        self.data('set_element_value', elementHandle=inputs[index]['handle'], value=value)
+
+    def key(self, text):
+        self.data('dispatch_key_event', windowHandle=self.window, text=text)
+
+    def wait(self, role, label):
+        end = time.monotonic() + 15
+        while time.monotonic() < end:
+            element = self.element(role, label)
+            if element:
+                return element
+            time.sleep(.1)
+        raise AssertionError(f'Missing {role}: {label}')
+
+    def click(self, role, label):
+        self.data('click_element', elementHandle=self.wait(role, label)['handle'])
+
+    def close(self):
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait()
+        self.log.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, default=Path('target/debug/azfs'))
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--scenes', nargs='+', choices=SCENES, default=SCENES)
+    parser.add_argument('--sizes', nargs='+', default=['800x600@1', '1280x800@1', '1920x1080@1.5', '1920x1080@2'])
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    labels = []
+    for spec in args.sizes:
+        size, scale = spec.split('@')
+        for scene in args.scenes:
+            preview = Preview(args.binary.resolve(), scene, size, scale, args.output)
+            try:
+                preview.ready()
+                labels.append(preview.screenshot())
+                print(labels[-1], flush=True)
+            finally:
+                preview.close()
+    cards = ''.join(f'<a href="{html.escape(label)}.png"><img src="{html.escape(label)}.png"><p>{html.escape(label)}</p></a>' for label in labels)
+    (args.output / 'index.html').write_text('<!doctype html><meta charset="utf-8"><title>Installer UI review</title><style>body{background:#181825;color:#cdd6f4;font:14px sans-serif}main{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:20px}img{width:100%}a{color:inherit;text-decoration:none}</style><h1>Installer UI review</h1><main>'+cards+'</main>')
+
+if __name__ == '__main__':
+    main()

--- a/slint-ui/scripts/review.py
+++ b/slint-ui/scripts/review.py
@@ -23,6 +23,7 @@ class Preview:
         self.output = output
         self.label = f'{scene}-{size}-{scale}x'
         self.scale = float(scale)
+        self.size = tuple(map(int, size.split('x')))
         with socket.socket() as sock:
             sock.bind(('127.0.0.1', 0))
             self.port = sock.getsockname()[1]
@@ -32,7 +33,7 @@ class Preview:
 
     def call(self, name, **arguments):
         request = urllib.request.Request(f'http://127.0.0.1:{self.port}/mcp', data=json.dumps({'jsonrpc':'2.0', 'id':1, 'method':'tools/call', 'params': {'name':name, 'arguments':arguments}}).encode(), headers={'Content-Type':'application/json', 'Accept':'application/json, text/event-stream'})
-        response = json.load(urllib.request.urlopen(request, timeout=5))
+        response = json.load(urllib.request.urlopen(request, timeout=30))
         if 'error' in response or response.get('result', {}).get('isError'):
             raise RuntimeError(response)
         return response['result']['content']
@@ -50,6 +51,7 @@ class Preview:
                 properties = self.data('get_window_properties', windowHandle=self.window)
                 self.root = properties['rootElementHandle']
                 assert abs(properties['scaleFactor'] - self.scale) < .001, properties
+                assert (properties['size']['width'], properties['size']['height']) == self.size, properties
                 (self.output / f'{self.label}-window.json').write_text(json.dumps(properties, indent=2))
                 return
             except (urllib.error.URLError, IndexError, TimeoutError):

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -108,6 +108,17 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         "Installation mode",
         mode.unwrap_or(InstallationMode::FullDisk),
     );
+    for (row, description) in items
+        .iter_mut()
+        .filter(|row| row.item_type == ItemType::RadioOption)
+        .zip([
+            "Erase the selected disk and create a ZFS root pool",
+            "Create a ZFS pool using existing partitions",
+            "Install into an existing ZFS pool",
+        ])
+    {
+        row.description = description.into();
+    }
 
     if matches!(mode, Some(InstallationMode::FullDisk) | None) {
         let disks = disk_choices();
@@ -501,7 +512,7 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     let mut items = Vec::new();
 
-    for (step, &label) in STEP_LABELS.iter().enumerate().take(TOTAL_STEPS - 1) {
+    for (step, &label) in STEP_LABELS.iter().enumerate().take(TOTAL_STEPS - 1).skip(1) {
         // Each step becomes a section in the review screen.
         items.push(section_header(label));
 
@@ -920,12 +931,24 @@ fn device_key(setting: DeviceSetting, path: &std::path::Path) -> SharedString {
 }
 
 fn disk_choices() -> Vec<ChoiceRow> {
+    if crate::preview::enabled() {
+        return crate::preview::disks()
+            .into_iter()
+            .map(ChoiceRow::from)
+            .collect();
+    }
     archinstall_zfs_core::disk::device::disk_choices()
         .map(|choices| choices.into_iter().map(ChoiceRow::from).collect())
         .unwrap_or_default()
 }
 
 fn partition_choices() -> Vec<ChoiceRow> {
+    if crate::preview::enabled() {
+        return crate::preview::partitions()
+            .into_iter()
+            .map(ChoiceRow::from)
+            .collect();
+    }
     archinstall_zfs_core::disk::device::partition_choices()
         .map(|choices| choices.into_iter().map(ChoiceRow::from).collect())
         .unwrap_or_default()

--- a/slint-ui/src/console_session.rs
+++ b/slint-ui/src/console_session.rs
@@ -1,0 +1,165 @@
+//! A small parent process restores the VT even if the KMS child aborts or is killed.
+//! Slint isolates keyboard input while running; the parent only owns recovery.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::process::{Command, ExitStatus};
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use nix::libc;
+
+const CHILD_ENV: &str = "AZFS_KMS_CHILD";
+const SIGNALS: [i32; 4] = [libc::SIGINT, libc::SIGTERM, libc::SIGHUP, libc::SIGQUIT];
+static CHILD_PID: AtomicI32 = AtomicI32::new(0);
+static PENDING_SIGNAL: AtomicI32 = AtomicI32::new(0);
+
+extern "C" fn forward_signal(signal: i32) {
+    let pid = CHILD_PID.load(Ordering::Relaxed);
+    if pid > 0 {
+        // SAFETY: kill is async-signal-safe; the child is not reaped yet.
+        unsafe {
+            libc::kill(pid, signal);
+        }
+    } else {
+        PENDING_SIGNAL.store(signal, Ordering::Relaxed);
+    }
+}
+
+struct SignalForwarder([libc::sighandler_t; 4]);
+
+impl SignalForwarder {
+    fn new() -> Self {
+        Self(SIGNALS.map(|signal| {
+            // SAFETY: the handler only accesses lock-free atomics and calls kill.
+            unsafe { libc::signal(signal, forward_signal as *const () as libc::sighandler_t) }
+        }))
+    }
+}
+
+impl Drop for SignalForwarder {
+    fn drop(&mut self) {
+        CHILD_PID.store(0, Ordering::Relaxed);
+        for (signal, handler) in SIGNALS.into_iter().zip(self.0) {
+            // SAFETY: restore the handler returned by the matching signal call.
+            unsafe {
+                libc::signal(signal, handler);
+            }
+        }
+    }
+}
+
+struct Console {
+    file: File,
+    keyboard_mode: libc::c_int,
+    display_mode: libc::c_int,
+}
+
+fn check(result: libc::c_int) -> io::Result<()> {
+    if result < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+impl Console {
+    fn open() -> io::Result<Option<Self>> {
+        let options = || {
+            let mut options = OpenOptions::new();
+            options
+                .read(true)
+                .write(true)
+                .custom_flags(libc::O_NOCTTY | libc::O_CLOEXEC);
+            options
+        };
+        let control = match options().open("/dev/tty0") {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        // Linux struct vt_stat consists of three unsigned shorts.
+        let mut state = [0u16; 3];
+        // SAFETY: the ioctl writes exactly three aligned unsigned shorts.
+        check(unsafe { libc::ioctl(control.as_raw_fd(), 0x5603, state.as_mut_ptr()) })?;
+        let file = options().open(format!("/dev/tty{}", state[0]))?;
+        let mut console = Self {
+            file,
+            keyboard_mode: 0,
+            display_mode: 0,
+        };
+        // SAFETY: both GET ioctls write an int to valid aligned storage.
+        check(unsafe {
+            libc::ioctl(console.file.as_raw_fd(), 0x4b44, &mut console.keyboard_mode)
+        })?;
+        check(unsafe { libc::ioctl(console.file.as_raw_fd(), 0x4b3b, &mut console.display_mode) })?;
+        Ok(Some(console))
+    }
+
+    fn restore(&self) -> io::Result<()> {
+        // SAFETY: the descriptor is open; these are valid terminal operations.
+        // Flush before reenabling input so a waiting shell receives no GUI text.
+        check(unsafe { libc::tcflush(self.file.as_raw_fd(), libc::TCIFLUSH) })?;
+        check(unsafe { libc::ioctl(self.file.as_raw_fd(), 0x4b45, self.keyboard_mode) })?;
+        check(unsafe { libc::ioctl(self.file.as_raw_fd(), 0x4b3a, self.display_mode) })
+    }
+}
+
+/// Returns the GUI exit status in the supervisor, or None in the GUI child.
+/// Call before starting threads, installing logging, or creating a Slint window.
+pub fn supervise() -> io::Result<Option<ExitStatus>> {
+    if std::env::var_os(CHILD_ENV).is_some() {
+        // SAFETY: startup is single threaded. Do not propagate the marker further.
+        unsafe {
+            std::env::remove_var(CHILD_ENV);
+        }
+        return Ok(None);
+    }
+    let Some(console) = Console::open()? else {
+        return Ok(None);
+    };
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .args(std::env::args_os().skip(1))
+        .env(CHILD_ENV, "1");
+    // Restore default signal handling in the child before exec. The closure only
+    // uses async-signal-safe libc calls, without allocation or locks.
+    unsafe {
+        command.pre_exec(|| {
+            for signal in SIGNALS {
+                libc::signal(signal, libc::SIG_DFL);
+            }
+            Ok(())
+        });
+    }
+    let _signals = SignalForwarder::new();
+    let mut child = command.spawn()?;
+    CHILD_PID.store(child.id() as i32, Ordering::Relaxed);
+    let pending = PENDING_SIGNAL.swap(0, Ordering::Relaxed);
+    if pending != 0 {
+        forward_signal(pending);
+    }
+    let status = match child.wait() {
+        Ok(status) => status,
+        Err(error) => {
+            // Do not restore console input while the GUI could still be alive.
+            child.kill()?;
+            child.wait()?;
+            CHILD_PID.store(0, Ordering::Relaxed);
+            console.restore()?;
+            return Err(error);
+        }
+    };
+    CHILD_PID.store(0, Ordering::Relaxed);
+    let restored = console.restore();
+    restored?;
+    Ok(Some(status))
+}
+
+pub fn exit_code(status: ExitStatus) -> i32 {
+    status
+        .code()
+        .unwrap_or_else(|| 128 + status.signal().unwrap_or(1))
+}

--- a/slint-ui/src/controllers/install.rs
+++ b/slint-ui/src/controllers/install.rs
@@ -58,6 +58,10 @@ pub fn setup(
     demo: bool,
     log_rx: crossbeam_channel::Receiver<(String, i32)>,
 ) {
+    if crate::preview::enabled() {
+        crate::preview::install(app, config);
+        return;
+    }
     // The markup starts at this phase too; setting it here keeps the value
     // owned in one place rather than agreeing by coincidence.
     set_phase(app, InstallPhase::Configuring);

--- a/slint-ui/src/controllers/install.rs
+++ b/slint-ui/src/controllers/install.rs
@@ -65,6 +65,8 @@ pub fn setup(
     // One pump for the process, fed by the global subscriber. It starts here
     // rather than per installation so nothing emitted before or between runs
     // is lost, and so the receiver is not re-created behind the layer's back.
+    app.global::<InstallState>()
+        .set_log_messages(ModelRc::new(VecModel::<LogMessage>::default()));
     spawn_log_pump(app, log_rx);
 
     let active_cancel = Arc::new(Mutex::new(None::<CancellationToken>));

--- a/slint-ui/src/controllers/lists.rs
+++ b/slint-ui/src/controllers/lists.rs
@@ -187,6 +187,10 @@ fn setup_packages(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &Editin
             return;
         }
         editing.set_package_searching_aur(false);
+        if crate::preview::enabled() {
+            search_model.set_vec(crate::preview::packages(&text, false));
+            return;
+        }
         let query = text.to_string();
         let weak2 = app.as_weak();
         tokio::spawn(async move {
@@ -218,6 +222,11 @@ fn setup_packages(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &Editin
         }
         let editing = app.global::<EditingState>();
         editing.set_package_searching_aur(true);
+        if crate::preview::enabled() {
+            set_search_results(&app, crate::preview::packages(&text, true));
+            editing.set_package_searching_aur(false);
+            return;
+        }
         editing.set_package_status_text(SharedString::from("Searching AUR..."));
         let query = text.to_string();
         let weak2 = app.as_weak();

--- a/slint-ui/src/controllers/quit.rs
+++ b/slint-ui/src/controllers/quit.rs
@@ -39,6 +39,9 @@ pub fn setup(app: &App) {
     app.on_reboot_requested(move || {
         let Some(app) = weak.upgrade() else { return };
         let _ = app.window().hide();
+        if crate::preview::enabled() {
+            return;
+        }
         let _ = std::process::Command::new("systemctl")
             .arg("reboot")
             .spawn();

--- a/slint-ui/src/controllers/welcome.rs
+++ b/slint-ui/src/controllers/welcome.rs
@@ -2,7 +2,7 @@
 //! the on_check_internet retry handler, the background ZFS-init job, and the
 //! background kernel compatibility scan.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
@@ -60,37 +60,53 @@ impl KernelScan {
 }
 
 pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &KernelScan, demo: bool) {
-    run_initial_checks(app, config, kernel_scan, demo);
+    run_initial_checks(app, demo);
 
     let weak = app.as_weak();
     let cfg = config.clone();
     let kscan = kernel_scan.clone();
+    let in_flight = Rc::new(RefCell::new(None::<tokio::task::AbortHandle>));
+    let generation = Rc::new(Cell::new(0_u64));
     app.global::<WelcomeState>().on_check_internet(move || {
-        let Some(app) = weak.upgrade() else { return };
-        let net = archinstall_zfs_core::system::net::check_internet();
-        app.global::<WelcomeState>().set_net_ok(net);
-        if net {
-            if !demo
-                && !app.global::<WelcomeState>().get_zfs_ok()
-                && !app.global::<WelcomeState>().get_zfs_installing()
-            {
-                start_zfs_init(&app, &cfg.borrow());
-            }
-            let distro = cfg.borrow().distribution();
-            if !kscan.has(distro) {
-                start_kernel_scan(&kscan, distro);
-            }
+        let request = generation.get().wrapping_add(1);
+        generation.set(request);
+        if let Some(previous) = in_flight.borrow_mut().take() {
+            previous.abort();
         }
+        let task = tokio::spawn(archinstall_zfs_core::system::net::check_internet());
+        *in_flight.borrow_mut() = Some(task.abort_handle());
+        let weak = weak.clone();
+        let cfg = cfg.clone();
+        let kscan = kscan.clone();
+        let generation = generation.clone();
+        // Await Tokio's network task without blocking Slint; the configuration
+        // stays on the UI thread and is read only after the request finishes.
+        slint::spawn_local(async move {
+            let Ok(net) = task.await else { return };
+            if generation.get() != request {
+                return;
+            }
+            let Some(app) = weak.upgrade() else { return };
+            app.global::<WelcomeState>().set_net_ok(net);
+            if net {
+                if !demo
+                    && !app.global::<WelcomeState>().get_zfs_ok()
+                    && !app.global::<WelcomeState>().get_zfs_installing()
+                {
+                    start_zfs_init(&app, &cfg.borrow());
+                }
+                let distro = cfg.borrow().distribution();
+                if !kscan.has(distro) {
+                    start_kernel_scan(&kscan, distro);
+                }
+            }
+        })
+        .expect("Slint event loop is available");
     });
+    app.global::<WelcomeState>().invoke_check_internet();
 }
 
-fn run_initial_checks(
-    app: &App,
-    config: &Rc<RefCell<GlobalConfig>>,
-    kernel_scan: &KernelScan,
-    demo: bool,
-) {
-    let net = archinstall_zfs_core::system::net::check_internet();
+fn run_initial_checks(app: &App, demo: bool) {
     let uefi = archinstall_zfs_core::system::sysinfo::has_uefi();
     let mut zfs_mod = archinstall_zfs_core::zfs_setup::check_zfs_module(
         &archinstall_zfs_core::system::cmd::RealRunner,
@@ -109,16 +125,8 @@ fn run_initial_checks(
 
     let welcome = app.global::<WelcomeState>();
     welcome.set_app_version(env!("CARGO_PKG_VERSION").into());
-    welcome.set_net_ok(net);
     welcome.set_uefi_ok(uefi);
     welcome.set_zfs_ok(zfs_mod && zfs_utils);
-
-    if net {
-        if !demo && !(zfs_mod && zfs_utils) {
-            start_zfs_init(app, &config.borrow());
-        }
-        start_kernel_scan(kernel_scan, config.borrow().distribution());
-    }
 }
 
 fn start_zfs_init(app: &App, config: &GlobalConfig) {

--- a/slint-ui/src/controllers/welcome.rs
+++ b/slint-ui/src/controllers/welcome.rs
@@ -60,6 +60,10 @@ impl KernelScan {
 }
 
 pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &KernelScan, demo: bool) {
+    if crate::preview::enabled() {
+        crate::preview::welcome(app);
+        return;
+    }
     run_initial_checks(app, demo);
 
     let weak = app.as_weak();

--- a/slint-ui/src/controllers/wifi.rs
+++ b/slint-ui/src/controllers/wifi.rs
@@ -39,7 +39,7 @@ pub fn setup(app: &App) {
     setup_pick(app, in_flight.clone());
     setup_cancel_pick(app);
     setup_submit_password(app, in_flight.clone());
-    setup_forget(app);
+    setup_forget(app, in_flight.clone());
     setup_disconnect(app, in_flight.clone());
     setup_connect_hidden(app, in_flight);
 }
@@ -48,6 +48,14 @@ pub fn setup(app: &App) {
 /// reachable on the system bus? Also snapshot the ethernet state once.
 /// Everything runs in a background task so app startup stays snappy.
 fn run_initial_probe(app: &App) {
+    if crate::preview::enabled() {
+        let s = app.global::<WifiState>();
+        s.set_has_hardware(true);
+        s.set_iwd_running(true);
+        s.set_ethernet_connected(true);
+        s.set_ethernet_ipv4("192.0.2.10".into());
+        return;
+    }
     let weak = app.as_weak();
     tokio::spawn(async move {
         let has_hardware = !wifi::detect_wifi_interfaces().is_empty();
@@ -176,7 +184,7 @@ fn setup_submit_password(app: &App, in_flight: InFlight) {
     });
 }
 
-fn setup_forget(app: &App) {
+fn setup_forget(app: &App, in_flight: InFlight) {
     let weak = app.as_weak();
     app.global::<WifiState>().on_forget(move |idx| {
         let Some(app) = weak.upgrade() else { return };
@@ -186,17 +194,29 @@ fn setup_forget(app: &App) {
             return;
         };
         let ssid = net.ssid.to_string();
+        let token = fresh_token(&in_flight);
+        let in_flight = in_flight.clone();
+        s.set_phase(WifiPhase::Scanning);
+        s.set_status_text("Removing saved network…".into());
         let weak = app.as_weak();
         tokio::spawn(async move {
-            let _ = wifi::forget_network(&ssid).await;
-            // Refresh the list so the "Known" badge drops away.
-            if let Ok(networks) = wifi::scan_networks().await {
-                let ui = networks.into_iter().map(to_ui).collect::<Vec<_>>();
-                let _ = weak.upgrade_in_event_loop(move |app| {
-                    app.global::<WifiState>()
-                        .set_networks(ModelRc::new(VecModel::from(ui)));
-                });
-            }
+            let result = tokio::select! {
+                _ = token.cancelled() => return,
+                result = wifi::forget_network(&ssid) => result,
+            };
+            let _ = weak.upgrade_in_event_loop(move |app| {
+                if token.is_cancelled() {
+                    return;
+                }
+                match result {
+                    Ok(()) => start_scan(&app, in_flight),
+                    Err(error) => {
+                        let s = app.global::<WifiState>();
+                        s.set_phase(WifiPhase::Error);
+                        s.set_error_text(error.to_string().into());
+                    }
+                }
+            });
         });
     });
 }
@@ -204,14 +224,30 @@ fn setup_forget(app: &App) {
 fn setup_disconnect(app: &App, in_flight: InFlight) {
     let weak = app.as_weak();
     app.global::<WifiState>().on_disconnect(move || {
-        abort_in_flight(&in_flight);
+        let Some(app) = weak.upgrade() else { return };
+        let token = fresh_token(&in_flight);
+        let s = app.global::<WifiState>();
+        s.set_phase(WifiPhase::Connecting);
+        s.set_status_text("Disconnecting…".into());
         let weak2 = weak.clone();
         tokio::spawn(async move {
-            let _ = wifi::disconnect().await;
-            let _ = weak2.upgrade_in_event_loop(|app| {
+            let result = tokio::select! {
+                _ = token.cancelled() => return,
+                result = wifi::disconnect() => result,
+            };
+            let _ = weak2.upgrade_in_event_loop(move |app| {
+                if token.is_cancelled() {
+                    return;
+                }
                 let s = app.global::<WifiState>();
+                if let Err(error) = result {
+                    s.set_phase(WifiPhase::Error);
+                    s.set_error_text(error.to_string().into());
+                    return;
+                }
                 s.set_current_ssid(SharedString::default());
                 s.set_phase(WifiPhase::Picking);
+                s.set_status_text(SharedString::default());
                 app.global::<WelcomeState>().invoke_check_internet();
             });
         });
@@ -275,6 +311,9 @@ fn start_scan(app: &App, in_flight: InFlight) {
                 let ui = networks.into_iter().map(to_ui).collect::<Vec<_>>();
                 let had_any = !ui.is_empty();
                 let _ = weak.upgrade_in_event_loop(move |app| {
+                    if token.is_cancelled() {
+                        return;
+                    }
                     let s = app.global::<WifiState>();
                     s.set_networks(ModelRc::new(VecModel::from(ui)));
                     s.set_phase(WifiPhase::Picking);
@@ -288,6 +327,9 @@ fn start_scan(app: &App, in_flight: InFlight) {
             Err(e) => {
                 let msg = e.to_string();
                 let _ = weak.upgrade_in_event_loop(move |app| {
+                    if token.is_cancelled() {
+                        return;
+                    }
                     let s = app.global::<WifiState>();
                     s.set_phase(WifiPhase::Error);
                     s.set_error_text(SharedString::from(msg));
@@ -341,7 +383,14 @@ async fn drive_post_connect(
             let online = tokio::select! {
                 biased;
                 _ = token.cancelled() => return,
-                online = net::wait_for_internet(Duration::from_secs(20)) => online,
+                online = async {
+                    if crate::preview::enabled() {
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        true
+                    } else {
+                        net::wait_for_internet(Duration::from_secs(20)).await
+                    }
+                } => online,
             };
 
             if online {

--- a/slint-ui/src/controllers/wifi.rs
+++ b/slint-ui/src/controllers/wifi.rs
@@ -40,7 +40,7 @@ pub fn setup(app: &App) {
     setup_cancel_pick(app);
     setup_submit_password(app, in_flight.clone());
     setup_forget(app);
-    setup_disconnect(app);
+    setup_disconnect(app, in_flight.clone());
     setup_connect_hidden(app, in_flight);
 }
 
@@ -201,9 +201,10 @@ fn setup_forget(app: &App) {
     });
 }
 
-fn setup_disconnect(app: &App) {
+fn setup_disconnect(app: &App, in_flight: InFlight) {
     let weak = app.as_weak();
     app.global::<WifiState>().on_disconnect(move || {
+        abort_in_flight(&in_flight);
         let weak2 = weak.clone();
         tokio::spawn(async move {
             let _ = wifi::disconnect().await;
@@ -211,6 +212,7 @@ fn setup_disconnect(app: &App) {
                 let s = app.global::<WifiState>();
                 s.set_current_ssid(SharedString::default());
                 s.set_phase(WifiPhase::Picking);
+                app.global::<WelcomeState>().invoke_check_internet();
             });
         });
     });
@@ -314,9 +316,8 @@ fn start_connect(app: &App, in_flight: InFlight, ssid: String, passphrase: Optio
     });
 }
 
-/// Shared post-connect verification: on success, move to Verifying,
-/// wait ~4s for DHCP, then check the internet. On failure, move to
-/// Error.
+/// Association and internet access are separate states. Retry the HTTP probe
+/// while addresses, routes and DNS settle; never infer a DHCP failure from it.
 async fn drive_post_connect(
     weak: &slint::Weak<App>,
     ssid: String,
@@ -325,27 +326,30 @@ async fn drive_post_connect(
 ) {
     match result {
         Ok(()) => {
-            let weak2 = weak.clone();
-            let _ = weak2.upgrade_in_event_loop(|app| {
+            let ssid_connected = ssid.clone();
+            let phase_token = token.clone();
+            let _ = weak.upgrade_in_event_loop(move |app| {
+                if phase_token.is_cancelled() {
+                    return;
+                }
                 let s = app.global::<WifiState>();
+                s.set_current_ssid(SharedString::from(ssid_connected));
                 s.set_phase(WifiPhase::Verifying);
-                s.set_status_text(SharedString::from("Waiting for IP address…"));
+                s.set_status_text(SharedString::from("Checking internet access…"));
             });
 
-            // Wait for DHCP — cancellable.
-            let sleep = tokio::time::sleep(Duration::from_secs(4));
-            tokio::select! {
+            let online = tokio::select! {
+                biased;
                 _ = token.cancelled() => return,
-                _ = sleep => {}
-            }
-
-            let online = tokio::task::spawn_blocking(net::check_internet)
-                .await
-                .unwrap_or(false);
+                online = net::wait_for_internet(Duration::from_secs(20)) => online,
+            };
 
             if online {
                 let ssid_final = ssid.clone();
                 let _ = weak.upgrade_in_event_loop(move |app| {
+                    if token.is_cancelled() {
+                        return;
+                    }
                     let s = app.global::<WifiState>();
                     s.set_phase(WifiPhase::Connected);
                     s.set_current_ssid(SharedString::from(ssid_final));
@@ -359,18 +363,23 @@ async fn drive_post_connect(
                     app.global::<WelcomeState>().invoke_check_internet();
                 });
             } else {
-                let _ = weak.upgrade_in_event_loop(|app| {
+                let _ = weak.upgrade_in_event_loop(move |app| {
+                    if token.is_cancelled() { return; }
                     let s = app.global::<WifiState>();
-                    s.set_phase(WifiPhase::Error);
+                    s.set_phase(WifiPhase::NoInternet);
                     s.set_error_text(SharedString::from(
-                        "Connected to the network, but no IP address was assigned (DHCP timeout).",
+                        "Wi-Fi connected, but internet access could not be verified via ping.archlinux.org. Check network settings or sign in to the network.",
                     ));
+                    app.global::<WelcomeState>().invoke_check_internet();
                 });
             }
         }
         Err(e) => {
             let msg = e.to_string();
             let _ = weak.upgrade_in_event_loop(move |app| {
+                if token.is_cancelled() {
+                    return;
+                }
                 let s = app.global::<WifiState>();
                 s.set_phase(WifiPhase::Error);
                 s.set_error_text(SharedString::from(msg));

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -3,7 +3,7 @@
 //! show_select / show_text_input / show_*_popup helpers used by
 //! handle_item_activated.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
@@ -316,7 +316,7 @@ fn setup_select_filter(app: &App) {
         let filter = filter_text.to_lowercase();
 
         if key == "locale_select" {
-            let all_locales = archinstall_zfs_core::installer::locale::list_locales();
+            let all_locales = available_locales();
             let filtered = fuzzy_filter(&all_locales, &filter);
             let popup = app.global::<PopupState>();
             popup.set_select_options(ModelRc::new(VecModel::from(filtered)));
@@ -324,7 +324,7 @@ fn setup_select_filter(app: &App) {
         }
 
         if key == "keyboard_select" {
-            let all_keymaps = archinstall_zfs_core::installer::locale::list_keymaps();
+            let all_keymaps = available_keymaps();
             let filtered = fuzzy_filter(&all_keymaps, &filter);
             let popup = app.global::<PopupState>();
             popup.set_select_options(ModelRc::new(VecModel::from(filtered)));
@@ -357,43 +357,73 @@ fn fuzzy_filter(items: &[String], filter: &str) -> Vec<SelectOption> {
 
 fn setup_password_strength(app: &App) {
     let weak = app.as_weak();
+    let generation = Rc::new(Cell::new(0u64));
     app.on_text_input_edited(move |key, value| {
         let Some(app) = weak.upgrade() else { return };
-
         if key != "root_password" && key != "encryption_password" && key != "user_password" {
             return;
         }
+        let current = generation.get().wrapping_add(1);
+        generation.set(current);
+        app.global::<PopupState>().set_password_strength_score(-1);
         if value.is_empty() {
-            app.global::<PopupState>().set_password_strength_score(-1);
             return;
         }
-        let entropy = zxcvbn::zxcvbn(value.as_str(), &[]);
-        let score = u8::from(entropy.score());
-        let theme = app.global::<Theme>().get_c();
-        let (label, color) = match score {
-            0 => ("Very weak", theme.red),
-            1 => ("Weak", theme.peach),
-            2 => ("Fair", theme.yellow),
-            3 => ("Strong", theme.green),
-            _ => ("Very strong", theme.teal),
-        };
 
-        let hint = entropy
-            .feedback()
-            .and_then(|f| f.suggestions().first().map(|s| s.to_string()))
-            .unwrap_or_else(|| {
-                let crack_time = entropy
-                    .crack_times()
-                    .online_no_throttling_10_per_second()
-                    .to_string();
-                format!("~{crack_time} to crack")
+        let generation = generation.clone();
+        let weak = app.as_weak();
+        // Scoring initializes a large dictionary and can take hundreds of
+        // milliseconds. Keep it off the input/render thread and skip stale edits.
+        slint::Timer::single_shot(std::time::Duration::from_millis(120), move || {
+            if generation.get() != current {
+                return;
+            }
+            let value = value.to_string();
+            let task = tokio::task::spawn_blocking(move || {
+                let entropy = zxcvbn::zxcvbn(&value, &[]);
+                let hint = entropy
+                    .feedback()
+                    .and_then(|f| f.suggestions().first().map(|s| s.to_string()))
+                    .unwrap_or_else(|| {
+                        format!(
+                            "~{} to crack",
+                            entropy.crack_times().online_no_throttling_10_per_second()
+                        )
+                    });
+                (u8::from(entropy.score()), hint)
             });
-
-        let popup = app.global::<PopupState>();
-        popup.set_password_strength_score(score as i32);
-        popup.set_password_strength_label(SharedString::from(label));
-        popup.set_password_strength_hint(SharedString::from(hint));
-        popup.set_password_strength_color(color);
+            slint::spawn_local(async move {
+                let Ok((score, hint)) = task.await else {
+                    return;
+                };
+                if generation.get() != current {
+                    return;
+                }
+                let Some(app) = weak.upgrade() else { return };
+                let popup = app.global::<PopupState>();
+                let visible = if key == "user_password" {
+                    popup.get_users_visible()
+                } else {
+                    popup.get_text_input_visible() && popup.get_text_input_key() == key
+                };
+                if !visible {
+                    return;
+                }
+                let theme = app.global::<Theme>().get_c();
+                let (label, color) = match score {
+                    0 => ("Very weak", theme.red),
+                    1 => ("Weak", theme.peach),
+                    2 => ("Fair", theme.yellow),
+                    3 => ("Strong", theme.green),
+                    _ => ("Very strong", theme.teal),
+                };
+                popup.set_password_strength_score(score as i32);
+                popup.set_password_strength_label(label.into());
+                popup.set_password_strength_hint(hint.into());
+                popup.set_password_strength_color(color);
+            })
+            .expect("Slint event loop is available");
+        });
     });
 }
 
@@ -474,7 +504,13 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             // Use the cached scan results if available; otherwise block-scan now.
             let fresh: Vec<archinstall_zfs_core::kernel::scanner::CompatibilityResult>;
             let distro = config.distribution();
-            let options = if let Some(opts) = kernel_scan.with(distro, |cached| {
+            let options = if crate::preview::enabled() {
+                distro
+                    .kernels
+                    .iter()
+                    .map(|k| format!("{} — compatible", k.name))
+                    .collect()
+            } else if let Some(opts) = kernel_scan.with(distro, |cached| {
                 cached.map(|r| build_kernel_options(distro, r))
             }) {
                 opts
@@ -540,7 +576,11 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             // Build the GPU driver options list. Order matches the TUI
             // picker (None first, then drivers in display order). The
             // suggested driver based on detected hardware is annotated.
-            let suggestion = suggested_driver(&detect_gpus());
+            let suggestion = if crate::preview::enabled() {
+                None
+            } else {
+                suggested_driver(&detect_gpus())
+            };
             let drivers: &[Option<GfxDriver>] = &[
                 None,
                 Some(GfxDriver::AllOpenSource),
@@ -599,7 +639,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             show_select(app, "timezone_region", "Timezone region", &regions, 0);
         }
         EditorSetting::Locale => {
-            let locales = archinstall_zfs_core::installer::locale::list_locales();
+            let locales = available_locales();
             let locale_strs: Vec<&str> = locales.iter().map(|s| s.as_str()).collect();
             let current_idx = config
                 .locale
@@ -620,7 +660,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             show_users_popup(app);
         }
         EditorSetting::Keyboard => {
-            let keymaps = archinstall_zfs_core::installer::locale::list_keymaps();
+            let keymaps = available_keymaps();
             let keymap_strs: Vec<&str> = keymaps.iter().map(|s| s.as_str()).collect();
             let current_idx = keymaps
                 .iter()
@@ -636,9 +676,9 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
                 true,
             );
         }
-        // The pool picker and the package list are the terminal interface's;
-        // here those rows are typed into and handled above.
-        EditorSetting::PoolName | EditorSetting::Packages => {}
+        EditorSetting::Packages => show_package_search(app),
+        // Pool names are handled by TextSetting above.
+        EditorSetting::PoolName => {}
     }
 }
 
@@ -740,4 +780,22 @@ fn show_package_search(app: &App) {
     editing.set_package_searching_aur(false);
     editing.set_package_status_text(SharedString::default());
     app.global::<PopupState>().set_pkg_search_visible(true);
+}
+
+fn available_locales() -> Vec<String> {
+    if crate::preview::enabled() {
+        ["en_US.UTF-8", "de_DE.UTF-8", "ru_RU.UTF-8", "ja_JP.UTF-8"]
+            .map(String::from)
+            .to_vec()
+    } else {
+        archinstall_zfs_core::installer::locale::list_locales()
+    }
+}
+
+fn available_keymaps() -> Vec<String> {
+    if crate::preview::enabled() {
+        ["us", "de", "ru", "jp106"].map(String::from).to_vec()
+    } else {
+        archinstall_zfs_core::installer::locale::list_keymaps()
+    }
 }

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -1,7 +1,10 @@
 mod config_items;
+#[cfg(feature = "linuxkms")]
+mod console_session;
 mod controllers;
 mod editing_models;
 mod format;
+mod preview;
 mod refresh;
 mod tracing_layer;
 
@@ -49,6 +52,14 @@ struct Cli {
     /// destructive storage operations.
     #[arg(long, global = true)]
     demo: bool,
+
+    /// Review a simulated installation-ready system (desktop-mock builds only).
+    #[arg(long, conflicts_with_all = ["demo", "silent", "config", "secrets"])]
+    preview: Option<preview::Scene>,
+
+    /// Physical preview window size, for example 1920x1080.
+    #[arg(long, requires = "preview", default_value = "1280x800")]
+    preview_size: preview::Size,
 }
 
 /// Install the process-wide tracing subscriber.
@@ -90,20 +101,36 @@ fn setup_logging(ui_log_tx: crossbeam_channel::Sender<(String, i32)>) -> Result<
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     color_eyre::install()?;
     let cli = Cli::parse();
-    let demo = cli.demo || archinstall_zfs_core::demo::enabled_from_kernel_cmdline();
+    #[cfg(feature = "linuxkms")]
+    if !cli.silent
+        && cli.preview.is_none()
+        && let Some(status) = console_session::supervise()?
+    {
+        std::process::exit(console_session::exit_code(status));
+    }
+    if cli.preview.is_some() {
+        color_eyre::eyre::ensure!(
+            cfg!(feature = "desktop-mock"),
+            "--preview requires a desktop-mock build"
+        );
+        preview::enable();
+    }
+    let demo = !preview::enabled()
+        && (cli.demo || archinstall_zfs_core::demo::enabled_from_kernel_cmdline());
 
     // Bounded: the UI cannot keep up with trace-level output, and dropping
     // lines it will never render is preferable to slowing the installation.
     let (log_tx, log_rx) = crossbeam_channel::bounded::<(String, i32)>(512);
     setup_logging(log_tx)?;
 
-    if let Some(scale) = cli.ui_scale
-        && scale > 0.0
-    {
+    if let Some(scale) = cli.ui_scale {
+        color_eyre::eyre::ensure!(
+            scale.is_finite() && scale > 0.0,
+            "UI scale must be finite and positive"
+        );
         // Must be set before any Slint window is created.
         // SAFETY: single-threaded at this point in startup.
         unsafe {
@@ -111,7 +138,9 @@ async fn main() -> Result<()> {
         }
     }
 
-    let mut config = if let Some(ref path) = cli.config {
+    let mut config = if preview::enabled() {
+        preview::config(cli.preview.unwrap())
+    } else if let Some(ref path) = cli.config {
         GlobalConfig::load_from_file(path)?
     } else {
         GlobalConfig::default()
@@ -120,32 +149,39 @@ async fn main() -> Result<()> {
         config.apply_secrets_from_file(path)?;
     }
 
-    if cli.silent {
-        use color_eyre::eyre::bail;
-        if demo {
-            bail!("--silent is unavailable in safe demo mode");
-        }
-        if cli.config.is_none() {
-            bail!("--silent requires --config");
-        }
-        let runner: Arc<dyn archinstall_zfs_core::system::cmd::CommandRunner> =
-            Arc::new(archinstall_zfs_core::system::cmd::RealRunner);
-        Ok(archinstall_zfs_core::install::run_install(
-            runner,
-            config,
-            tokio_util::sync::CancellationToken::new(),
-            None,
-        )
-        .await?)
-    } else {
-        run_gui(config, demo, log_rx)
-    }
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async move {
+            if cli.silent {
+                use color_eyre::eyre::bail;
+                if demo {
+                    bail!("--silent is unavailable in safe demo mode");
+                }
+                if cli.config.is_none() {
+                    bail!("--silent requires --config");
+                }
+                let runner: Arc<dyn archinstall_zfs_core::system::cmd::CommandRunner> =
+                    Arc::new(archinstall_zfs_core::system::cmd::RealRunner);
+                Ok(archinstall_zfs_core::install::run_install(
+                    runner,
+                    config,
+                    tokio_util::sync::CancellationToken::new(),
+                    None,
+                )
+                .await?)
+            } else {
+                run_gui(config, demo, log_rx, cli.preview, cli.preview_size)
+            }
+        })
 }
 
 fn run_gui(
     config: GlobalConfig,
     demo: bool,
     log_rx: crossbeam_channel::Receiver<(String, i32)>,
+    scene: Option<preview::Scene>,
+    size: preview::Size,
 ) -> Result<()> {
     let app = App::new()?;
     let config = Rc::new(RefCell::new(config));
@@ -167,6 +203,10 @@ fn run_gui(
     let demo_session = demo.then(controllers::demo::DemoSession::new);
     if let Some(session) = &demo_session {
         controllers::demo::setup(&app, &config, session);
+    }
+
+    if let Some(scene) = scene {
+        preview::show(&app, scene, size);
     }
 
     app.run()?;

--- a/slint-ui/src/preview.rs
+++ b/slint-ui/src/preview.rs
@@ -1,0 +1,429 @@
+//! Deterministic UI fixtures. Enabled explicitly, and only in desktop-mock builds.
+//! Installation, reboot, probes, device discovery and package searches are replaced
+//! before their controllers can start real work. Editing still uses the real wizard.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use archinstall_zfs_core::config::types::{
+    GlobalConfig, InstallationMode, ProfileSelection, UserConfig,
+};
+use archinstall_zfs_core::disk::device::{
+    BlockDevice, BlockPartition, DeviceChoice, DevicePath, DevicePathKind,
+};
+use slint::{ComponentHandle, ModelRc, VecModel};
+
+use crate::ui::{
+    App, DownloadInfo, InstallState, LogMessage, PackageSearchResult, WelcomeState, WizardState,
+};
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+pub fn enable() {
+    if !cfg!(feature = "desktop-mock") {
+        panic!("preview requires a desktop-mock build");
+    }
+    ENABLED.store(true, Ordering::Relaxed);
+}
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub enum Scene {
+    Welcome,
+    Offline,
+    Disk,
+    NewPool,
+    ExistingPool,
+    Zfs,
+    System,
+    Users,
+    Desktop,
+    Review,
+    Install,
+    Done,
+    Failed,
+    Cancelled,
+    Inspect,
+    Invalid,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Size(pub u32, pub u32);
+
+impl std::str::FromStr for Size {
+    type Err = String;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (w, h) = value.split_once('x').ok_or("expected WIDTHxHEIGHT")?;
+        let w = w.parse::<u32>().map_err(|_| "invalid width")?;
+        let h = h.parse::<u32>().map_err(|_| "invalid height")?;
+        if !(640..=7680).contains(&w) || !(480..=4320).contains(&h) {
+            return Err("preview size must be between 640x480 and 7680x4320".into());
+        }
+        Ok(Self(w, h))
+    }
+}
+
+fn devices() -> Vec<BlockDevice> {
+    [
+        (
+            "nvme0n1",
+            "Samsung SSD 990 PRO 2TB",
+            "S7HENX0W123456A",
+            2048,
+            "nvme",
+            false,
+        ),
+        (
+            "sda",
+            "KINGSTON RBUSNS8180S3128GJ",
+            "50026B76825246C7",
+            119,
+            "sata",
+            false,
+        ),
+        (
+            "sdb",
+            "Kingston DataTraveler 70",
+            "1831BFBC9935E681298501A3",
+            115,
+            "usb",
+            true,
+        ),
+    ]
+    .into_iter()
+    .map(|(node, model, serial, size, bus, removable)| BlockDevice {
+        devnode: format!("/dev/{node}").into(),
+        aliases: vec![DevicePath {
+            path: format!(
+                "/dev/disk/by-id/{bus}-{}_{}",
+                model.replace(' ', "_"),
+                serial
+            )
+            .into(),
+            kind: DevicePathKind::ById,
+        }],
+        model: Some(model.into()),
+        serial: Some(serial.into()),
+        size_bytes: Some(size * 1024 * 1024 * 1024),
+        transport: Some(bus.into()),
+        rotational: Some(false),
+        removable,
+    })
+    .collect()
+}
+
+pub fn disks() -> Vec<DeviceChoice> {
+    devices().into_iter().map(Into::into).collect()
+}
+
+pub fn partitions() -> Vec<DeviceChoice> {
+    devices()
+        .into_iter()
+        .flat_map(|disk| {
+            (1..=2).map(move |number| {
+                BlockPartition {
+                    devnode: format!(
+                        "{}{}{number}",
+                        disk.devnode.display(),
+                        if disk.transport.as_deref() == Some("nvme") {
+                            "p"
+                        } else {
+                            ""
+                        }
+                    )
+                    .into(),
+                    aliases: vec![DevicePath {
+                        path: format!("{}-part{number}", disk.aliases[0].path.display()).into(),
+                        kind: DevicePathKind::ById,
+                    }],
+                    parent_devnode: Some(disk.devnode.clone()),
+                    model: disk.model.clone(),
+                    serial: disk.serial.clone(),
+                    size_bytes: Some(if number == 1 {
+                        1024 * 1024 * 1024
+                    } else {
+                        disk.size_bytes.unwrap() - 1024 * 1024 * 1024
+                    }),
+                    parent_size_bytes: disk.size_bytes,
+                    transport: disk.transport.clone(),
+                    rotational: disk.rotational,
+                    removable: disk.removable,
+                }
+                .into()
+            })
+        })
+        .collect()
+}
+
+pub fn config(scene: Scene) -> GlobalConfig {
+    if matches!(scene, Scene::Invalid) {
+        return GlobalConfig::default();
+    }
+    GlobalConfig {
+        installation_mode: Some(match scene {
+            Scene::NewPool => InstallationMode::NewPool,
+            Scene::ExistingPool => InstallationMode::ExistingPool,
+            _ => InstallationMode::FullDisk,
+        }),
+        disk: Some(disks()[0].path.clone()),
+        efi_partition: Some(partitions()[0].path.clone()),
+        zfs_partition: Some(partitions()[1].path.clone()),
+        pool_name: Some("zroot".into()),
+        hostname: Some("arch-workstation".into()),
+        locale: Some("en_US.UTF-8".into()),
+        timezone: Some("Europe/Moscow".into()),
+        kernels: Some(vec!["linux".into()]),
+        root_password: Some("preview-only-password".into()),
+        profile_selection: ProfileSelection::new("kde"),
+        users: Some(vec![UserConfig {
+            username: "alex".into(),
+            password: Some("preview-only-password".into()),
+            sudo: true,
+            shell: Some("/bin/zsh".into()),
+            groups: None,
+            ssh_authorized_keys: vec![],
+            autologin: false,
+        }]),
+        additional_packages: vec!["firefox".into(), "git".into(), "htop".into()],
+        extra_services: vec!["sshd".into()],
+        ..GlobalConfig::default()
+    }
+}
+
+pub fn welcome(app: &App) {
+    let state = app.global::<WelcomeState>();
+    state.set_app_version(env!("CARGO_PKG_VERSION").into());
+    state.set_uefi_ok(true);
+    state.set_zfs_ok(true);
+    state.set_net_ok(true);
+    let weak = app.as_weak();
+    state.on_check_internet(move || {
+        if let Some(app) = weak.upgrade() {
+            let wifi = app.global::<crate::ui::WifiState>();
+            app.global::<WelcomeState>()
+                .set_net_ok(wifi.get_ethernet_connected() || !wifi.get_current_ssid().is_empty());
+        }
+    });
+}
+
+pub fn packages(query: &str, aur: bool) -> Vec<PackageSearchResult> {
+    [
+        ("firefox", "Fast, private web browser"),
+        ("git", "Distributed version control"),
+        ("htop", "Interactive process viewer"),
+        (
+            "visual-studio-code-bin",
+            "Code editor with integrated debugging",
+        ),
+    ]
+    .into_iter()
+    .filter(|(name, _)| name.contains(query))
+    .map(|(name, description)| PackageSearchResult {
+        name: name.into(),
+        description: description.into(),
+        repo: if aur { "aur" } else { "extra" }.into(),
+    })
+    .collect()
+}
+
+pub fn install(app: &App, config: &std::rc::Rc<std::cell::RefCell<GlobalConfig>>) {
+    app.global::<InstallState>()
+        .set_log_messages(ModelRc::new(VecModel::<LogMessage>::default()));
+    let weak = app.as_weak();
+    let config = config.clone();
+    app.on_install_requested(move || {
+        if let Some(app) = weak.upgrade() {
+            if let Some(error) = config.borrow().validate_for_install().first() {
+                app.global::<WizardState>()
+                    .set_status_text(format!("Validation: {error}").into());
+                return;
+            }
+            progress(&app, 1);
+            advance(app.as_weak());
+        }
+    });
+    let weak = app.as_weak();
+    app.on_cancel_requested(move || {
+        if let Some(app) = weak.upgrade() {
+            progress(&app, 5);
+        }
+    });
+}
+
+fn advance(weak: slint::Weak<App>) {
+    slint::Timer::single_shot(Duration::from_secs(1), move || {
+        let Some(app) = weak.upgrade() else { return };
+        let state = app.global::<InstallState>();
+        if state.get_state() != 1 {
+            return;
+        }
+        let phase = state.get_phase() + 1;
+        if phase >= state.get_total_phases() {
+            progress(&app, 2);
+        } else {
+            state.set_phase(phase);
+            advance(app.as_weak());
+        }
+    });
+}
+
+fn progress(app: &App, state: i32) {
+    let install = app.global::<InstallState>();
+    install.set_state(state);
+    install.set_phase(5);
+    install.set_phase_label("Installing base system".into());
+    install.set_download_active(state == 1);
+    install.set_download_pct(62);
+    install.set_download_status("62% · 24.8 MiB/s · 18 seconds remaining".into());
+    install.set_download_items(ModelRc::new(VecModel::from(vec![DownloadInfo {
+        filename: "linux-7.2.3.arch1-3-x86_64.pkg.tar.zst".into(),
+        pct: 62,
+        speed: "24.8 MiB/s".into(),
+        state: 0,
+    }])));
+    install.set_log_messages(ModelRc::new(VecModel::from(vec![
+        LogMessage {
+            text: "Preview: prepared simulated disk and ZFS datasets".into(),
+            level: 0,
+        },
+        LogMessage {
+            text: if state == 3 {
+                "Download failed: connection interrupted. No disks were modified."
+            } else {
+                "Preview: installing base packages"
+            }
+            .into(),
+            level: if state == 3 { 4 } else { 2 },
+        },
+    ])));
+}
+
+pub fn show(app: &App, scene: Scene, size: Size) {
+    app.set_preview_mode(true);
+    // The headless backend does not consume SLINT_SCALE_FACTOR. Deliver the
+    // same event a desktop backend emits so screenshot tests exercise real DPI.
+    if let Ok(value) = std::env::var("SLINT_SCALE_FACTOR")
+        && let Ok(scale_factor) = value.parse::<f32>()
+        && scale_factor.is_finite()
+        && scale_factor > 0.0
+    {
+        app.window()
+            .dispatch_event(slint::platform::WindowEvent::ScaleFactorChanged { scale_factor });
+    }
+    app.window()
+        .set_size(slint::PhysicalSize::new(size.0, size.1));
+    let step = match scene {
+        Scene::Welcome | Scene::Offline => 0,
+        Scene::Disk | Scene::NewPool | Scene::ExistingPool => 1,
+        Scene::Zfs => 2,
+        Scene::System => 3,
+        Scene::Users => 4,
+        Scene::Desktop => 5,
+        _ => 6,
+    };
+    app.global::<WizardState>().set_max_visited(6);
+    app.global::<WizardState>().invoke_go_to(step);
+    if matches!(scene, Scene::Offline) {
+        app.global::<WelcomeState>().set_net_ok(false);
+        app.global::<crate::ui::WifiState>()
+            .set_ethernet_connected(false);
+    }
+    match scene {
+        Scene::Install => progress(app, 1),
+        Scene::Done => progress(app, 2),
+        Scene::Failed => progress(app, 3),
+        Scene::Cancelled => progress(app, 5),
+        Scene::Inspect => inspect(app),
+        _ => {}
+    }
+}
+
+fn inspect(app: &App) {
+    use crate::ui::{DemoDataset, DemoPool, DemoState};
+    use slint::Model;
+    let state = app.global::<DemoState>();
+    let pools = std::rc::Rc::new(VecModel::from(vec![
+        DemoPool {
+            name: "zroot".into(),
+            state: "ONLINE".into(),
+            imported: true,
+            owned: false,
+        },
+        DemoPool {
+            name: "backup-workstation".into(),
+            state: "ONLINE".into(),
+            imported: false,
+            owned: false,
+        },
+    ]));
+    state.set_pools(pools.clone().into());
+    state.set_datasets(ModelRc::new(VecModel::from(vec![
+        DemoDataset {
+            name: "zroot/ROOT/arch0".into(),
+            kind: "filesystem".into(),
+        },
+        DemoDataset {
+            name: "zroot/ROOT/arch0/home".into(),
+            kind: "filesystem".into(),
+        },
+    ])));
+    state.set_status("Simulated pools and datasets".into());
+    state.set_popup_visible(true);
+    let import_pools = pools.clone();
+    state.on_import_readonly(move |name| {
+        for index in 0..import_pools.row_count() {
+            let mut pool = import_pools.row_data(index).unwrap();
+            if pool.name == name {
+                pool.imported = true;
+                pool.owned = true;
+                import_pools.set_row_data(index, pool);
+            }
+        }
+    });
+    state.on_export_pool(move |name| {
+        for index in 0..pools.row_count() {
+            let mut pool = pools.row_data(index).unwrap();
+            if pool.name == name {
+                pool.imported = false;
+                pool.owned = false;
+                pools.set_row_data(index, pool);
+            }
+        }
+    });
+    let weak = app.as_weak();
+    state.on_select_pool(move |name| {
+        if let Some(app) = weak.upgrade() {
+            app.invoke_text_confirmed("pool_name".into(), name);
+            app.global::<DemoState>().set_popup_visible(false);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installation_fixtures_are_valid_and_select_visible_devices() {
+        let disks = disks();
+        let partitions = partitions();
+        for scene in [Scene::Disk, Scene::NewPool, Scene::ExistingPool] {
+            let config = config(scene);
+            assert!(config.validate_for_install().is_empty());
+            assert!(disks.iter().any(|d| Some(&d.path) == config.disk.as_ref()));
+            assert!(
+                partitions
+                    .iter()
+                    .any(|p| Some(&p.path) == config.efi_partition.as_ref())
+            );
+            assert!(
+                partitions
+                    .iter()
+                    .any(|p| Some(&p.path) == config.zfs_partition.as_ref())
+            );
+        }
+        assert!(disks.iter().any(|disk| disk.removable));
+    }
+}

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -43,6 +43,13 @@ import { InstallView } from "views/install-view.slint";
 // ── Main application ─────────────────────────────────
 
 export component App inherits Window {
+    in property <bool> preview-mode: false;
+    property <bool> popup-open: PopupState.select-visible || PopupState.text-input-visible
+        || PopupState.users-visible || PopupState.pkg-search-visible || PopupState.strlist-visible
+        || PopupState.multi-select-visible || PopupState.wifi-visible || DemoState.popup-visible;
+    changed popup-open => {
+        if !root.popup-open && InstallState.state == 0 { main-focus-scope.focus(); }
+    }
     background: Theme.c.base;
     preferred-width: 800px;
     preferred-height: 600px;
@@ -81,6 +88,34 @@ export component App inherits Window {
     callback key-nav-up();
     callback key-nav-activate();
 
+    function handle-global-key(text: string) -> bool {
+            if WizardState.current-step > 0 {
+                if text == "j" || text == Key.DownArrow { key-nav-down(); return true; }
+                if text == "k" || text == Key.UpArrow { key-nav-up(); return true; }
+                if text == Key.Return { key-nav-activate(); return true; }
+            }
+            if text == Key.Tab {
+                WizardState.next();
+                return true;
+            }
+            if text == Key.Backtab {
+                WizardState.back();
+                return true;
+            }
+            if text == "q" {
+                quit-requested();
+                return true;
+            }
+            if text == "1" { WizardState.go-to(0); return true; }
+            if text == "2" { WizardState.go-to(1); return true; }
+            if text == "3" { WizardState.go-to(2); return true; }
+            if text == "4" { WizardState.go-to(3); return true; }
+            if text == "5" { WizardState.go-to(4); return true; }
+            if text == "6" { WizardState.go-to(5); return true; }
+            if text == "7" { WizardState.go-to(6); return true; }
+            return false;
+            }
+
     // ── Global keyboard shortcuts ──────────────────
     // Wizard-local keys (j/k/arrows/Enter) live inside WizardView's own
     // FocusScope; this scope only handles globally-meaningful shortcuts
@@ -96,44 +131,40 @@ export component App inherits Window {
             && !PopupState.multi-select-visible
             && !PopupState.wifi-visible;
         key-pressed(e) => {
-            if e.text == Key.Tab {
-                WizardState.next();
-                return accept;
-            }
-            if e.text == Key.Backtab {
-                WizardState.back();
-                return accept;
-            }
-            if e.text == "q" {
-                quit-requested();
-                return accept;
-            }
-            if e.text == "1" { WizardState.go-to(0); return accept; }
-            if e.text == "2" { WizardState.go-to(1); return accept; }
-            if e.text == "3" { WizardState.go-to(2); return accept; }
-            if e.text == "4" { WizardState.go-to(3); return accept; }
-            if e.text == "5" { WizardState.go-to(4); return accept; }
-            if e.text == "6" { WizardState.go-to(5); return accept; }
-            if e.text == "7" { WizardState.go-to(6); return accept; }
+            if root.handle-global-key(e.text) { return accept; }
             return reject;
+        }
+    }
+
+    if root.preview-mode: Rectangle {
+        y: 0px;
+        height: 32px;
+        background: Theme.c.surface0;
+        Text {
+            text: "UI preview · Simulated devices and installation";
+            color: Theme.c.yellow;
+            font-size: 12px;
+            horizontal-alignment: center;
+            vertical-alignment: center;
         }
     }
 
     // ── Welcome screen (step 0, no sidebar) ───────────
     if InstallState.state == 0 && WizardState.current-step == 0: WelcomeView {
-        y: DemoState.enabled ? 32px : 0px;
+        y: DemoState.enabled || root.preview-mode ? 32px : 0px;
         height: root.height - self.y;
         quit-requested() => { quit-requested(); }
     }
 
     // ── Wizard config screen (steps 1+, with sidebar) ──
     if InstallState.state == 0 && WizardState.current-step > 0: WizardView {
-        y: DemoState.enabled ? 32px : 0px;
+        y: DemoState.enabled || root.preview-mode ? 32px : 0px;
         height: root.height - self.y;
         item-activated(key) => { item-activated(key); }
         toggle-activated(key) => { toggle-activated(key); }
         install-requested() => { install-requested(); }
         quit-requested() => { quit-requested(); }
+        global-key(text) => { return root.handle-global-key(text); }
         key-nav-down() => { key-nav-down(); }
         key-nav-up() => { key-nav-up(); }
         key-nav-activate() => { key-nav-activate(); }
@@ -141,7 +172,9 @@ export component App inherits Window {
 
     // ── Install progress screen ──────────────────────
     if InstallState.state >= 1: InstallView {
-        y: DemoState.enabled ? 32px : 0px;
+        width: min(root.width, 1280px);
+        x: (root.width - self.width) / 2;
+        y: DemoState.enabled || root.preview-mode ? 32px : 0px;
         height: root.height - self.y;
         quit-requested() => { quit-requested(); }
         reboot-requested() => { reboot-requested(); }

--- a/slint-ui/ui/components/config-item.slint
+++ b/slint-ui/ui/components/config-item.slint
@@ -50,6 +50,13 @@ export component ConfigItemRow inherits Rectangle {
     callback toggled(string);            // toggle items
     callback action-clicked(string);     // action items ("install" / "quit")
     callback focus-requested(int);       // pointer hover/click → set focus
+    callback ensure-visible(length, length);
+
+    changed focused-index => {
+        if root.focused-index == root.index {
+            root.ensure-visible(root.y, root.height);
+        }
+    }
 
     // Pre-computed predicates so the rest of the component reads cleanly.
     // Section header and radio header render identically — the distinction
@@ -66,7 +73,7 @@ export component ConfigItemRow inherits Rectangle {
     property <bool> is-grouped-radio-option: is-radio-option && item.group-label != "";
     property <bool> is-readonly: item.item-type == ItemType.readonly;
     property <bool> is-toggle: item.item-type == ItemType.toggle;
-    property <bool> has-choice-details: item.icon != "";
+    property <bool> has-choice-details: item.icon != "" || is-grouped-radio-option;
     property <bool> has-device-secondary-text: item.detail-model != ""
         || item.detail-serial != "" || item.persistent-path != "";
     property <bool> has-secondary-text: has-device-secondary-text || item.description != "";
@@ -81,12 +88,13 @@ export component ConfigItemRow inherits Rectangle {
         || is-radio-subheader;
 
     height: is-separator ? 8px
-          : is-warning ? 32px
+          : is-warning ? max(32px, warning-text.preferred-height + 16px)
           : is-section-header ? 36px
           : is-radio-subheader ? (has-secondary-text ? 48px : 40px)
-          : is-grouped-radio-option ? (has-secondary-text ? 46px : 36px)
-          : is-radio-option ? (has-secondary-text ? 58px : 40px)
+          : is-grouped-radio-option ? (has-secondary-text ? 62px : 44px)
+          : is-radio-option ? (has-choice-details ? 86px : has-secondary-text ? 62px : 44px)
           : is-action ? 40px
+          : is-readonly && has-device-secondary-text ? 92px
           : is-readonly && has-secondary-text ? 52px
           : 44px;
 
@@ -145,10 +153,13 @@ export component ConfigItemRow inherits Rectangle {
     }
 
     // ── Warning ──
-    if is-warning: HorizontalLayout {
+    HorizontalLayout {
+        visible: root.is-warning;
         padding-left: 12px;
+        padding-right: 12px;
+        padding-top: 8px;
+        padding-bottom: 8px;
         spacing: 8px;
-        alignment: start;
 
         Text {
             text: "\u{26a0}";
@@ -156,11 +167,13 @@ export component ConfigItemRow inherits Rectangle {
             font-size: 14px;
             vertical-alignment: center;
         }
-        Text {
+        warning-text := Text {
             text: item.value;
             color: Theme.c.yellow;
             font-size: 13px;
             vertical-alignment: center;
+            horizontal-stretch: 1;
+            wrap: word-wrap;
         }
     }
 
@@ -249,121 +262,78 @@ export component ConfigItemRow inherits Rectangle {
         }
     }
 
-    // ── Radio option (sits on the section card) ──
+    // Device identity and capacity lead; paths and serials stay on separate lines.
     if is-radio-option: HorizontalLayout {
         padding-left: 14px;
         padding-right: 14px;
         spacing: 10px;
-        alignment: start;
 
         RadioDot {
             filled: item.value == "selected";
             dot-color: item.value == "selected" ? Theme.c.green : Theme.c.overlay0;
         }
 
-        if item.icon != "": Rectangle {
-            width: 20px;
-            horizontal-stretch: 0;
-
-            Icon {
-                source: item.icon == "usb"
-                    ? @image-url("../../assets/icons/usb.svg")
-                    : @image-url("../../assets/icons/hard-drive.svg");
-                size: 20px;
-                tint: item.value == "selected" ? Theme.c.blue : Theme.c.overlay0;
-                y: (parent.height - self.height) / 2;
-            }
+        if item.icon != "": Icon {
+            source: item.icon == "usb"
+                ? @image-url("../../assets/icons/usb.svg")
+                : @image-url("../../assets/icons/hard-drive.svg");
+            size: 20px;
+            tint: item.value == "selected" ? Theme.c.blue : Theme.c.overlay0;
         }
 
         VerticalLayout {
             horizontal-stretch: 1;
             alignment: center;
-            spacing: 3px;
+            spacing: 5px;
 
             HorizontalLayout {
-                spacing: 6px;
-                horizontal-stretch: 1;
-
+                spacing: 12px;
                 Text {
-                    text: item.label;
-                    color: item.value == "selected" ? Theme.c.text : Theme.c.subtext0;
+                    text: has-choice-details && item.detail-model != "" && !is-grouped-radio-option ? item.detail-model : item.label;
+                    color: Theme.c.text;
                     font-size: 14px;
                     font-weight: has-choice-details ? FontWeight.semi-bold : FontWeight.normal;
-                    vertical-alignment: has-secondary-text ? bottom : center;
+                    vertical-alignment: center;
                     horizontal-stretch: 1;
                     overflow: elide;
                 }
-
-                if item.detail-size != "": DetailPill {
-                    label: item.detail-size;
-                    horizontal-stretch: 0;
-                }
-
-                if item.detail-media != "": DetailPill {
-                    label: item.detail-media;
-                    horizontal-stretch: 0;
-                }
-
-                if item.detail-transport != "": DetailPill {
-                    label: item.detail-transport;
-                    horizontal-stretch: 0;
-                }
-
-                if item.is-removable: DetailPill {
-                    label: "removable";
+                if item.detail-size != "": Text {
+                    text: item.detail-size;
+                    color: Theme.c.text;
+                    font-size: 14px;
+                    font-weight: FontWeight.semi-bold;
+                    vertical-alignment: center;
                     horizontal-stretch: 0;
                 }
             }
 
-            if has-secondary-text: HorizontalLayout {
-                spacing: 6px;
-                horizontal-stretch: 1;
-
-                if item.detail-model != "": Text {
-                    text: item.detail-model;
-                    color: Theme.c.overlay0;
+            if has-choice-details && !is-grouped-radio-option: HorizontalLayout {
+                spacing: 10px;
+                Text {
+                    text: item.label + (item.detail-serial != "" ? "  ·  SN " + item.detail-serial : "");
+                    color: Theme.c.subtext0;
                     font-size: 12px;
-                    vertical-alignment: top;
-                    horizontal-stretch: item.persistent-path == "" ? 1 : 0;
+                    horizontal-stretch: 1;
                     overflow: elide;
                 }
-
-                if item.detail-serial != "": Text {
-                    text: "SN " + item.detail-serial;
-                    color: Theme.c.overlay0;
+                Text {
+                    text: item.detail-transport.to-uppercase() + (item.is-removable ? " · Removable" : " · " + item.detail-media);
+                    color: item.is-removable ? Theme.c.yellow : Theme.c.subtext0;
                     font-size: 12px;
-                    vertical-alignment: top;
-                    horizontal-stretch: item.detail-model == "" && item.persistent-path == "" ? 1 : 0;
-                    max-width: 160px;
-                    overflow: elide;
-                }
-
-                if item.persistent-path != "": Text {
-                    text: item.persistent-kind;
-                    color: Theme.c.blue;
-                    font-size: 12px;
-                    font-weight: FontWeight.semi-bold;
-                    vertical-alignment: top;
                     horizontal-stretch: 0;
                 }
-
-                if item.persistent-path != "": Text {
-                    text: item.persistent-path;
-                    color: Theme.c.overlay0;
-                    font-size: 12px;
-                    vertical-alignment: top;
-                    horizontal-stretch: 1;
-                    overflow: elide;
-                }
-
-                if !has-device-secondary-text && item.description != "": Text {
-                    text: item.description;
-                    color: Theme.c.overlay0;
-                    font-size: 12px;
-                    vertical-alignment: top;
-                    horizontal-stretch: 1;
-                    overflow: elide;
-                }
+            }
+            if has-choice-details && item.persistent-path != "": Text {
+                text: item.persistent-path;
+                color: Theme.c.overlay0;
+                font-size: 11px;
+                overflow: elide;
+            }
+            if !has-choice-details && item.description != "": Text {
+                text: item.description;
+                color: Theme.c.subtext0;
+                font-size: 12px;
+                overflow: elide;
             }
         }
     }
@@ -389,111 +359,45 @@ export component ConfigItemRow inherits Rectangle {
         }
     }
 
-    // ── Read-only summary (review step) — sits on the section card ──
-    if is-readonly: HorizontalLayout {
+    // Review keeps complete device identity on separate, readable lines.
+    if is-readonly && has-device-secondary-text: VerticalLayout {
+        padding-left: 14px;
+        padding-right: 14px;
+        alignment: center;
+        spacing: 5px;
+        HorizontalLayout {
+            spacing: 12px;
+            Text { text: item.label; color: Theme.c.subtext0; font-size: 13px; }
+            Text {
+                text: item.detail-model != "" ? item.detail-model : item.value;
+                color: Theme.c.text; font-size: 13px; font-weight: FontWeight.semi-bold;
+                horizontal-stretch: 1; horizontal-alignment: right; overflow: elide;
+            }
+            Text { text: item.detail-size; color: Theme.c.text; font-size: 13px; }
+        }
+        Text {
+            text: item.value + (item.detail-serial != "" ? " · SN " + item.detail-serial : "")
+                + (item.is-removable ? " · Removable" : "");
+            color: item.is-removable ? Theme.c.yellow : Theme.c.subtext0;
+            font-size: 12px; overflow: elide;
+        }
+        Text {
+            text: item.persistent-path;
+            color: Theme.c.overlay0; font-size: 11px; overflow: elide;
+        }
+    }
+    if is-readonly && !has-device-secondary-text: HorizontalLayout {
         padding-left: 14px;
         padding-right: 14px;
         spacing: 12px;
-
         Text {
-            text: item.label;
-            color: Theme.c.subtext0;
-            font-size: 13px;
-            vertical-alignment: center;
-            horizontal-stretch: 0;
+            text: item.label; color: Theme.c.subtext0; font-size: 13px;
+            vertical-alignment: center; horizontal-stretch: 0;
         }
-
-        VerticalLayout {
-            horizontal-stretch: 1;
-            alignment: center;
-            spacing: 1px;
-
-            Text {
-                text: item.value;
-                color: item.is-empty ? Theme.c.overlay0 : Theme.c.green;
-                font-size: 13px;
-                vertical-alignment: has-secondary-text ? bottom : center;
-                horizontal-alignment: right;
-                horizontal-stretch: 1;
-                overflow: elide;
-            }
-
-            if has-secondary-text: HorizontalLayout {
-                spacing: 6px;
-                horizontal-stretch: 1;
-
-                Rectangle { horizontal-stretch: 1; }
-
-                if item.detail-model != "": Text {
-                    text: item.detail-model;
-                    color: Theme.c.overlay0;
-                    font-size: 12px;
-                    vertical-alignment: top;
-                    horizontal-stretch: 0;
-                    max-width: 160px;
-                    overflow: elide;
-                }
-
-                if item.detail-serial != "": Text {
-                    text: "SN " + item.detail-serial;
-                    color: Theme.c.overlay0;
-                    font-size: 12px;
-                    vertical-alignment: top;
-                    horizontal-stretch: 0;
-                    max-width: 100px;
-                    overflow: elide;
-                }
-
-                if item.detail-size != "": DetailPill {
-                    label: item.detail-size;
-                    horizontal-stretch: 0;
-                }
-
-                if item.detail-media != "": DetailPill {
-                    label: item.detail-media;
-                    horizontal-stretch: 0;
-                }
-
-                if item.detail-transport != "": DetailPill {
-                    label: item.detail-transport;
-                    horizontal-stretch: 0;
-                }
-
-                if item.is-removable: DetailPill {
-                    label: "removable";
-                    horizontal-stretch: 0;
-                }
-
-                if item.persistent-path != "": Text {
-                    text: item.persistent-kind;
-                    color: Theme.c.blue;
-                    font-size: 12px;
-                    font-weight: FontWeight.semi-bold;
-                    vertical-alignment: top;
-                    horizontal-stretch: 0;
-                }
-
-                if item.persistent-path != "": Text {
-                    text: item.persistent-path;
-                    color: Theme.c.overlay0;
-                    font-size: 12px;
-                    vertical-alignment: top;
-                    horizontal-stretch: 0;
-                    max-width: 240px;
-                    overflow: elide;
-                }
-
-                if !has-device-secondary-text && item.description != "": Text {
-                    text: item.description;
-                    color: Theme.c.overlay0;
-                    font-size: 12px;
-                    vertical-alignment: top;
-                    horizontal-alignment: right;
-                    horizontal-stretch: 0;
-                    max-width: 300px;
-                    overflow: elide;
-                }
-            }
+        Text {
+            text: item.value; color: item.is-empty ? Theme.c.overlay0 : Theme.c.text;
+            font-size: 13px; vertical-alignment: center;
+            horizontal-alignment: right; horizontal-stretch: 1; overflow: elide;
         }
     }
 
@@ -521,13 +425,7 @@ export component ConfigItemRow inherits Rectangle {
             spacing: 6px;
             horizontal-stretch: 1;
 
-            if is-toggle: RadioDot {
-                width: 14px;
-                dot-size: 10px;
-                filled: item.value == "Enabled";
-                dot-color: item.value == "Enabled" ? Theme.c.green : Theme.c.overlay0;
-                horizontal-stretch: 0;
-            }
+
 
             Text {
                 text: item.value;
@@ -538,20 +436,34 @@ export component ConfigItemRow inherits Rectangle {
                 horizontal-stretch: 1;
                 overflow: elide;
             }
+            if is-toggle: RadioDot {
+                width: 14px;
+                dot-size: 10px;
+                filled: item.value == "Enabled";
+                dot-color: item.value == "Enabled" ? Theme.c.green : Theme.c.overlay0;
+                horizontal-stretch: 0;
+            }
+            if !is-toggle: Text {
+                text: "›"; color: Theme.c.overlay0; font-size: 18px;
+                width: 14px; vertical-alignment: center;
+            }
+
         }
     }
 
+    function activate() {
+        root.focus-requested(index);
+        if is-action { root.action-clicked(item.key); }
+        else if is-toggle { root.toggled(item.key); }
+        else if !is-non-interactive { root.activated(item.key); }
+    }
+    if !is-non-interactive: Rectangle {
+        accessible-role: button;
+        accessible-label: item.label + (has-choice-details ? " " + item.detail-model + " " + item.persistent-path : "");
+        accessible-action-default => { root.activate(); }
+    }
     row-ta := TouchArea {
         mouse-cursor: is-non-interactive ? default : pointer;
-        clicked => {
-            root.focus-requested(index);
-            if is-action {
-                root.action-clicked(item.key);
-            } else if is-toggle {
-                root.toggled(item.key);
-            } else if !is-non-interactive {
-                root.activated(item.key);
-            }
-        }
+        clicked => { root.activate(); }
     }
 }

--- a/slint-ui/ui/components/icon.slint
+++ b/slint-ui/ui/components/icon.slint
@@ -15,7 +15,8 @@
 
 import { Theme } from "../styling.slint";
 
-export component Icon inherits Image {
+export component Icon inherits Rectangle {
+    in property <image> source;
     // Square edge length. Defaults to `font-lg` (16px) which matches
     // the inline-with-text use case — icons next to a standard label.
     in property <length> size: Theme.font-lg;
@@ -26,8 +27,16 @@ export component Icon inherits Image {
     in property <brush> tint: Theme.c.text;
 
     width: size;
-    height: size;
-    colorize: tint;
-    image-fit: contain;
+    min-height: size;
+    preferred-height: size;
     accessible-role: none;
+
+    // The slot follows the row height; the image stays square and centered.
+    Image {
+        source: root.source;
+        width: root.size;
+        height: root.size;
+        colorize: root.tint;
+        image-fit: contain;
+    }
 }

--- a/slint-ui/ui/popups/text-input-popup.slint
+++ b/slint-ui/ui/popups/text-input-popup.slint
@@ -60,7 +60,7 @@ export component TextInputPopup inherits Rectangle {
                     accepted(val) => { root.confirmed(val); }
                 }
 
-                init => { input.focus-input(); }
+                init => { input.focus-input(); root.text-edited(root.input-text); }
 
                 // Password strength bar
                 if root.is-password && root.strength-score >= 0: VerticalLayout {

--- a/slint-ui/ui/popups/user-manage-popup.slint
+++ b/slint-ui/ui/popups/user-manage-popup.slint
@@ -143,6 +143,7 @@ export component UserManagePopup inherits Rectangle {
                 username-input := StyledTextInput {
                     placeholder: "username";
                 }
+                init => { username-input.focus-input(); root.password-edited(""); }
 
                 password-input := StyledTextInput {
                     placeholder: "password (optional)";

--- a/slint-ui/ui/popups/wifi-popup.slint
+++ b/slint-ui/ui/popups/wifi-popup.slint
@@ -523,7 +523,7 @@ export component WifiPopup inherits Rectangle {
                         text: WifiState.status-text != ""
                             ? WifiState.status-text
                             : (WifiState.phase == WifiPhase.verifying
-                                ? "Waiting for IP address…"
+                                ? "Checking internet access…"
                                 : "Connecting…");
                         color: Theme.c.subtext0;
                         font-size: Theme.font-base;
@@ -564,7 +564,8 @@ export component WifiPopup inherits Rectangle {
                 }
 
                 // — error — failure + retry actions —
-                if WifiState.phase == WifiPhase.error: VerticalLayout {
+                if WifiState.phase == WifiPhase.error
+                    || WifiState.phase == WifiPhase.no-internet: VerticalLayout {
                     alignment: center;
                     spacing: Theme.spacing-md;
 
@@ -580,7 +581,8 @@ export component WifiPopup inherits Rectangle {
                     }
 
                     Text {
-                        text: "Connection failed";
+                        text: WifiState.phase == WifiPhase.no-internet
+                            ? "Internet access not verified" : "Connection failed";
                         color: Theme.c.red;
                         font-size: Theme.font-lg;
                         font-weight: 600;
@@ -601,6 +603,7 @@ export component WifiPopup inherits Rectangle {
             // ───────────────── FOOTER (phase-driven buttons) ─────────────────
             if WifiState.phase == WifiPhase.auth
                 || WifiState.phase == WifiPhase.error
+                || WifiState.phase == WifiPhase.no-internet
                 || WifiState.phase == WifiPhase.connected: HorizontalLayout {
                     height: Theme.control-height;
                     alignment: end;
@@ -620,19 +623,22 @@ export component WifiPopup inherits Rectangle {
                 }
 
                 // Error phase: Back to the last list, or run a fresh scan.
-                if WifiState.phase == WifiPhase.error: StyledButton {
+                if WifiState.phase == WifiPhase.error
+                    || WifiState.phase == WifiPhase.no-internet: StyledButton {
                     label: "Back";
                     style: Theme.button-default;
                     clicked => { WifiState.cancel-pick(); }
                 }
-                if WifiState.phase == WifiPhase.error: StyledButton {
+                if WifiState.phase == WifiPhase.error
+                    || WifiState.phase == WifiPhase.no-internet: StyledButton {
                     label: "Rescan";
                     style: Theme.button-primary;
                     clicked => { WifiState.rescan(); }
                 }
 
                 // Connected phase: Disconnect button for quick access
-                if WifiState.phase == WifiPhase.connected: StyledButton {
+                if WifiState.phase == WifiPhase.connected
+                    || WifiState.phase == WifiPhase.no-internet: StyledButton {
                     label: "Disconnect";
                     style: Theme.button-default;
                     clicked => { WifiState.disconnect(); }

--- a/slint-ui/ui/popups/wifi-popup.slint
+++ b/slint-ui/ui/popups/wifi-popup.slint
@@ -79,6 +79,11 @@ export component WifiPopup inherits Rectangle {
                 return accept;
             }
 
+            if ev.text == Key.Return && WifiState.phase == WifiPhase.connected {
+                WifiState.close();
+                return accept;
+            }
+
             // Below here: only relevant in the picking phase (list
             // navigation). Auth phase delegates Enter to the text
             // input itself so show-password toggles and normal text
@@ -121,7 +126,9 @@ export component WifiPopup inherits Rectangle {
     // Centered card
     Rectangle {
         width: min(560px, parent.width - 64px);
-        height: min(620px, parent.height - 64px);
+        height: min(WifiState.phase == WifiPhase.connected ? 340px
+            : WifiState.phase == WifiPhase.picking || WifiState.phase == WifiPhase.scanning ? 520px
+            : 400px, parent.height - 48px);
         background: Theme.c.base;
         border-radius: Theme.radius-lg;
         border-width: 1px;
@@ -139,8 +146,8 @@ export component WifiPopup inherits Rectangle {
 
             // ───────────────── HEADER ─────────────────
             HorizontalLayout {
+                height: 40px;
                 spacing: Theme.spacing-sm;
-                alignment: start;
 
                 Icon {
                     source: @image-url("../../assets/icons/wifi.svg");
@@ -157,16 +164,11 @@ export component WifiPopup inherits Rectangle {
                     horizontal-stretch: 1;
                 }
 
-                // Rescan only meaningful in picking phase.
-                if WifiState.phase == WifiPhase.picking: StyledButton {
-                    label: "Rescan";
-                    style: Theme.button-ghost;
-                    clicked => { WifiState.rescan(); }
-                }
-
                 StyledButton {
                     label: "Close";
-                    style: Theme.button-ghost;
+                    width: 88px;
+                    height: 40px;
+                    style: Theme.button-default;
                     clicked => { WifiState.close(); }
                 }
             }
@@ -381,8 +383,11 @@ export component WifiPopup inherits Rectangle {
 
                                 // Forget action for known networks
                                 if net.known: Rectangle {
-                                    width: 28px;
-                                    height: 28px;
+                                    width: 32px;
+                                    height: 32px;
+                                    accessible-role: button;
+                                    accessible-label: "Forget " + net.ssid;
+                                    accessible-action-default => { WifiState.forget(idx); }
                                     y: (parent.height - self.height) / 2;
                                     background: forget-ta.has-hover
                                         ? Theme.c.red : transparent;
@@ -440,12 +445,16 @@ export component WifiPopup inherits Rectangle {
                                 horizontal-stretch: 1;
                             }
 
-                            SignalBars {
-                                percent: WifiState.selected-index >= 0
-                                    && WifiState.selected-index < WifiState.networks.length
-                                    ? WifiState.networks[WifiState.selected-index].signal-percent
-                                    : 0;
-                                lit: Theme.c.subtext0;
+                            VerticalLayout {
+                                alignment: center;
+                                horizontal-stretch: 0;
+                                SignalBars {
+                                    percent: WifiState.selected-index >= 0
+                                        && WifiState.selected-index < WifiState.networks.length
+                                        ? WifiState.networks[WifiState.selected-index].signal-percent
+                                        : 0;
+                                    lit: Theme.c.subtext0;
+                                }
                             }
                         }
                     }
@@ -595,17 +604,18 @@ export component WifiPopup inherits Rectangle {
                         font-size: Theme.font-sm;
                         horizontal-alignment: center;
                         wrap: word-wrap;
-                        width: 400px;
+                        width: min(400px, parent.width);
                     }
                 }
             }
 
             // ───────────────── FOOTER (phase-driven buttons) ─────────────────
             if WifiState.phase == WifiPhase.auth
+                || WifiState.phase == WifiPhase.picking
                 || WifiState.phase == WifiPhase.error
                 || WifiState.phase == WifiPhase.no-internet
                 || WifiState.phase == WifiPhase.connected: HorizontalLayout {
-                    height: Theme.control-height;
+                    height: 40px;
                     alignment: end;
                     spacing: Theme.spacing-sm;
 
@@ -636,12 +646,32 @@ export component WifiPopup inherits Rectangle {
                     clicked => { WifiState.rescan(); }
                 }
 
-                // Connected phase: Disconnect button for quick access
-                if WifiState.phase == WifiPhase.connected
+                if WifiState.phase == WifiPhase.picking: StyledButton {
+                    label: "Rescan";
+                    style: Theme.button-default;
+                    clicked => { WifiState.rescan(); }
+                }
+
+                // Disconnect belongs to network management, not the success action.
+                if (WifiState.phase == WifiPhase.picking && WifiState.current-ssid != "")
                     || WifiState.phase == WifiPhase.no-internet: StyledButton {
                     label: "Disconnect";
                     style: Theme.button-default;
                     clicked => { WifiState.disconnect(); }
+                }
+
+                if WifiState.phase == WifiPhase.connected: StyledButton {
+                    label: "Other networks";
+                    style: Theme.button-default;
+                    clicked => { WifiState.rescan(); }
+                }
+
+                if WifiState.phase == WifiPhase.connected
+                    || WifiState.phase == WifiPhase.picking: StyledButton {
+                    label: "Done";
+                    min-width: 100px;
+                    style: Theme.button-primary;
+                    clicked => { WifiState.close(); }
                 }
             }
         }

--- a/slint-ui/ui/popups/zfs-inspect-popup.slint
+++ b/slint-ui/ui/popups/zfs-inspect-popup.slint
@@ -74,42 +74,60 @@ export component ZfsInspectPopup inherits Rectangle {
                 ListView {
                     height: 180px;
                     for pool[index] in DemoState.pools: Rectangle {
-                        height: 48px;
+                        height: 64px;
                         background: Math.mod(index, 2) == 0 ? Theme.c.surface0 : Theme.c.base;
                         border-radius: Theme.radius-sm;
                         HorizontalLayout {
                             padding-left: Theme.spacing-md;
                             padding-right: Theme.spacing-sm;
+                            padding-top: Theme.spacing-sm;
+                            padding-bottom: Theme.spacing-sm;
                             spacing: Theme.spacing-sm;
-                            Text {
-                                text: pool.name;
-                                color: Theme.c.text;
-                                font-family: "monospace";
-                                vertical-alignment: center;
+                            VerticalLayout {
+                                alignment: center;
+                                spacing: 4px;
                                 horizontal-stretch: 1;
+                                Text {
+                                    text: pool.name;
+                                    color: Theme.c.text;
+                                    font-family: "monospace";
+                                    overflow: elide;
+                                }
+                                Text {
+                                    text: pool.imported
+                                        ? (pool.owned ? "read-only demo import" : "already imported")
+                                        : "available · " + pool.state;
+                                    color: pool.owned ? Theme.c.green : Theme.c.overlay0;
+                                    font-size: Theme.font-sm;
+                                    overflow: elide;
+                                }
                             }
-                            Text {
-                                text: pool.imported
-                                    ? (pool.owned ? "read-only demo import" : "already imported")
-                                    : "available · " + pool.state;
-                                color: pool.owned ? Theme.c.green : Theme.c.overlay0;
-                                font-size: Theme.font-sm;
-                                vertical-alignment: center;
+                            VerticalLayout {
+                                alignment: center;
+                                StyledButton {
+                                    label: "Use";
+                                    width: 64px;
+                                    height: 32px;
+                                    enabled: !DemoState.busy;
+                                    clicked => { DemoState.select-pool(pool.name); }
+                                }
                             }
-                            StyledButton {
-                                label: "Use";
-                                enabled: !DemoState.busy;
-                                clicked => { DemoState.select-pool(pool.name); }
-                            }
-                            if !pool.imported: StyledButton {
-                                label: "Import read-only";
-                                enabled: !DemoState.busy;
-                                clicked => { DemoState.import-readonly(pool.name); }
-                            }
-                            if pool.owned: StyledButton {
-                                label: "Export";
-                                enabled: !DemoState.busy;
-                                clicked => { DemoState.export-pool(pool.name); }
+                            Rectangle {
+                                width: 132px;
+                                if !pool.imported: StyledButton {
+                                    width: 100%;
+                                    height: 32px;
+                                    label: "Import read-only";
+                                    enabled: !DemoState.busy;
+                                    clicked => { DemoState.import-readonly(pool.name); }
+                                }
+                                if pool.owned: StyledButton {
+                                    width: 100%;
+                                    height: 32px;
+                                    label: "Export";
+                                    enabled: !DemoState.busy;
+                                    clicked => { DemoState.export-pool(pool.name); }
+                                }
                             }
                         }
                     }

--- a/slint-ui/ui/state/wifi-state.slint
+++ b/slint-ui/ui/state/wifi-state.slint
@@ -2,7 +2,7 @@
 // wifi popup / welcome-screen corner widget.
 //
 // The Rust controller (`slint-ui/src/controllers/wifi.rs`) owns the
-// async work — scanning, connecting, waiting for DHCP, subscribing to
+// async work — scanning, connecting, verifying internet access, subscribing to
 // iwd's `PropertiesChanged` signals — and pushes results here via
 // `upgrade_in_event_loop`. The Slint side only reads state and emits
 // user-intent callbacks.
@@ -17,6 +17,7 @@
 //   auth ──cancel-pick──▶ picking
 //   connecting ──iwd-ok──▶ verifying
 //   verifying ──online──▶ connected
+//   verifying ──timeout──▶ no-internet (Wi-Fi remains connected)
 //   * ──error──▶ error
 //   * ──close()──▶ idle  (controller aborts in-flight tasks)
 //
@@ -55,10 +56,10 @@ export global WifiState {
 
     // ── Status / feedback ──────────────────────────────────────────────
     // Free-form status line shown during scanning / connecting /
-    // verifying. Short, e.g. "Scanning on wlan0…" or "Waiting for DHCP…".
+    // verifying. Short, e.g. "Scanning on wlan0…" or "Checking internet access…".
     in property <string> status-text;
 
-    // Non-empty when phase == error. The popup shows this inline.
+    // Non-empty for error / no-internet. The popup shows this inline.
     in property <string> error-text;
 
     // ── Live connection info ───────────────────────────────────────────

--- a/slint-ui/ui/types.slint
+++ b/slint-ui/ui/types.slint
@@ -144,6 +144,7 @@ export enum WifiPhase {
     connecting,
     verifying,
     connected,
+    no-internet,
     error,
 }
 

--- a/slint-ui/ui/views/install-view.slint
+++ b/slint-ui/ui/views/install-view.slint
@@ -12,29 +12,16 @@ export component InstallView inherits VerticalLayout {
     callback reboot-requested();
     callback cancel-requested();
 
-    padding: 12px;
-    spacing: 8px;
+    padding: 20px;
+    spacing: 12px;
 
-    // Log area (fills available space)
-    log-view := ListView {
-        for msg[index] in InstallState.log-messages: Rectangle {
-            height: msg-text.preferred-height + 4px;
-
-            msg-text := Text {
-                text: msg.text;
-                color: msg.level == 4 ? Theme.c.red
-                     : msg.level == 3 ? Theme.c.yellow
-                     : msg.level == 2 ? Theme.c.green
-                     : msg.level == 1 ? Theme.c.blue
-                     : Theme.c.overlay0;
-                font-family: "monospace";
-                font-size: 12px;
-                x: 8px;
-                width: parent.width - 16px;
-                wrap: word-wrap;
-                vertical-alignment: center;
-            }
-        }
+    Text {
+        text: "Installation";
+        color: Theme.c.blue;
+        font-size: 24px;
+        font-weight: FontWeight.semi-bold;
+        height: 40px;
+        vertical-alignment: center;
     }
 
     // Auto-pin to the bottom whenever a new log line lands. Computed from
@@ -43,14 +30,14 @@ export component InstallView inherits VerticalLayout {
     // the top.
     property <int> scroll-trigger: InstallState.log-messages.length;
     changed scroll-trigger => {
-        log-view.viewport-y = -max(0px, log-view.viewport-height - log-view.height);
+        log-view.content-y = -max(0px, log-view.content-height - log-view.height);
     }
 
     // Progress card (always visible during install)
     Rectangle {
-        height: InstallState.download-active ? 232px
+        height: InstallState.download-active ? 188px
             : (InstallState.state == 1 || InstallState.state == 4) ? 132px
-            : 80px;
+            : 104px;
         background: Theme.c.surface0;
         border-radius: 10px;
 
@@ -214,4 +201,34 @@ export component InstallView inherits VerticalLayout {
             }
         }
     }
+    Text {
+        text: "Installation log";
+        color: Theme.c.subtext0;
+        font-size: 13px;
+        height: 24px;
+        vertical-alignment: center;
+    }
+    // Log area (fills available space)
+    log-view := ListView {
+        for msg[index] in InstallState.log-messages: Rectangle {
+            height: msg-text.preferred-height + 4px;
+
+            msg-text := Text {
+                text: msg.text;
+                color: msg.level == 4 ? Theme.c.red
+                     : msg.level == 3 ? Theme.c.yellow
+                     : msg.level == 2 ? Theme.c.green
+                     : msg.level == 1 ? Theme.c.blue
+                     : Theme.c.overlay0;
+                font-family: "monospace";
+                font-size: 12px;
+                x: 8px;
+                width: parent.width - 16px;
+                wrap: word-wrap;
+                vertical-alignment: center;
+            }
+        }
+    }
+
+
 }

--- a/slint-ui/ui/views/welcome-view.slint
+++ b/slint-ui/ui/views/welcome-view.slint
@@ -21,6 +21,9 @@ export component WelcomeView inherits Rectangle {
         height: 36px;
         background: quit-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
         border-radius: Theme.radius-sm;
+        accessible-role: button;
+        accessible-label: "Quit";
+        accessible-action-default => { root.quit-requested(); }
         quit-ta := TouchArea {
             clicked => { root.quit-requested(); }
             mouse-cursor: pointer;
@@ -41,6 +44,9 @@ export component WelcomeView inherits Rectangle {
     // shows and explains the situation on click (via the popup's
     // iwd-unavailable path, which just leaves the network list empty).
     if WifiState.has-hardware: Rectangle {
+        accessible-role: button;
+        accessible-label: "Network settings";
+        accessible-action-default => { WifiState.open(); }
         x: root.width - self.width - 16px;
         y: root.height - self.height - 16px;
         width: 172px;
@@ -64,11 +70,13 @@ export component WelcomeView inherits Rectangle {
             // for "iwd running but not associated", muted for "iwd not
             // running or no connection at all".
             Icon {
-                source: WifiState.current-ssid != ""
+                source: WifiState.ethernet-connected && WifiState.current-ssid == ""
+                    ? @image-url("../../assets/icons/ethernet-port.svg")
+                    : WifiState.current-ssid != ""
                     ? @image-url("../../assets/icons/wifi.svg")
                     : @image-url("../../assets/icons/wifi-off.svg");
                 size: 18px;
-                tint: WifiState.current-ssid != "" ? Theme.c.green
+                tint: WifiState.current-ssid != "" || WifiState.ethernet-connected ? Theme.c.green
                     : WifiState.iwd-running ? Theme.c.blue
                     : Theme.c.overlay0;
             }
@@ -78,8 +86,9 @@ export component WelcomeView inherits Rectangle {
             Text {
                 text: WifiState.current-ssid != ""
                     ? WifiState.current-ssid
+                    : WifiState.ethernet-connected ? "Ethernet connected"
                     : (WifiState.iwd-running ? "Not connected" : "WiFi unavailable");
-                color: WifiState.current-ssid != ""
+                color: WifiState.current-ssid != "" || WifiState.ethernet-connected
                     ? Theme.c.text : Theme.c.subtext0;
                 font-size: Theme.font-sm;
                 vertical-alignment: center;
@@ -159,22 +168,31 @@ export component WelcomeView inherits Rectangle {
                                 vertical-alignment: center;
                             }
 
-                            if !WelcomeState.net-ok: Rectangle {
-                                width: 90px;
-                                height: 30px;
-                                background: check-net-ta.has-hover ? Theme.c.surface1 : Theme.c.mantle;
-                                border-radius: 6px;
+                            if !WelcomeState.net-ok: VerticalLayout {
+                                alignment: center;
+                                horizontal-stretch: 0;
 
-                                check-net-ta := TouchArea {
-                                    clicked => { WelcomeState.check-internet(); }
-                                }
+                                Rectangle {
+                                    width: 90px;
+                                    height: 30px;
+                                    background: check-net-ta.has-hover ? Theme.c.surface1 : Theme.c.mantle;
+                                    border-radius: 6px;
+                                    accessible-role: button;
+                                    accessible-label: "Check again";
+                                    accessible-action-default => { WelcomeState.check-internet(); }
 
-                                Text {
-                                    text: "Check again";
-                                    color: Theme.c.blue;
-                                    font-size: 12px;
-                                    horizontal-alignment: center;
-                                    vertical-alignment: center;
+                                    check-net-ta := TouchArea {
+                                        clicked => { WelcomeState.check-internet(); }
+                                        mouse-cursor: pointer;
+                                    }
+
+                                    Text {
+                                        text: "Check again";
+                                        color: Theme.c.blue;
+                                        font-size: 12px;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
                                 }
                             }
                         }
@@ -310,6 +328,12 @@ export component WelcomeView inherits Rectangle {
                     alignment: center;
 
                     start-button := Rectangle {
+                        accessible-role: button;
+                        accessible-label: "Get Started";
+                        accessible-enabled: WelcomeState.all-checks-ok;
+                        accessible-action-default => {
+                            if WelcomeState.all-checks-ok { WizardState.go-to(1); }
+                        }
                         width: 160px;
                         height: 44px;
                         background: Theme.c.surface1;

--- a/slint-ui/ui/views/wizard-view.slint
+++ b/slint-ui/ui/views/wizard-view.slint
@@ -18,6 +18,7 @@ export component WizardView inherits Rectangle {
 
     // Wizard-local keyboard navigation. Emitted from `wizard-focus-scope`
     // and bound to Rust's on_key_nav_* handlers in app.slint.
+    callback global-key(string) -> bool;
     callback key-nav-down();
     callback key-nav-up();
     callback key-nav-activate();
@@ -38,7 +39,10 @@ export component WizardView inherits Rectangle {
             && !PopupState.text-input-visible
             && !PopupState.users-visible
             && !PopupState.strlist-visible
-            && !PopupState.pkg-search-visible;
+            && !PopupState.pkg-search-visible
+            && !PopupState.multi-select-visible
+            && !PopupState.wifi-visible
+            && !DemoState.popup-visible;
 
         key-pressed(event) => {
             if event.text == Key.DownArrow || event.text == "j" {
@@ -53,6 +57,7 @@ export component WizardView inherits Rectangle {
                 root.key-nav-activate();
                 return accept;
             }
+            if root.global-key(event.text) { return accept; }
             return reject;
         }
     }
@@ -60,6 +65,8 @@ export component WizardView inherits Rectangle {
     init => { wizard-focus-scope.focus(); }
 
     VerticalLayout {
+        width: min(root.width, 1280px);
+        x: (root.width - self.width) / 2;
         padding: 0px;
         spacing: 0px;
 
@@ -101,15 +108,14 @@ export component WizardView inherits Rectangle {
                 spacing: 2px;
                 alignment: start;
 
-                for label[index] in WizardState.step-labels: SidebarItem {
-                    visible: index > 0;
-                    label: label;
-                    state: WizardState.step-state-at(index);
-                    step-index: index;
+                for index in WizardState.total-steps - 1: SidebarItem {
+                    label: WizardState.step-labels[index + 1];
+                    state: WizardState.step-state-at(index + 1);
+                    step-index: index + 1;
 
                     clicked => {
-                        if index <= WizardState.max-visited {
-                            WizardState.go-to(index);
+                        if index + 1 <= WizardState.max-visited {
+                            WizardState.go-to(index + 1);
                         }
                     }
                 }
@@ -144,7 +150,7 @@ export component WizardView inherits Rectangle {
                     // rows in the same section touch and stitch into one
                     // connected card; section breaks come from the
                     // SectionHeader rows themselves having top padding.
-                    ScrollView {
+                    items-scroll := ScrollView {
                         VerticalLayout {
                             spacing: 0px;
                             padding-left: 4px;
@@ -156,6 +162,13 @@ export component WizardView inherits Rectangle {
                                 focused-index: WizardState.focused-index;
 
                                 focus-requested(i) => { WizardState.focused-index = i; }
+                                ensure-visible(item-y, item-height) => {
+                                    if item-y + items-scroll.content-y < 0px {
+                                        items-scroll.content-y = -item-y;
+                                    } else if item-y + item-height + items-scroll.content-y > items-scroll.height {
+                                        items-scroll.content-y = items-scroll.height - item-y - item-height;
+                                    }
+                                }
                                 activated(key) => { root.item-activated(key); }
                                 toggled(key) => { root.toggle-activated(key); }
                                 action-clicked(key) => {
@@ -171,13 +184,12 @@ export component WizardView inherits Rectangle {
 
         // Footer — full window width, sits on the shell color
         HorizontalLayout {
-            height: 56px;
+            height: 64px;
             padding-left: 16px;
             padding-right: 16px;
             padding-top: 12px;
             padding-bottom: 12px;
             spacing: 8px;
-            alignment: center;
 
             // Quit button
             StyledButton {
@@ -207,9 +219,10 @@ export component WizardView inherits Rectangle {
                 text: WizardState.status-text;
                 color: Theme.c.overlay0;
                 font-size: 12px;
-                horizontal-alignment: center;
+                horizontal-alignment: left;
                 vertical-alignment: center;
                 horizontal-stretch: 1;
+                overflow: elide;
             }
 
             // Next button (all steps except the final Review step)

--- a/tui/src/tui/screens/wifi.rs
+++ b/tui/src/tui/screens/wifi.rs
@@ -25,9 +25,7 @@ pub async fn run_wifi_setup(
 ) -> color_eyre::eyre::Result<bool> {
     // ── 1. Already online ───────────────────────────────────────────────────
     terminal.draw(render_checking)?;
-    // net::check_internet is still sync (quick TCP probe); keep spawn_blocking
-    // so the TUI event loop isn't stalled waiting on DNS / connect timeouts.
-    let online = tokio::task::spawn_blocking(net::check_internet).await?;
+    let online = net::check_internet().await;
     if online {
         return Ok(false);
     }
@@ -45,7 +43,7 @@ pub async fn run_wifi_setup(
     // ── 4. Ask user ─────────────────────────────────────────────────────────
     let result = run_select(
         terminal,
-        "No network connection detected",
+        "Could not verify internet access via ping.archlinux.org",
         &["Connect to WiFi", "Skip (continue without network)"],
         0,
     )?;
@@ -162,12 +160,9 @@ pub async fn run_wifi_setup(
             }
         }
 
-        // ── 9. Verify — wait for DHCP / IP assignment ───────────────────────
-        terminal.draw(|frame| render_status(frame, "Waiting for IP address…"))?;
-        tokio::time::sleep(std::time::Duration::from_secs(4)).await;
-
-        // Full internet reachability check (not just layer-2 association).
-        let online = tokio::task::spawn_blocking(net::check_internet).await?;
+        // ── 9. Verify — allow addresses, routes and DNS to settle ───────────
+        terminal.draw(|frame| render_status(frame, "Checking internet access…"))?;
+        let online = net::wait_for_internet(std::time::Duration::from_secs(20)).await;
         if online {
             let _ = run_select(
                 terminal,
@@ -179,17 +174,17 @@ pub async fn run_wifi_setup(
             return Ok(true);
         }
 
-        // IP not assigned yet — let the user decide
+        // Association succeeded; a failed HTTP probe does not diagnose DHCP.
         let result = run_select(
             terminal,
-            "Connected but no IP address assigned yet",
+            "WiFi connected, but internet access could not be verified. Check DNS or captive portal.",
             &["Wait and retry", "Continue anyway", "Skip WiFi"],
             0,
         )?;
         match result.selected {
             Some(0) => {
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                let online = tokio::task::spawn_blocking(net::check_internet).await?;
+                terminal.draw(|frame| render_status(frame, "Checking internet access…"))?;
+                let online = net::wait_for_internet(std::time::Duration::from_secs(20)).await;
                 if online {
                     return Ok(true);
                 }


### PR DESCRIPTION
The live installer could leave GUI keystrokes queued for the root shell, render incomplete cursors, and misalign common controls. This fixes KMS input ownership and recovery, updates the Slint branch, and makes the graphical workflow reproducible with simulated installation-ready data.

- Check internet access through Arch's connectivity endpoint and reuse saved Wi-Fi credentials.
- Restore VT state after normal or abnormal GUI exit, fix cursor damage ordering, and use neutral adjustable libinput acceleration.
- Align wizard/device/status controls, make Done the primary connection-success action, and handle stale network operations and password scoring asynchronously.
- Add safe preview scenes, screenshot capture, and repeatable UI interaction checks with verified scale factors.
- Build Broadcom modules through DKMS, update vulnerable h2, and remove shared-environment races from AUR cache tests.

Testing

UEFI QEMU reproduced the old shell-input leak and verified normal exit, GUI SIGKILL, and supervisor SIGTERM recovery. Software-Skia pixel tests cover cursor movement and clipping. UI scenarios were rendered and driven at 800×600 and 1920×1080/200%; real Synaptics touchpad feel still requires laptop testing.
