### PR TITLE
Improve installer setup UI and support live updates from Ventoy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,172 +1,124 @@
-# AGENTS.md
+# Repository instructions
 
-Guidance for AI coding agents working in this repository.
+## Start here
 
-## Project Overview
+Read [Developer guide](docs/development.md) for environments, checks, release
+artifacts and USB updates. For Slint work, also read
+[Slint coding and visual review](docs/slint-ui-review.md) and the
+[GUI README](slint-ui/README.md). [Documentation index](docs/README.md) links the
+remaining guides. Keep shared rules in this file; `CLAUDE.md` points here.
 
-`archinstall_zfs` is an Arch Linux installer focused on ZFS root setups. It has:
+`archinstall_zfs` is a Rust workspace: `core/` owns installer operations and
+validation, `tui/` the terminal frontend, `slint-ui/` the GUI, `xtask/` build/test
+harnesses, and `gen_iso/profile/` versioned live-image inputs. Prefer existing
+patterns over new abstractions; do not patch only generated profiles or artifacts.
 
-- `core/`: shared installer logic, config, ZFS/disk/network/system helpers.
-- `tui/`: ratatui terminal installer.
-- `slint-ui/`: graphical installer built with Slint.
-- `xtask/`: development and QEMU install-test harnesses.
-- `gen_iso/`: Arch ISO profiles and build assets.
+## Development and checks
 
-The workspace is Rust. Keep changes scoped and prefer existing local patterns over new abstractions.
+- Use `cargo add` or the relevant package-manager command for dependencies;
+  inspect manifest and lockfile changes. Prefer Rust edition 2024.
+- Run Python with `uv run`, add Python dependencies with `uv add` if needed.
+- Use tracked process/session tools for previews and VMs. Stop the process you
+  started, not all processes matching a name. Do not launch untracked shell jobs.
+- Keep blocking work off the UI thread and follow existing cancellation,
+  weak-handle and event-loop update patterns.
 
-## Common Commands
-
-Use these before committing unless the change clearly does not require the full set:
+Before committing, run these unless the change clearly does not require them:
 
 ```sh
 cargo fmt --all --check
-cargo test --workspace
-cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
 ```
 
 Useful targeted checks:
 
 ```sh
-cargo test -p archinstall-zfs-core prepare
-cargo test -p archinstall-zfs-slint
-cargo check -p archinstall-zfs-slint --no-default-features --features desktop-mock
+cargo test -p archinstall-zfs-core prepare --locked
+cargo test -p archinstall-zfs-slint --locked
+cargo check -p archinstall-zfs-slint --no-default-features --features desktop-mock --locked
+just test-live-update
 ```
 
-Real install tests require a built `xtask` and installer binary plus QEMU/KVM:
+Documentation-only edits need accurate commands and working links. UI changes
+need runtime checks in addition to Rust checks. Boot/input/cleanup changes need
+the relevant VM or hardware test; a passing unit test does not prove that path.
+For disposable install tests, build with `just cargo-build`, then use
+`just test-install-encrypted-pool --tmpfs --timeout 1800`.
+
+## Git workflow
+
+- Work from a feature branch off `main`; preserve unrelated local changes.
+- Commit completed, validated logical steps separately with clear messages.
+- Delete local branches only when merged and unrelated to active work.
+- Never mention assistants or AI tools in commit messages, trailers, branch
+  names, PR titles or PR descriptions. Do not add generated-by/session trailers.
+- PR descriptions: a short paragraph describing what and why, then bullets.
+  Add a Breaking changes section only for breaking changes, and Testing only for
+  manual/hardware checks not covered by CI.
+- Do not post GitHub/GitLab review replies or comments. Draft replies in chat for
+  the user to edit and post.
+
+## Safe UI development
+
+The GUI features select these networking/rendering paths:
+
+| Feature | Backend | Wi-Fi |
+| --- | --- | --- |
+| `linuxkms` (default) | LinuxKMS, software Skia | iwd |
+| `desktop` | winit | NetworkManager |
+| `desktop-mock` | winit | Deterministic mock |
+
+**`desktop-mock` alone mocks only Wi-Fi. Always pass `--preview` for UI review on
+the development host.** Preview also replaces storage/system probes, package
+search, installation and reboot, while retaining real components and editing
+callbacks. Use disposable fixture credentials.
 
 ```sh
-cargo build --release --bin azfs-tui --bin xtask
-just test-install-encrypted-pool --tmpfs --timeout 1800
+SLINT_EMIT_DEBUG_INFO=1 cargo build -p archinstall-zfs-slint \
+  --no-default-features --features desktop-mock,slint/mcp --locked
+SLINT_BACKEND=headless SLINT_MCP_PORT=9315 target/debug/azfs \
+  --preview welcome --preview-size 1920x1080 --ui-scale 1
 ```
 
-## Git Workflow
+Emit debug info at build time for MCP element lookup. Rebuild and restart after
+edits. Keep MCP/mock features out of production artifacts; use `just cargo-build`
+for the LinuxKMS release binary. Read the runtime and `slint-build` pins in
+`slint-ui/Cargo.toml` and `Cargo.lock` before changing the Slint dependency.
 
-- Work from a feature branch off `main`.
-- Do not revert unrelated local changes.
-- Delete local branches only when they are merged and unrelated to active work.
-- Prefer focused commits with clear messages.
+## UI review requirements
 
-## Wi-Fi Backends
+- Review **design, interaction and rendering** separately. Correct drawing does
+  not prove good hierarchy, alignment, action placement or information density.
+- Use 1920×1080 at 100% as the primary baseline, plus compact and scaled checks
+  from the [review guide](docs/slint-ui-review.md). Do not use 800×600 as the main
+  design reference or resize a screenshot to simulate another viewport.
+- Capture the real Slint preview. Inspect individual full-size screenshots;
+  galleries/contact sheets are overviews, not sufficient evidence for details.
+- Record a coverage matrix of pages, modes, dialogs, data states, scale and
+  interactions. Exercise keyboard navigation, focus return, validation, errors,
+  empty/loading states and long/missing/many-item fixtures where applicable.
+- Extend existing `slint-ui/scripts/` flows and `slint-ui/src/preview.rs` fixtures
+  when needed. Do not bypass the callback being tested by directly forcing its
+  final state. `storage_review.py --fixture` needs the matching
+  `AZFS_PREVIEW_STORAGE` environment value to select fixture data.
+- Use shared controls and `slint-ui/ui/styling.slint` tokens, layouts instead of manual
+  positioning, bounded scrolling bodies and fixed action footers. Wrap an entire
+  conditional layout in `if` so an empty layout does not consume space.
+- Revisit consumers when a shared component changes. Do not call the entire UI
+  reviewed after opening each page once or merely passing capture assertions.
+- State exactly what was checked. Headless previews do not establish physical
+  touchpad feel, KMS cursor damage, VT keyboard isolation or real chroot cleanup.
 
-`slint-ui` chooses the core Wi-Fi backend by feature:
+## Live image and physical media
 
-- `linuxkms` (default): installer ISO path, Slint Linux KMS backend, `wifi-iwd`.
-- `desktop`: local desktop development path, winit backend, `wifi-nm`.
-- `desktop-mock`: deterministic canned Wi-Fi data, winit backend, `wifi-mock`.
+Follow [Live binary updates](gen_iso/LIVE_UPDATE.md) for `/azfs-update/azfs` on
+Ventoy. The service copies a trusted release binary into the live writable root
+before consoles start; it does not launch the GUI. A base ISO with that service
+is required, and kernel/ZFS/service changes still require a new base ISO.
 
-For UI iteration, prefer `desktop-mock` so tests do not depend on host Wi-Fi hardware, iwd, NetworkManager, or real credentials.
-
-## Slint UI Development Loop
-
-When touching `.slint` files, do not rely on compile success alone. Render and interact with the UI yourself.
-
-Recommended agentic loop:
-
-1. Build the app with Slint MCP support and debug info:
-
-   ```sh
-   SLINT_EMIT_DEBUG_INFO=1 cargo build \
-     -p archinstall-zfs-slint \
-     --no-default-features \
-     --features desktop-mock,slint/mcp
-   ```
-
-   `SLINT_EMIT_DEBUG_INFO=1` must be present at build time. Setting it only when running the already-built binary is not enough for MCP element-tree and id lookup.
-
-2. Run the app headlessly with MCP:
-
-   ```sh
-   SLINT_MCP_PORT=9315 SLINT_BACKEND=headless target/debug/azfs
-   ```
-
-   The app should log:
-
-   ```text
-   Slint MCP server listening on http://127.0.0.1:9315/mcp
-   ```
-
-3. Use MCP over HTTP to inspect and drive the UI:
-
-   ```sh
-   curl -s -X POST http://127.0.0.1:9315/mcp \
-     -H 'Content-Type: application/json' \
-     -H 'Accept: application/json, text/event-stream' \
-     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_windows","arguments":{}}}'
-   ```
-
-   Useful MCP tools:
-
-   - `list_windows`
-   - `get_window_properties`
-   - `get_element_tree`
-   - `find_elements_by_id`
-   - `query_element_descendants`
-   - `click_element`
-   - `set_element_value`
-   - `dispatch_key_event`
-   - `take_screenshot`
-
-4. Save screenshots and inspect them visually:
-
-   ```sh
-   curl -s -X POST http://127.0.0.1:9315/mcp \
-     -H 'Content-Type: application/json' \
-     -H 'Accept: application/json, text/event-stream' \
-     -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"take_screenshot","arguments":{"windowHandle":{"index":"1","generation":"1"},"imageMimeType":"image/png"}}}' \
-     > /tmp/azfs-screenshot.json
-
-   jq -r '.result.content[] | select(.type=="image") | .data' /tmp/azfs-screenshot.json \
-     | base64 -d > /tmp/azfs-screenshot.png
-   ```
-
-   Then inspect with the local image viewer tool. Do not ask the human to verify basic layout and interaction issues that the agent can verify with screenshots and MCP.
-
-5. Drive realistic flows end to end:
-
-   - Open the Wi-Fi popup from the welcome connectivity pill.
-   - Wait for mock scan results.
-   - Select a secured unknown network and verify password entry.
-   - Set a passphrase with `set_element_value`.
-   - Click `Connect` and wait through connecting/verifying/connected states.
-   - Test enterprise-network error state.
-   - Test `Back`, `Rescan`, `Disconnect`, and known-network `Forget`.
-   - Take screenshots for the important states and inspect for clipping, overlap, off-center icons, missing buttons, and truncated text.
-
-6. After visual and interaction checks, run normal Rust checks:
-
-   ```sh
-   cargo fmt --all --check
-   cargo test --workspace
-   cargo clippy --workspace --all-targets -- -D warnings
-   ```
-
-## Slint Layout Notes
-
-- Use layouts (`VerticalLayout`, `HorizontalLayout`, `GridLayout`) instead of manual positions, except for overlays.
-- A layout with no visible children can still affect sizing if it exists unconditionally. For phase-specific footers, wrap the whole layout in an `if` so it is not allocated in phases that do not need it.
-- Scrollable content should fill the allocated body area. Avoid binding a `ScrollView` preferred height to its content height when the parent is meant to constrain it.
-- Set `clip: true` on body containers where phase-specific content must not draw outside its allocated area.
-- For status icons inside `VerticalLayout`, wrap the icon in a centered `HorizontalLayout` if visual centering matters.
-- Prefer existing shared components such as `StyledButton`, `StyledTextInput`, `Icon`, and `SignalBars`.
-- Keep UI state in Slint globals and async/business logic in Rust controllers.
-
-## Slint MCP Pitfalls
-
-- `slint/mcp` is a Cargo feature. Add it only on the command line for debug runs.
-- `SLINT_MCP_PORT` starts the MCP server at runtime.
-- `SLINT_EMIT_DEBUG_INFO=1` is needed at build time for element ids and tree traversal.
-- If MCP returns errors about `ElementHandle API requires debug info`, rebuild with `SLINT_EMIT_DEBUG_INFO=1`.
-- Window handles and element handles have the same shape but are not interchangeable.
-- Headless screenshots can work even when element-tree lookup is broken; do not mistake screenshot success for full MCP readiness.
-
-## Slint References
-
-The local Slint checkout contains agent docs and deeper MCP documentation:
-
-- `/home/okhsunrog/code/rust/slint/ai-plugins/skills/slint/SKILL.md`
-- `/home/okhsunrog/code/rust/slint/ai-plugins/skills/slint/reference/debugging-and-mcp.md`
-- `/home/okhsunrog/code/rust/slint/ai-plugins/skills/slint/reference/polish.md`
-- `/home/okhsunrog/code/rust/slint/docs/development/mcp-server.md`
-- `/home/okhsunrog/code/rust/slint/docs/astro/src/content/docs/guide/tooling/ai-coding-assistants.mdx`
-
-Read the relevant file before doing non-trivial Slint work.
+Before writing, identify physical media by current model, serial and mount source.
+Preserve unrelated files, verify copied data, and unmount/eject only after writes
+and any VM using the drive finish. Never infer physical boot success from QEMU.
+Follow [Post-install shell](slint-ui/POST_INSTALL_SHELL.md) for VT/chroot ownership
+and cleanup; simulated shell screenshots do not validate that lifecycle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Repository instructions
+
+Read and follow [AGENTS.md](AGENTS.md) first. It is the shared source of project
+rules; keep those rules there rather than maintaining a second conflicting copy.
+
+Before development, read [docs/development.md](docs/development.md).
+For any Slint/UI implementation or review, read
+[docs/slint-ui-review.md](docs/slint-ui-review.md) and use the real preview and
+interaction scripts described in [slint-ui/README.md](slint-ui/README.md).
+
+Do not call UI work complete from compilation, passing assertions or a contact
+sheet alone. Review individual screenshots, interaction/state coverage and the
+design itself. Use Full HD at 100% as the primary baseline, then compact and
+scaled configurations. Keep preview, VM and hardware claims separate.
+
+For binary-only USB updates, follow
+[gen_iso/LIVE_UPDATE.md](gen_iso/LIVE_UPDATE.md); rebuild the base ISO when its
+service, kernel or system dependencies change. Never ship a desktop-mock/MCP
+preview executable as the production installer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset"
 version = "0.2.1"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset-macro"
 version = "0.2.1"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-linuxkms"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "calloop 0.14.4",
  "cfg_aliases",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-selector"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "cfg-if",
  "cfg_aliases",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-testing"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "cfg_aliases",
  "i-slint-common",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-winit"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "arboard",
  "block2 0.6.2",
@@ -2574,7 +2574,7 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "derive_more",
  "fontique",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "i-slint-compiler"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "annotate-snippets",
  "by_address",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core-macros"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "quote",
  "serde_json",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-skia"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-software"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "bytemuck",
  "clru",
@@ -5618,7 +5618,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slint"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "const-field-offset",
  "i-slint-backend-linuxkms",
@@ -5639,7 +5639,7 @@ dependencies = [
 [[package]]
 name = "slint-build"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "derive_more",
  "fontique",
@@ -5651,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "slint-macros"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -6759,7 +6759,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vtable"
 version = "0.5.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -6770,7 +6770,7 @@ dependencies = [
 [[package]]
 name = "vtable-macro"
 version = "0.5.0"
-source = "git+https://github.com/okhsunrog/slint.git?rev=d6b44e120#d6b44e1208da125406ec2730fc3dc1c53cc10a84"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ The only remaining shell calls are:
 
 ## Development
 
+Start with the [developer guide](docs/development.md) and
+[documentation index](docs/README.md). For GUI changes, follow
+[Slint coding and visual review](docs/slint-ui-review.md). The
+[Ventoy live-update guide](gen_iso/LIVE_UPDATE.md) explains how to deploy a new
+installer binary without rebuilding the base ISO.
+
 Two supported workflows depending on the host distro. Pick one.
 
 ### Option 1 — Arch native

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ just cargo-test
 just iso-test             # native mkarchiso (sudo)
 just iso-full
 just zfs-be-build         # writable bare-metal LinuxKMS demo BE on novafs
-just test-install         # QEMU regression test (requires cargo-build first)
+just test-install         # QEMU regression test (requires iso-test and cargo-build first)
 just qemu-install         # interactive boot of latest ISO
 ```
 
@@ -365,7 +365,7 @@ cargo check / cargo test / cargo run     # fast native iteration, rust-analyzer-
 just cargo-build-container   # Arch-glibc target/release/{azfs,azfs-tui,xtask}
 just iso-test-podman         # container-backed mkarchiso
 just iso-full-podman
-just test-install            # QEMU regression test (requires cargo-build-container first)
+just test-install            # QEMU regression test (requires iso-test-podman and cargo-build-container first)
 just qemu-install            # qemu runs on host either way
 ```
 
@@ -380,7 +380,12 @@ just builder-clean  # Remove podman image and cache volumes
 ```
 
 ### Testing
-The xtask test suite boots a QEMU VM, runs the installer, reboots from the installed disk, and verifies 13 system health checks (kernel, ZFS pool, sshd, fstab, initramfs, zram, mounts, hostid, ZED hook, bootfs, rootprefix, ZBM build, ZBM pacman hook).
+The xtask test suite boots the newest `*-testing-*.iso`, runs the installer,
+reboots from the installed disk, and verifies 13 system health checks (kernel,
+ZFS pool, sshd, fstab, initramfs, zram, mounts, hostid, ZED hook, bootfs,
+rootprefix, ZBM build, ZBM pacman hook). Production ISOs intentionally do not
+allow the passwordless root SSH login used by this harness. Pass `--iso PATH`
+only for a custom image configured with equivalent test access.
 
 Installer logs are automatically pulled from the VM to `test-install.log` for analysis.
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ Legacy configuration files containing inline passwords remain supported.
 | **New Pool** | Creates ZFS pool on an existing partition. Uses your existing partition layout, creates ZFS pool on selected partition | Dual-boot scenarios, custom partitioning schemes, preserving existing OS installations |
 | **Existing Pool** | Installs into an existing ZFS pool as a new boot environment. Creates new BE datasets within your existing pool structure | Experiments, testing different configurations, multiple Arch installations |
 
+`New Pool` can preserve an existing Windows installation when its ZFS partition
+has already been prepared. It reuses a selected FAT32 ESP without formatting it,
+keeps unrelated EFI files and boot entries, and registers ZFSBootMenu alongside
+the existing firmware entries. It does not yet shrink NTFS or create a combined
+Windows/Linux boot-manager menu; select the operating system in the UEFI firmware
+menu. Never use `Full Disk` for this scenario because it erases the selected disk.
+
 > **Pro tip**: Existing Pool mode is excellent for trying different desktop environments or system configurations without risk — each installation becomes its own boot environment selectable from ZFSBootMenu.
 
 ### Kernel support

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ azfs-tui
 
 > Why recommended: the ISO already contains ZFS components and both installers, so startup is faster and avoids on-the-fly package installation.
 
+For development, [load an updated GUI binary from Ventoy](gen_iso/LIVE_UPDATE.md)
+at boot without rebuilding the ISO on every iteration.
+
 ### Safe LinuxKMS UI demo
 
 The ISO boot menu also offers **Arch Linux installer — safe LinuxKMS demo**.

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -1,5 +1,6 @@
-use std::fs;
-use std::path::Path;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufReader, Read, Write};
+use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{Context, Result};
 use serde::Serialize;
@@ -49,6 +50,7 @@ struct ZbmEfi {
 #[derive(Serialize)]
 #[serde(rename_all = "PascalCase")]
 struct ZbmKernel {
+    prefix: String,
     command_line: String,
 }
 
@@ -72,6 +74,9 @@ fn write_zbm_config(target: &Path, init_system: InitSystem) -> Result<()> {
             enabled: true,
         },
         kernel: ZbmKernel {
+            // Keep the filename stable: the NVRAM entries and fallback copy
+            // below deliberately point at this name.
+            prefix: "vmlinuz".into(),
             command_line: "zbm.import_policy=hostid zbm.timeout=10 ro quiet loglevel=0".into(),
         },
     };
@@ -110,6 +115,99 @@ fn install_zbm_pacman_hook(target: &Path) -> Result<()> {
     fs::create_dir_all(&hooks_dir)?;
     fs::write(hooks_dir.join("95-zfsbootmenu.hook"), ZBM_PACMAN_HOOK)?;
     tracing::info!("installed ZBM pacman hook");
+    Ok(())
+}
+
+fn files_equal(a: &Path, b: &Path) -> Result<bool> {
+    let a_meta = fs::metadata(a)?;
+    let b_meta = fs::metadata(b)?;
+    if a_meta.len() != b_meta.len() {
+        return Ok(false);
+    }
+
+    let mut a = BufReader::new(File::open(a)?);
+    let mut b = BufReader::new(File::open(b)?);
+    let mut a_buf = [0_u8; 64 * 1024];
+    let mut b_buf = [0_u8; 64 * 1024];
+    loop {
+        let a_len = a.read(&mut a_buf)?;
+        let b_len = b.read(&mut b_buf)?;
+        if a_len != b_len || a_buf[..a_len] != b_buf[..b_len] {
+            return Ok(false);
+        }
+        if a_len == 0 {
+            return Ok(true);
+        }
+    }
+}
+
+fn copy_file_atomically(source: &Path, destination: &Path) -> Result<()> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| color_eyre::eyre::eyre!("EFI destination has no parent directory"))?;
+    let source_len = fs::metadata(source)?.len();
+    let fs_info = nix::sys::statvfs::statvfs(parent)?;
+    let available = fs_info
+        .blocks_available()
+        .saturating_mul(fs_info.fragment_size());
+    if available < source_len {
+        color_eyre::eyre::bail!(
+            "EFI system partition has {} MiB free, but the ZFSBootMenu fallback needs {} MiB",
+            available / (1024 * 1024),
+            source_len.div_ceil(1024 * 1024)
+        );
+    }
+
+    let temporary = destination.with_extension(format!("EFI.azfs-{}.tmp", std::process::id()));
+    let result = (|| -> Result<()> {
+        let mut input = File::open(source)?;
+        let mut output = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        std::io::copy(&mut input, &mut output)?;
+        output.flush()?;
+        output.sync_all()?;
+        fs::rename(&temporary, destination)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result.wrap_err_with(|| {
+        format!(
+            "failed to atomically install EFI fallback {}",
+            destination.display()
+        )
+    })
+}
+
+fn install_fallback(target: &Path) -> Result<()> {
+    let zbm_dir = target.join("boot/efi/EFI/zbm");
+    let source = zbm_dir.join("vmlinuz.EFI");
+    if !source.is_file() {
+        color_eyre::eyre::bail!(
+            "generate-zbm did not create the configured EFI image {}",
+            source.display()
+        );
+    }
+
+    let fallback_dir = target.join("boot/efi/EFI/BOOT");
+    fs::create_dir_all(&fallback_dir)?;
+    let fallback = fallback_dir.join("BOOTX64.EFI");
+    let previous = zbm_dir.join("vmlinuz-backup.EFI");
+    let owned_previous =
+        fallback.is_file() && previous.is_file() && files_equal(&fallback, &previous)?;
+    if fallback.exists() && !files_equal(&fallback, &source)? && !owned_previous {
+        tracing::warn!(
+            path = %fallback.display(),
+            "preserving an existing EFI fallback that is not owned by ZFSBootMenu"
+        );
+        return Ok(());
+    }
+
+    copy_file_atomically(&source, &fallback)?;
+    tracing::info!("installed ZFSBootMenu as EFI/BOOT/BOOTX64.EFI fallback");
     Ok(())
 }
 
@@ -178,36 +276,7 @@ pub async fn install_and_generate_zbm(
         let output = chroot_cmd(&*r, &t, "generate-zbm", &[])?;
         check_exit(&output, "generate-zbm")?;
 
-        let efi_src = t.join("boot/efi/EFI/zbm/vmlinuz.EFI");
-        let fallback_dir = t.join("boot/efi/EFI/BOOT");
-        fs::create_dir_all(&fallback_dir)?;
-        if efi_src.exists() {
-            fs::copy(&efi_src, fallback_dir.join("BOOTX64.EFI"))
-                .wrap_err("failed to copy ZBM EFI to fallback path")?;
-            tracing::info!("copied ZBM EFI to EFI/BOOT/BOOTX64.EFI fallback");
-        } else {
-            tracing::warn!("generate-zbm output not found at expected path, checking alternatives");
-            let zbm_dir = t.join("boot/efi/EFI/zbm");
-            if zbm_dir.exists() {
-                for entry in fs::read_dir(&zbm_dir)? {
-                    let entry = entry?;
-                    let path = entry.path();
-                    if path
-                        .extension()
-                        .is_some_and(|e| e.eq_ignore_ascii_case("efi"))
-                        && !path.to_string_lossy().contains("backup")
-                    {
-                        fs::copy(&path, fallback_dir.join("BOOTX64.EFI"))
-                            .wrap_err("failed to copy ZBM EFI to fallback path")?;
-                        tracing::info!(
-                            src = %path.display(),
-                            "copied ZBM EFI to EFI/BOOT/BOOTX64.EFI fallback"
-                        );
-                        break;
-                    }
-                }
-            }
-        }
+        install_fallback(&t)?;
 
         tracing::info!("ZFSBootMenu built and installed locally");
         Ok(())
@@ -218,47 +287,130 @@ pub async fn install_and_generate_zbm(
 /// Create efibootmgr entries pointing to the locally-built ZBM EFI bundle.
 /// Since the cmdline is already embedded in the EFI by generate-zbm,
 /// we don't need to pass -u here.
-pub fn create_efi_entries(runner: &dyn CommandRunner, efi_partition: &Path) -> Result<()> {
-    let efi_str = efi_partition.to_string_lossy();
+struct EfiLocation {
+    disk: PathBuf,
+    partition: u32,
+    partuuid: String,
+}
 
-    // Check for existing entries
-    let existing = runner.run("efibootmgr", &["-v"])?;
-    let existing_text = existing.stdout.clone();
+fn resolve_efi_location(runner: &dyn CommandRunner, efi_partition: &Path) -> Result<EfiLocation> {
+    let efi = efi_partition.to_string_lossy();
+    let output = runner.run(
+        "lsblk",
+        &[
+            "--noheadings",
+            "--raw",
+            "--paths",
+            "--output",
+            "PKNAME,PARTN,PARTUUID",
+            &efi,
+        ],
+    )?;
+    check_exit(&output, "resolve EFI disk and partition")?;
+    let fields: Vec<_> = output.stdout.split_whitespace().collect();
+    if fields.len() != 3 {
+        color_eyre::eyre::bail!(
+            "cannot resolve EFI disk, partition number and PARTUUID for {}",
+            efi_partition.display()
+        );
+    }
+    Ok(EfiLocation {
+        disk: fields[0].into(),
+        partition: fields[1].parse().wrap_err("invalid EFI partition number")?,
+        partuuid: fields[2].to_ascii_lowercase(),
+    })
+}
 
-    // Add main entry if not exists
-    if !existing_text.contains("ZFSBootMenu") {
-        let output = runner.run(
-            "efibootmgr",
-            &[
-                "-c",
-                "-d",
-                &efi_str,
-                "-L",
-                "ZFSBootMenu",
-                "-l",
-                "\\EFI\\zbm\\vmlinuz.EFI",
-            ],
-        )?;
-        check_exit(&output, "efibootmgr create ZFSBootMenu entry")?;
+fn boot_entry(line: &str) -> Option<(&str, &str, &str)> {
+    let rest = line.strip_prefix("Boot")?;
+    let number = rest.get(..4)?;
+    if !number.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let rest = rest.get(4..)?.strip_prefix('*').unwrap_or(&rest[4..]);
+    let device_start = rest.find("HD(")?;
+    Some((number, rest[..device_start].trim(), &rest[device_start..]))
+}
+
+fn entry_matches(device_path: &str, location: &EfiLocation, loader: &str) -> bool {
+    let normalized = device_path.to_ascii_lowercase().replace('/', "\\");
+    normalized.contains(&format!(
+        "hd({},gpt,{},",
+        location.partition, location.partuuid
+    )) && normalized.contains(&format!("file({})", loader.to_ascii_lowercase()))
+}
+
+fn ensure_efi_entry(
+    runner: &dyn CommandRunner,
+    existing: &str,
+    location: &EfiLocation,
+    label: &str,
+    loader: &str,
+    required: bool,
+) -> Result<()> {
+    let mut found = false;
+    for (number, entry_label, device_path) in existing.lines().filter_map(boot_entry) {
+        if entry_label != label {
+            continue;
+        }
+        if !found && entry_matches(device_path, location, loader) {
+            found = true;
+            continue;
+        }
+        let output = runner.run("efibootmgr", &["-b", number, "-B"])?;
+        if let Err(error) = check_exit(&output, "remove stale EFI boot entry") {
+            if required {
+                return Err(error);
+            }
+            tracing::warn!(%error, label, "failed to remove stale optional EFI entry");
+        }
+    }
+    if found {
+        return Ok(());
     }
 
-    // Add backup entry if backup exists
-    if !existing_text.contains("ZFSBootMenu (Backup)") {
-        let output = runner.run(
-            "efibootmgr",
-            &[
-                "-c",
-                "-d",
-                &efi_str,
-                "-L",
-                "ZFSBootMenu (Backup)",
-                "-l",
-                "\\EFI\\zbm\\vmlinuz-backup.EFI",
-            ],
+    let disk = location.disk.to_string_lossy();
+    let partition = location.partition.to_string();
+    let output = runner.run(
+        "efibootmgr",
+        &[
+            "-c", "-d", &disk, "-p", &partition, "-L", label, "-l", loader,
+        ],
+    )?;
+    if required {
+        check_exit(&output, "create ZFSBootMenu EFI entry")?;
+    } else if !output.success() {
+        tracing::warn!(label, "failed to create optional EFI boot entry");
+    }
+    Ok(())
+}
+
+pub fn create_efi_entries(
+    runner: &dyn CommandRunner,
+    efi_partition: &Path,
+    target: &Path,
+) -> Result<()> {
+    let location = resolve_efi_location(runner, efi_partition)?;
+
+    let existing = runner.run("efibootmgr", &["-v"])?;
+    check_exit(&existing, "read EFI boot entries")?;
+    ensure_efi_entry(
+        runner,
+        &existing.stdout,
+        &location,
+        "ZFSBootMenu",
+        "\\EFI\\zbm\\vmlinuz.EFI",
+        true,
+    )?;
+    if target.join("boot/efi/EFI/zbm/vmlinuz-backup.EFI").is_file() {
+        ensure_efi_entry(
+            runner,
+            &existing.stdout,
+            &location,
+            "ZFSBootMenu (Backup)",
+            "\\EFI\\zbm\\vmlinuz-backup.EFI",
+            false,
         )?;
-        if !output.success() {
-            tracing::warn!("failed to create ZBM backup boot entry (non-fatal)");
-        }
     }
 
     tracing::info!("created ZFSBootMenu EFI boot entries");
@@ -349,6 +501,7 @@ mod tests {
         assert!(config.contains("zbm.timeout=10"));
         assert!(config.contains("Versions: false"));
         assert!(config.contains("Enabled: true"));
+        assert!(config.contains("Prefix: vmlinuz"));
     }
 
     #[test]
@@ -398,24 +551,152 @@ mod tests {
     }
 
     #[test]
-    fn test_create_efi_entries_no_u_flag() {
+    fn test_fallback_preserves_an_unowned_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let zbm = dir.path().join("boot/efi/EFI/zbm");
+        let boot = dir.path().join("boot/efi/EFI/BOOT");
+        fs::create_dir_all(&zbm).unwrap();
+        fs::create_dir_all(&boot).unwrap();
+        fs::write(zbm.join("vmlinuz.EFI"), b"new zbm").unwrap();
+        fs::write(boot.join("BOOTX64.EFI"), b"another bootloader").unwrap();
+
+        install_fallback(dir.path()).unwrap();
+
+        assert_eq!(
+            fs::read(boot.join("BOOTX64.EFI")).unwrap(),
+            b"another bootloader"
+        );
+    }
+
+    #[test]
+    fn test_fallback_updates_the_previous_zbm_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let zbm = dir.path().join("boot/efi/EFI/zbm");
+        let boot = dir.path().join("boot/efi/EFI/BOOT");
+        fs::create_dir_all(&zbm).unwrap();
+        fs::create_dir_all(&boot).unwrap();
+        fs::write(zbm.join("vmlinuz.EFI"), b"new zbm").unwrap();
+        fs::write(zbm.join("vmlinuz-backup.EFI"), b"old zbm").unwrap();
+        fs::write(boot.join("BOOTX64.EFI"), b"old zbm").unwrap();
+
+        install_fallback(dir.path()).unwrap();
+
+        assert_eq!(fs::read(boot.join("BOOTX64.EFI")).unwrap(), b"new zbm");
+    }
+
+    fn target_with_zbm(backup: bool) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let zbm = dir.path().join("boot/efi/EFI/zbm");
+        fs::create_dir_all(&zbm).unwrap();
+        fs::write(zbm.join("vmlinuz.EFI"), b"main").unwrap();
+        if backup {
+            fs::write(zbm.join("vmlinuz-backup.EFI"), b"backup").unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn test_create_efi_entries_uses_the_selected_disk_and_partition() {
         // With locally-built ZBM, cmdline is embedded - no -u needed
+        let target = target_with_zbm(true);
         let runner = RecordingRunner::new(vec![
             CannedResponse {
-                stdout: "BootCurrent: 0000\n".into(), // no existing ZFSBootMenu entries
+                stdout: "/dev/nvme0n1 7 AABB-CCDD\n".into(),
+                ..Default::default()
+            },
+            CannedResponse {
+                stdout: "BootCurrent: 0000\n".into(),
                 ..Default::default()
             },
             CannedResponse::default(), // efibootmgr -c (main)
             CannedResponse::default(), // efibootmgr -c (backup)
         ]);
 
-        create_efi_entries(&runner, Path::new("/dev/sda1")).unwrap();
+        create_efi_entries(
+            &runner,
+            Path::new("/dev/disk/by-id/disk-part7"),
+            target.path(),
+        )
+        .unwrap();
 
         let calls = runner.calls();
-        // Main entry should NOT have -u flag (cmdline embedded in EFI)
-        let main_call = &calls[1];
+        let main_call = &calls[2];
         assert!(!main_call.args.contains(&"-u".to_string()));
-        assert!(main_call.args.contains(&"ZFSBootMenu".to_string()));
+        assert!(
+            main_call
+                .args
+                .windows(2)
+                .any(|a| a == ["-d", "/dev/nvme0n1"])
+        );
+        assert!(main_call.args.windows(2).any(|a| a == ["-p", "7"]));
         assert!(main_call.args.iter().any(|a| a.contains("vmlinuz.EFI")));
+    }
+
+    #[test]
+    fn test_matching_entries_are_kept() {
+        let target = target_with_zbm(true);
+        let runner = RecordingRunner::new(vec![
+            CannedResponse {
+                stdout: "/dev/sda 1 aabb-ccdd\n".into(),
+                ..Default::default()
+            },
+            CannedResponse {
+                stdout: concat!(
+                    "Boot0001* ZFSBootMenu\tHD(1,GPT,AABB-CCDD,0x800,0x1000)/File(\\EFI\\zbm\\vmlinuz.EFI)\n",
+                    "Boot0002* ZFSBootMenu (Backup)\tHD(1,GPT,AABB-CCDD,0x800,0x1000)/File(\\EFI\\zbm\\vmlinuz-backup.EFI)\n"
+                )
+                .into(),
+                ..Default::default()
+            },
+        ]);
+
+        create_efi_entries(&runner, Path::new("/dev/sda1"), target.path()).unwrap();
+
+        assert_eq!(runner.calls().len(), 2);
+    }
+
+    #[test]
+    fn test_backup_entry_does_not_hide_a_missing_main_entry() {
+        let target = target_with_zbm(true);
+        let runner = RecordingRunner::new(vec![
+            CannedResponse {
+                stdout: "/dev/sda 1 aabb-ccdd\n".into(),
+                ..Default::default()
+            },
+            CannedResponse {
+                stdout: "Boot0002* ZFSBootMenu (Backup)\tHD(1,GPT,AABB-CCDD,0x800,0x1000)/File(\\EFI\\zbm\\vmlinuz-backup.EFI)\n".into(),
+                ..Default::default()
+            },
+            CannedResponse::default(),
+        ]);
+
+        create_efi_entries(&runner, Path::new("/dev/sda1"), target.path()).unwrap();
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 3);
+        assert!(calls[2].args.windows(2).any(|a| a == ["-L", "ZFSBootMenu"]));
+    }
+
+    #[test]
+    fn test_stale_same_name_entry_is_replaced() {
+        let target = target_with_zbm(false);
+        let runner = RecordingRunner::new(vec![
+            CannedResponse {
+                stdout: "/dev/sda 3 aabb-ccdd\n".into(),
+                ..Default::default()
+            },
+            CannedResponse {
+                stdout: "Boot00AF* ZFSBootMenu\tHD(1,GPT,DEAD-BEEF,0x800,0x1000)/File(\\EFI\\zbm\\vmlinuz.EFI)\n".into(),
+                ..Default::default()
+            },
+            CannedResponse::default(),
+            CannedResponse::default(),
+        ]);
+
+        create_efi_entries(&runner, Path::new("/dev/sda3"), target.path()).unwrap();
+
+        let calls = runner.calls();
+        assert_eq!(calls[2].args, ["-b", "00AF", "-B"]);
+        assert!(calls[3].args.windows(2).any(|a| a == ["-p", "3"]));
     }
 }

--- a/core/src/config/edit.rs
+++ b/core/src/config/edit.rs
@@ -175,6 +175,11 @@ pub fn apply_choice(config: &mut GlobalConfig, setting: ChoiceSetting, index: us
             };
             // Devices chosen under one mode mean nothing under another.
             if config.installation_mode != Some(mode) {
+                if mode == InstallationMode::ExistingPool
+                    || config.installation_mode == Some(InstallationMode::ExistingPool)
+                {
+                    config.pool_name = None;
+                }
                 config.disk = None;
                 config.efi_partition = None;
                 config.zfs_partition = None;
@@ -378,6 +383,22 @@ mod tests {
         assert_eq!(c.installation_mode, Some(InstallationMode::NewPool));
         assert!(c.disk.is_none());
         assert!(c.efi_partition.is_none());
+    }
+
+    #[test]
+    fn an_existing_pool_name_is_not_reused_as_a_new_pool_name() {
+        let mut c = cfg();
+        apply_choice(&mut c, ChoiceSetting::InstallationMode, 0);
+        c.pool_name = Some("newpool".into());
+        apply_choice(&mut c, ChoiceSetting::InstallationMode, 1);
+        assert_eq!(c.pool_name.as_deref(), Some("newpool"));
+        apply_choice(&mut c, ChoiceSetting::InstallationMode, 2);
+        assert!(c.pool_name.is_none());
+        c.pool_name = Some("existing".into());
+        apply_choice(&mut c, ChoiceSetting::InstallationMode, 2);
+        assert_eq!(c.pool_name.as_deref(), Some("existing"));
+        apply_choice(&mut c, ChoiceSetting::InstallationMode, 0);
+        assert!(c.pool_name.is_none());
     }
 
     #[test]

--- a/core/src/config/validation.rs
+++ b/core/src/config/validation.rs
@@ -24,6 +24,10 @@ pub enum ValidationError {
         path: PathBuf,
     },
     DiskRequired,
+    PartitionRoleConflict {
+        first: &'static str,
+        second: &'static str,
+    },
     EfiPartitionRequired(InstallationMode),
     ZfsPartitionRequired,
     /// Full-disk mode carves the swap partition itself and needs its size.
@@ -78,6 +82,9 @@ impl fmt::Display for ValidationError {
                  path, got: {}",
                 path.display()
             ),
+            Self::PartitionRoleConflict { first, second } => {
+                write!(f, "{first} and {second} must use different partitions")
+            }
             Self::DiskRequired => write!(f, "Full disk mode requires a disk selection (disk)"),
             Self::EfiPartitionRequired(mode) => {
                 write!(f, "{} mode requires an EFI partition (efi_partition)", mode)
@@ -175,6 +182,34 @@ impl GlobalConfig {
                 }
                 if wants_swap_partition && self.swap_partition.is_none() {
                     errors.push(ValidationError::SwapPartitionRequired(mode));
+                }
+            }
+        }
+
+        if mode != InstallationMode::FullDisk {
+            let roles = [
+                ("EFI", self.efi_partition.as_ref()),
+                (
+                    "ZFS",
+                    (mode == InstallationMode::NewPool)
+                        .then_some(self.zfs_partition.as_ref())
+                        .flatten(),
+                ),
+                (
+                    "Swap",
+                    wants_swap_partition
+                        .then_some(self.swap_partition.as_ref())
+                        .flatten(),
+                ),
+            ];
+            for (i, (first, a)) in roles.iter().enumerate() {
+                for (second, b) in &roles[i + 1..] {
+                    if let (Some(a), Some(b)) = (a, b)
+                        && std::fs::canonicalize(a).unwrap_or_else(|_| (*a).clone())
+                            == std::fs::canonicalize(b).unwrap_or_else(|_| (*b).clone())
+                    {
+                        errors.push(ValidationError::PartitionRoleConflict { first, second });
+                    }
                 }
             }
         }
@@ -666,5 +701,39 @@ mod tests {
             cfg.swap_partition.as_deref(),
             Some(std::path::Path::new("/dev/disk/by-id/legacy-disk-part3"))
         );
+    }
+}
+
+#[cfg(test)]
+mod partition_role_tests {
+    use super::*;
+    #[test]
+    fn duplicate_roles_are_rejected_but_inactive_roles_are_ignored() {
+        let mut c = GlobalConfig {
+            installation_mode: Some(InstallationMode::NewPool),
+            efi_partition: Some("/dev/sda1".into()),
+            zfs_partition: Some("/dev/sda1".into()),
+            ..Default::default()
+        };
+        assert!(
+            c.validate_for_install()
+                .iter()
+                .any(|e| matches!(e, ValidationError::PartitionRoleConflict { .. }))
+        );
+        c.installation_mode = Some(InstallationMode::ExistingPool);
+        assert!(
+            !c.validate_for_install()
+                .iter()
+                .any(|e| matches!(e, ValidationError::PartitionRoleConflict { .. }))
+        );
+        c.swap_mode = SwapMode::ZswapPartition;
+        c.swap_partition = c.efi_partition.clone();
+        assert!(c.validate_for_install().iter().any(|e| matches!(
+            e,
+            ValidationError::PartitionRoleConflict {
+                first: "EFI",
+                second: "Swap"
+            }
+        )));
     }
 }

--- a/core/src/disk/device.rs
+++ b/core/src/disk/device.rs
@@ -20,6 +20,16 @@ pub struct DevicePath {
     pub kind: DevicePathKind,
 }
 
+/// Filesystem identity and active use, kept separate from hardware identity.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct DeviceUsage {
+    pub filesystem: String,
+    pub label: String,
+    pub partition_type: String,
+    pub mountpoints: Vec<String>,
+    pub in_use: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockDevice {
     pub devnode: PathBuf,
@@ -30,6 +40,7 @@ pub struct BlockDevice {
     pub transport: Option<String>,
     pub rotational: Option<bool>,
     pub removable: bool,
+    pub usage: DeviceUsage,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +55,7 @@ pub struct BlockPartition {
     pub transport: Option<String>,
     pub rotational: Option<bool>,
     pub removable: bool,
+    pub usage: DeviceUsage,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,6 +78,7 @@ pub struct DeviceChoice {
     pub group_transport: String,
     pub group_media: String,
     pub group_removable: bool,
+    pub usage: DeviceUsage,
 }
 
 impl DeviceChoice {
@@ -128,6 +141,7 @@ impl From<BlockDevice> for DeviceChoice {
             group_transport: String::new(),
             group_media: String::new(),
             group_removable: false,
+            usage: device.usage.clone(),
         }
     }
 }
@@ -153,6 +167,7 @@ impl From<BlockPartition> for DeviceChoice {
             group_transport: partition.selection_group_transport(),
             group_media: partition.selection_group_media(),
             group_removable: partition.removable,
+            usage: partition.usage.clone(),
         }
     }
 }
@@ -296,7 +311,7 @@ struct LsblkOutput {
     blockdevices: Vec<LsblkDevice>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct LsblkDevice {
     path: Option<PathBuf>,
     #[serde(rename = "type")]
@@ -307,6 +322,11 @@ struct LsblkDevice {
     tran: Option<String>,
     rota: Option<Value>,
     rm: Option<Value>,
+    fstype: Option<String>,
+    label: Option<String>,
+    parttype: Option<String>,
+    #[serde(default)]
+    mountpoints: Vec<Option<String>>,
     #[serde(default)]
     children: Vec<LsblkDevice>,
 }
@@ -359,7 +379,7 @@ fn inspect_block_devices() -> Result<(LsblkOutput, HashMap<PathBuf, Vec<DevicePa
             "--json",
             "--bytes",
             "--output",
-            "PATH,TYPE,SIZE,MODEL,SERIAL,TRAN,ROTA,RM",
+            "PATH,TYPE,SIZE,MODEL,SERIAL,TRAN,ROTA,RM,FSTYPE,LABEL,PARTTYPE,MOUNTPOINTS",
         ])
         .output()
         .wrap_err("failed to run lsblk")?;
@@ -377,6 +397,29 @@ fn inspect_block_devices() -> Result<(LsblkOutput, HashMap<PathBuf, Vec<DevicePa
     Ok((parsed, aliases))
 }
 
+fn device_usage(node: &LsblkDevice) -> DeviceUsage {
+    fn in_use(node: &LsblkDevice) -> bool {
+        node.mountpoints.iter().flatten().any(|s| !s.is_empty())
+            || node
+                .children
+                .iter()
+                .any(|child| child.device_type.as_deref() != Some("part") || in_use(child))
+    }
+    DeviceUsage {
+        filesystem: node.fstype.clone().unwrap_or_default(),
+        label: node.label.clone().unwrap_or_default(),
+        partition_type: node.parttype.clone().unwrap_or_default(),
+        mountpoints: node
+            .mountpoints
+            .iter()
+            .flatten()
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .collect(),
+        in_use: in_use(node),
+    }
+}
+
 fn collect_lsblk_disks(
     node: LsblkDevice,
     aliases: &HashMap<PathBuf, Vec<DevicePath>>,
@@ -390,7 +433,9 @@ fn collect_lsblk_disks(
         let mut device_aliases = aliases.get(&canonical).cloned().unwrap_or_default();
         device_aliases.sort_by_key(alias_preference_key);
 
+        let usage = device_usage(&node);
         devices.push(BlockDevice {
+            usage,
             devnode,
             aliases: device_aliases,
             model: clean_string(node.model),
@@ -438,7 +483,9 @@ fn collect_lsblk_partitions(
             .and_then(|parent| parent_details_by_devnode.get(&parent));
         let details = current_details.as_ref().or(flat_parent_details);
 
+        let usage = device_usage(&node);
         partitions.push(BlockPartition {
+            usage,
             devnode,
             aliases: partition_aliases,
             parent_devnode: details.map(|details| details.devnode.clone()),
@@ -707,6 +754,7 @@ mod tests {
             transport: None,
             rotational: None,
             removable: false,
+            usage: Default::default(),
         };
 
         assert_eq!(
@@ -729,6 +777,7 @@ mod tests {
             transport: None,
             rotational: None,
             removable: false,
+            usage: Default::default(),
         };
 
         assert_eq!(
@@ -748,6 +797,7 @@ mod tests {
             transport: None,
             rotational: None,
             removable: false,
+            usage: Default::default(),
         };
 
         assert_eq!(device.preferred_path().path, PathBuf::from("/dev/vda"));
@@ -767,6 +817,7 @@ mod tests {
             transport: Some("virtio".to_string()),
             rotational: Some(false),
             removable: false,
+            usage: Default::default(),
         };
 
         assert_eq!(device.selection_title(), "/dev/vda");
@@ -815,6 +866,7 @@ mod tests {
             transport: Some("virtio".to_string()),
             rotational: Some(false),
             removable: false,
+            usage: Default::default(),
         };
 
         assert_eq!(
@@ -864,6 +916,7 @@ mod tests {
             transport: Some("usb".to_string()),
             rotational: Some(false),
             removable: false,
+            usage: Default::default(),
         };
 
         assert_eq!(device.selection_icon(), "usb");
@@ -890,7 +943,9 @@ mod tests {
                 rota: None,
                 rm: None,
                 children: Vec::new(),
+                ..Default::default()
             }],
+            ..Default::default()
         };
 
         let aliases = HashMap::new();
@@ -926,6 +981,7 @@ mod tests {
             rota: Some(Value::Bool(false)),
             rm: Some(Value::Bool(false)),
             children: Vec::new(),
+            ..Default::default()
         };
         let partition = LsblkDevice {
             path: Some(PathBuf::from("/dev/nvme0n1p1")),
@@ -937,6 +993,7 @@ mod tests {
             rota: None,
             rm: None,
             children: Vec::new(),
+            ..Default::default()
         };
 
         let aliases = HashMap::new();
@@ -978,5 +1035,32 @@ mod tests {
             parent_devnode_for_partition(Path::new("/dev/mmcblk0p2")),
             Some(PathBuf::from("/dev/mmcblk0"))
         );
+    }
+}
+
+#[cfg(test)]
+mod usage_tests {
+    use super::*;
+    #[test]
+    fn filesystem_identity_and_nested_active_use_are_preserved() {
+        let node: LsblkDevice = serde_json::from_str(
+            r#"{
+            "path":"/dev/sda", "type":"disk", "children":[{
+                "path":"/dev/sda1", "type":"part", "fstype":"vfat", "label":"EFI",
+                "parttype":"c12a7328-f81f-11d2-ba4b-00a0c93ec93b", "mountpoints":[null,"/boot"]
+            }]}"#,
+        )
+        .unwrap();
+        assert!(device_usage(&node).in_use);
+        let usage = device_usage(&node.children[0]);
+        assert_eq!(usage.filesystem, "vfat");
+        assert_eq!(usage.label, "EFI");
+        assert_eq!(usage.mountpoints, ["/boot"]);
+        let inactive: LsblkDevice =
+            serde_json::from_str(r#"{"type":"part", "mountpoints":[null]}"#).unwrap();
+        assert!(!device_usage(&inactive).in_use);
+        let mapped: LsblkDevice =
+            serde_json::from_str(r#"{"type":"part", "children":[{"type":"crypt"}]}"#).unwrap();
+        assert!(device_usage(&mapped).in_use);
     }
 }

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -358,8 +358,11 @@ async fn install(
     {
         let runner = runner.clone();
         let efi = efi_partition.clone();
-        tokio::task::spawn_blocking(move || crate::bootmenu::create_efi_entries(&*runner, &efi))
-            .await??;
+        let target = mountpoint.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::bootmenu::create_efi_entries(&*runner, &efi, &target)
+        })
+        .await??;
     }
 
     // Last, so they are the final thing in the log the user is looking at

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# Documentation
+
+| Document | Purpose |
+| --- | --- |
+| [Developer guide](development.md) | Build environments, checks, release/USB workflow and validation boundaries |
+| [Slint coding and visual review](slint-ui-review.md) | Practical design, interaction, rendering and implementation procedure |
+| [GUI development](../slint-ui/README.md) | Preview scenes, fixtures and executable review commands |
+| [Live binary updates](../gen_iso/LIVE_UPDATE.md) | Update the installer on Ventoy without rebuilding its base ISO |
+| [Post-install shell](../slint-ui/POST_INSTALL_SHELL.md) | VT handoff, chroot, owned cleanup and completion GUI restart |
+| [Boot debugging](debugging-boot.md) | Inspect a disposable installed system or USB boot in QEMU |
+| [ZFS root installation guide](zfs-root-install-guide.md) | Manual installation and the installer's system setup |
+| [Installation benchmark results](install-bench-results.md) | Recorded measurements, not a performance guarantee |
+| [Design review, 2026-09-09](../slint-ui/DESIGN_REVIEW.md) | Dated design findings and coverage |
+| [Earlier UI/KMS review](../slint-ui/UI_REVIEW.md) | Historical rendering/input investigation |
+
+Coding-agent instructions live in [AGENTS.md](../AGENTS.md).
+Current procedures belong in the guides; dated results describe the tested
+revision and do not establish that later changes have been rechecked.

--- a/docs/debugging-boot.md
+++ b/docs/debugging-boot.md
@@ -1,6 +1,10 @@
 # Debugging Boot Issues in QEMU
 
-Guide for diagnosing why an installed system doesn't boot after `archinstall-zfs-rs` installation.
+Guide for diagnosing boot behavior after `archinstall_zfs` installation and
+testing the live ISO. See the [developer guide](development.md) for the broader
+workflow. Installed-system repair examples below belong inside a disposable test
+guest: pool names, mount paths and hostids are fixture values, not instructions
+to modify the development host.
 
 ## Quick Diagnosis Workflow
 
@@ -12,7 +16,9 @@ Guide for diagnosing why an installed system doesn't boot after `archinstall-zfs
 
 ## Boot with VNC + QEMU Monitor
 
-The serial console is useless for ZFSBootMenu (it renders to the framebuffer, not serial). Use VNC + the QEMU monitor for screenshots:
+For the graphical boot path, serial output alone does not show the framebuffer.
+Use VNC and the QEMU monitor for screenshots; retain serial logs for stages that
+actually emit them. Run the VM in a tracked terminal/session:
 
 ```bash
 OVMF_CODE=$(find /usr/share/edk2 /usr/share/edk2-ovmf -name "OVMF_CODE*.4m.fd" ! -name "*secboot*" -print -quit)
@@ -29,8 +35,7 @@ qemu-system-x86_64 -enable-kvm -cpu host -m 4096 -smp 2 \
     -drive "if=pflash,format=raw,unit=0,file=$OVMF_CODE,read-only=on" \
     -drive "if=pflash,format=raw,unit=1,file=$VARS" \
     -drive "file=$DISK,format=qcow2,if=none,id=disk0" \
-    -device "virtio-blk-pci,drive=disk0,serial=archzfs-test-disk" \
-    -daemonize
+    -device "virtio-blk-pci,drive=disk0,serial=archzfs-test-disk"
 ```
 
 Take a screenshot after ~30 seconds:
@@ -44,10 +49,66 @@ Send Enter key to ZFSBootMenu (if stuck at menu):
 echo "sendkey ret" | socat - UNIX-CONNECT:/tmp/qemu-mon.sock
 ```
 
-Kill the VM:
+Prefer shutting down inside the guest. To stop this disposable test VM through
+its own monitor (an immediate power cut; do not use during a write under test):
 ```bash
-kill $(pgrep -f qemu-system)
+echo "quit" | socat - UNIX-CONNECT:/tmp/qemu-mon.sock
 ```
+
+Use a unique monitor socket for each concurrent VM. Never kill all QEMU processes
+by name; another process may belong to an unrelated installation test.
+
+## Testing a physical Ventoy drive without writing to it
+
+First identify the USB by model, serial and partition layout, finish all host
+writes, and unmount its partitions. Use the verified **whole-disk** by-id path,
+not a partition. This example exposes the physical device read-only as backing
+storage and puts guest writes into a fresh local qcow2 overlay. Making the entire
+virtual USB read-only can instead prevent Ventoy's device-mapper setup.
+
+Run from a Bash terminal, replacing the placeholder before proceeding. The OVMF
+paths are for Arch's edk2 package; use matching code/vars files on other hosts.
+
+```bash
+USB_DEVICE=/dev/disk/by-id/usb-REPLACE_WITH_VERIFIED_DEVICE
+test -b "$USB_DEVICE" || exit 1
+mkdir -p target
+VM_DIR=$(mktemp -d "$PWD/target/ventoy-boot.XXXXXX")
+cp /usr/share/edk2/x64/OVMF_VARS.4m.fd "$VM_DIR/OVMF_VARS.fd"
+sudo qemu-img create -f qcow2 -F raw -b "$USB_DEVICE" "$VM_DIR/usb-cow.qcow2"
+sudo qemu-system-x86_64 -enable-kvm -machine q35 -cpu host -m 4096 -smp 4 \
+    -drive if=pflash,format=raw,readonly=on,file=/usr/share/edk2/x64/OVMF_CODE.4m.fd \
+    -drive "if=pflash,format=raw,file=$VM_DIR/OVMF_VARS.fd" \
+    -blockdev "driver=host_device,node-name=usbbase,filename=$USB_DEVICE,read-only=on" \
+    -blockdev driver=raw,node-name=base,file=usbbase,read-only=on \
+    -blockdev "driver=file,node-name=cowfile,filename=$VM_DIR/usb-cow.qcow2" \
+    -blockdev driver=qcow2,node-name=usb,file=cowfile,backing=base \
+    -device qemu-xhci -device usb-storage,drive=usb,bootindex=1 \
+    -display vnc=127.0.0.1:1 -vga std \
+    -serial "file:$VM_DIR/serial.log" \
+    -monitor "unix:$VM_DIR/monitor.sock,server=on,wait=off" -no-reboot
+```
+
+Use `host_device` for the physical block device, and `file` for the local overlay.
+Do not mount/write the physical USB on the host while this VM is running. Keep
+the process tracked and record `VM_DIR` for accessing its log and monitor from
+another terminal. Guest writes do not update the flash drive.
+
+In Ventoy, boot the intended ISO and test the
+[live-update service](../gen_iso/LIVE_UPDATE.md). If the image uses the
+`_VTGRUB2.iso` suffix, Ventoy selects its GRUB2 boot mode. In the guest, inspect:
+
+```sh
+systemctl status azfs-live-update.service --no-pager
+journalctl -b -u azfs-live-update.service --no-pager
+sha256sum /usr/local/bin/azfs
+azfs --demo
+```
+
+After collecting evidence, power off the guest and wait for the QEMU process to
+exit before ejecting the USB. Use a fresh overlay for an independent test run;
+an existing overlay retains guest changes. This validates boot from the physical
+drive in virtual hardware, not boot or touchpad behavior on the target laptop.
 
 ## UEFI Vars and Boot Order
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,156 @@
+# Developer guide
+
+Run commands from the repository root. Use the checked-out source, `Cargo.lock`,
+and `just --list` as the authority for current versions and available tasks.
+The native Arch and container/Nix setup options are in the
+[main README](../README.md#development).
+
+## Choose the right environment
+
+| Work | Environment | What it proves |
+| --- | --- | --- |
+| Composition, controls, dialogs, error states | `desktop-mock` **with `--preview`**, Slint MCP | Real UI and editing callbacks on deterministic fixtures |
+| Host NetworkManager integration | `desktop` | Host networking behavior; not ISO/iwd behavior |
+| LinuxKMS rendering, VT ownership, shell handoff | Default release build in a disposable VM | Actual KMS and process lifecycle on virtual hardware |
+| Touchpad feel, hardware cursor artifacts, real iwd | ISO `azfs --demo` on the target computer | Behavior on that device; not an installation test |
+| Partitioning, ZFS, bootability, cleanup | Dedicated disposable installation VM | The specific tested installation scenario |
+
+`desktop-mock` alone only selects a mock Wi-Fi backend. Pass `--preview` to
+replace storage probes, package lookup, installation, and reboot too. Do not
+run the ordinary installer on the development host to obtain screenshots.
+
+## Source map
+
+- `core/`: configuration, validation, disk/ZFS/network operations and installation.
+- `tui/`: terminal frontend.
+- `slint-ui/ui/`: real Slint views, dialogs, shared controls and globals.
+- `slint-ui/src/`: controllers, UI adapters, preview fixtures and VT supervisor.
+- `slint-ui/scripts/`: repeatable capture and interaction flows.
+- `xtask/`: profile rendering and QEMU installation harness.
+- `gen_iso/profile/`: versioned ISO input. `profile_rendered/`, workdirs and
+  generated ISOs are outputs; do not implement changes only in those trees.
+
+For Slint implementation and design review, follow
+[Slint coding and visual review](slint-ui-review.md). The
+[GUI README](../slint-ui/README.md) lists all available preview states and flows.
+
+## Build and check
+
+```sh
+just cargo-build
+cargo fmt --all --check
+cargo test --workspace --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
+just check-features
+```
+
+`just cargo-build` produces production `target/release/azfs`, `azfs-tui`, and
+`xtask`. `just check` also runs the dependency audit. On a non-Arch host, use the
+documented container build for binaries intended for an Arch ISO; a host-linked
+binary may require a different dynamic loader or shared libraries.
+
+When adding dependencies, use the package manager (`cargo add`, `uv add`, etc.)
+and inspect the resulting manifest/lockfile changes. Prefer Rust edition 2024.
+Run Python tooling through `uv run`; the UI review scripts use the standard
+library and do not require adding a Python dependency for each review.
+
+Select checks by the changed behavior. A docs-only change needs working links
+and accurate commands, not a new ISO. Shared UI controls need checks of their
+consumers, not just the page edited. A boot helper needs failure-path tests and
+a boot check, not only Rust tests. Do not treat ignored hardware tests as passed.
+
+## Slint fork and release builds
+
+The GUI runtime and `slint-build` use the same Slint fork branch, currently
+`feat/linuxkms-integration`. Read their manifests and the git source revision
+in `Cargo.lock` before updating or diagnosing backend behavior. An upstream
+branch moving does not change the revision used by a locked build.
+
+Keep mock/MCP builds separate from production artifacts. Before distributing a
+binary, run `just cargo-build` with the default LinuxKMS/iwd features. Do not copy
+`target/debug/azfs` from a preview run onto the installer USB. `slint/mcp` is a
+debug build feature, not a feature to add permanently to the shipping manifest.
+
+## Updating the installer on Ventoy
+
+Use [Live binary updates](../gen_iso/LIVE_UPDATE.md) for the exact USB workflow.
+One base ISO containing `azfs-live-update.service` is required. Afterwards:
+
+1. Build the LinuxKMS release binary.
+2. Publish it as `/azfs-update/azfs` on the Ventoy data partition using a
+   temporary filename, verify the copy, and safely unmount the USB drive.
+3. Boot the ISO and run `azfs` from the console as usual.
+4. Check `journalctl -b -u azfs-live-update.service` for the loaded SHA-256.
+
+The oneshot runs before login consoles. It reads only the boot disk's data
+partition and stages the binary in `/usr/local/bin` before an atomic rename.
+The live root's OverlayFS normally stores that replacement in RAM; the ISO is
+unchanged. An absent or rejected update leaves the built-in installer available.
+The service neither starts the GUI nor periodically reloads a running process.
+
+Changes to the service, ISO profile, kernel, ZFS, TUI or incompatible system
+libraries require updating the base image. Replacing `azfs` cannot change those.
+
+```sh
+just test-live-update
+shellcheck gen_iso/profile/airootfs/usr/local/libexec/azfs-live-update
+```
+
+For boot changes, test the actual service in a disposable VM with Ventoy, not
+only a direct CD-ROM boot. Exercise valid, absent and invalid updates, check the
+installed hash and login ordering, and verify fallback still reaches the console.
+
+## ISO and USB delivery
+
+```sh
+just iso-full --mode dkms --kernel linux
+```
+
+This is a full build. Repacking a known base can save package-build time, but
+still requires replacing the compressed root image, regenerating its checksum,
+preserving BIOS/UEFI boot metadata, and checking the final image. It is not a
+binary-sized in-place edit. Never ship temporary boot collectors or automatic
+shutdown fixtures used during testing.
+
+Before writing physical media, inspect `lsblk` and identify the drive by model,
+serial, partition and mount source. Copy a file onto Ventoy's data filesystem;
+do not overwrite the entire disk with `dd`. Preserve unrelated images. Delete
+the superseded installer image only after the new copy is verified.
+
+Wait for writes to finish, compare source/destination hashes, unmount and
+recheck the hashes after mounting read-only. Cached reads alone are weaker
+evidence than a direct read. `oflag=direct` has alignment constraints; do not
+blindly apply an ISO-copy command to an arbitrarily sized binary. Unmount all
+partitions and power off/eject the USB only after every VM using it has exited.
+Do not report safe removal until these steps succeed.
+
+A stalled flush is not proof of a defective USB drive. Inspect the kernel log
+and existing hung-task/panic settings when diagnosing a write stall; do not
+change host panic policy as a routine part of copying an image.
+
+For QEMU booting from physical media, keep the physical backing device read-only
+and direct guest writes into a local qcow2 overlay. A fully read-only virtual
+disk can fail during Ventoy's device-mapper setup. The working block-device
+arrangement and shutdown procedure are in [Boot debugging](debugging-boot.md).
+
+## Installation and shell lifecycle
+
+The disposable encrypted-install harness is separate from UI preview:
+
+```sh
+just cargo-build
+just test-install-encrypted-pool --tmpfs --timeout 1800
+```
+
+See [Post-install shell](../slint-ui/POST_INSTALL_SHELL.md) for the real VT/chroot
+round trip and fixture. The GUI child exits before the shell opens. The parent
+restores the console, manages owned mounts/processes, cleans up, then starts a
+new completion GUI. Simulated `shell` screenshots do not prove this lifecycle.
+
+## Reporting completed work
+
+Record the revision, feature set, commands, tested states/display configurations,
+and artifact paths. Separate code checks, visual inspection, VM behavior and
+physical-device results. A green screenshot capture is not a design review; a
+successful GUI boot is not a successful disk installation. Dated review reports
+are historical evidence, not a standing claim that future changes are covered.

--- a/docs/development.md
+++ b/docs/development.md
@@ -138,9 +138,15 @@ arrangement and shutdown procedure are in [Boot debugging](debugging-boot.md).
 The disposable encrypted-install harness is separate from UI preview:
 
 ```sh
+just iso-test --mode dkms --kernel linux-lts
 just cargo-build
 just test-install-encrypted-pool --tmpfs --timeout 1800
 ```
+
+The install harness selects only `*-testing-*.iso` images because that profile
+enables the passwordless root SSH session used to upload and run the current
+installer binary. A newer full hardware ISO in `gen_iso/out` is ignored. Use
+`--iso PATH` only when a custom image provides the same SSH access.
 
 See [Post-install shell](../slint-ui/POST_INSTALL_SHELL.md) for the real VT/chroot
 round trip and fixture. The GUI child exits before the shell opens. The parent

--- a/docs/slint-ui-review.md
+++ b/docs/slint-ui-review.md
@@ -1,0 +1,261 @@
+# Slint coding and visual review
+
+This is the working procedure for developers and coding agents changing the
+installer UI. It covers design judgment, interaction, and rendering separately.
+Use the actual Slint application and deterministic data, not a recreated HTML
+page or a generated image that merely resembles the interface.
+
+## 1. Establish the scope and design question
+
+Read the touched view, its shared controls, its Rust controller and the relevant
+state/model. Inspect the Slint versions and git revision in
+`slint-ui/Cargo.toml` and `Cargo.lock`; use documentation matching that checkout.
+If a local Slint checkout is available, its `ai-plugins/skills/slint/` references
+on layout, polish, events, interop and MCP are useful. The project workflow must
+remain usable without a developer-specific absolute path to that checkout.
+
+Before changing spacing, state what the user must understand and do on the
+screen. Ask whether the primary action is clear, whether the information order
+supports the decision, and whether the layout still makes sense in other modes.
+An interface can render perfectly while presenting the wrong interaction.
+
+Make a small coverage matrix before a broad review:
+
+| Screen/dialog | State and fixture | Display/scale | Interaction | Capture | Finding/status |
+| --- | --- | --- | --- | --- | --- |
+| Disk / picker | New pool, many partitions | 1920×1080 / 1 | Search, select, cancel, confirm | PNG + tree | Pending |
+| Welcome / Wi-Fi | Offline, then connected | 1366×768 / 1 | Connect, Done, reopen settings | PNG + tree | Pending |
+
+Only mark rows reviewed after inspecting their images and performing the listed
+actions. Enumerate the screens and states checked in the final report. Do not
+say “all UI checked” because every wizard page was opened once.
+
+## 2. Build a safe, representative preview
+
+All commands below run from the repository root:
+
+```sh
+SLINT_EMIT_DEBUG_INFO=1 cargo build -p archinstall-zfs-slint \
+  --no-default-features --features desktop-mock,slint/mcp --locked
+```
+
+Use **both** `desktop-mock` and `--preview`. The feature by itself only mocks
+Wi-Fi; preview replaces hardware/installation operations while retaining the
+real UI, editing controllers and validation. Never use actual passwords or
+private identifiers as review fixtures.
+
+For manual MCP exploration:
+
+```sh
+SLINT_BACKEND=headless SLINT_MCP_PORT=9315 target/debug/azfs \
+  --preview new-pool --preview-size 1920x1080 --ui-scale 1
+```
+
+Omit `SLINT_BACKEND=headless` to use a desktop window. Use your tool's tracked
+process/session mechanism for a long-running preview and stop that exact process
+afterwards. The capture scripts manage their own child processes and ports.
+Do not start untracked shell jobs or kill every `azfs`/QEMU process by name.
+
+Debug info must be emitted **at build time**. Setting that variable only when
+starting an old executable does not enable element lookup. Rebuild and restart
+after source changes; a running process does not pick up the new binary.
+
+## 3. Use the agreed display matrix
+
+| Configuration | Purpose |
+| --- | --- |
+| 1920×1080, scale 1 | Primary composition, typography and screenshot baseline |
+| 1366×768, scale 1 | Smaller laptop viewport, density and scrolling |
+| 1280×800, scale 1 | Additional compact/aspect-ratio check |
+| 1920×1080, scale 1.5 | Fractional scaling, alignment and readable controls |
+| 1920×1080, scale 2 | Large UI, wrapping, footer and dialog constraints |
+
+Treat 800×600 captures in older reports as historical stress checks, not the
+current design baseline. A screenshot's physical dimensions and UI scale both
+matter: 1920×1080 at scale 2 has roughly 960×540 logical pixels. Do not resize an
+existing PNG and call that a new display test. `Preview.ready()` checks the
+actual window size and scale reported by MCP.
+
+## 4. Capture pages, then exercise transitions
+
+```sh
+# Every canned scene at the five display configurations above.
+uv run python slint-ui/scripts/review.py --output target/ui-review/pages
+
+# Standard editing, Wi-Fi, install/cancel, shell, logs and validation flows.
+uv run python slint-ui/scripts/interactions.py --output target/ui-review/flows
+
+# Extended account, regional and desktop/package editor states.
+uv run python slint-ui/scripts/design_review.py --output target/ui-review/editors
+
+# Storage selection across modes and adjacent ZFS/Review screens.
+uv run python slint-ui/scripts/storage_review.py --size 1920x1080 \
+  --output target/ui-review/storage
+uv run python slint-ui/scripts/storage_review.py --keyboard-only \
+  --size 1920x1080 --scale 2 --output target/ui-review/storage-keyboard
+AZFS_PREVIEW_STORAGE=many uv run python slint-ui/scripts/storage_review.py \
+  --fixture many --size 1920x1080 --output target/ui-review/storage-many
+```
+
+For an isolated change, start with the affected cases instead of blindly
+rerunning every scenario:
+
+```sh
+uv run python slint-ui/scripts/review.py --scenes welcome offline \
+  --sizes 1920x1080@1 1366x768@1 1920x1080@2 --output target/ui-review/network
+uv run python slint-ui/scripts/interactions.py --flows wifi \
+  --output target/ui-review/network-flows
+```
+
+The page script defaults to five configurations; interaction/editor scripts
+default to three. `storage_review.py` defaults to **1366×768**, so specify
+`--size 1920x1080` for the primary review. Its `--fixture` flag selects assertions,
+while `AZFS_PREVIEW_STORAGE` selects data: use matching values (`empty`, `many`,
+or `missing`). Do not assume the flag alone changes the inventory.
+
+The [GUI README](../slint-ui/README.md) lists scenes and additional flows.
+Scripts emit individual PNGs, element trees, window metadata and process logs.
+`review.py` also writes an HTML gallery. Passing assertions is evidence of the
+asserted behavior, not an automated design score.
+
+## 5. Inspect full-size images, not just galleries
+
+Open the actual PNG with the available image viewer. Use a gallery/contact
+sheet to find inconsistent pages, then inspect each relevant image individually.
+At thumbnail size, clipped text, uneven baselines, small hit targets and missing
+icon strokes can disappear. Zoom or inspect a crop when necessary; keep the
+original full-screen capture as evidence of composition. Crops and overviews do
+not replace it.
+
+Review three distinct aspects:
+
+- **Design:** grouping, reading order, primary action, density, typography,
+  alignment, spacing, color meaning and consistency with adjacent screens.
+- **Interaction:** selection/commit/cancel, focus, keyboard scrolling, validation,
+  loading, errors, recovery, disabled explanations and preserved user input.
+- **Rendering:** clipping, overlap, ellipsis, icon alignment, scaling and redraw.
+
+In particular, apply these project decisions:
+
+- Keep comparable values and metadata groups on consistent columns/edges.
+  Badges must not float according to the model name's length or distribute
+  themselves across spare row width. Size/type/transport are secondary metadata.
+- Use compact storage assignment summaries with Choose/Change opening a bounded,
+  searchable picker. Do not repeat the entire partition inventory under every
+  assignment. Check Full Disk, New Pool and Existing Pool, and their effects on
+  ZFS and Review. Preserve enough device identity to avoid an ambiguous choice;
+  explain why a partition is unavailable.
+- Give actions visible button treatment. Quit should look clickable; a small
+  bare word is insufficient. Keep related actions together with a clear primary
+  and secondary order. Use explicit verbs instead of relying on a chevron.
+- With Wi-Fi hardware present, **Wi-Fi & network** with its icon remains available
+  before and after connection. It is prominent offline and secondary once the
+  user can proceed. Connection success leads to **Done**; disconnect belongs in
+  connection management. A VM without Wi-Fi hardware will not show this button.
+- Keep installation logs above the lower action card. The card holds progress,
+  status and buttons; it stays available while logs scroll. Inspect completion,
+  failure, cancelling/cancelled, and return from the installed-system shell.
+- Use consistent heading/body/secondary sizes and restrained rounding. Prefer
+  the existing 44 logical-pixel height for prominent actions; compact row actions
+  can use the established 40-pixel pattern. Do not shrink text/buttons to make
+  an overfull screen fit. Allow the appropriate body to scroll.
+- Keep labels visible when inputs contain text. Validation should explain the
+  problem near the field and preserve entered values. Ordinary settings should
+  not look like success notifications merely because they have a value.
+
+Include ready, empty, loading, success, error, disabled, selected and focused
+states where they exist. Exercise long labels/serials/paths, missing metadata,
+many items, search with no results, and switching modes after making selections.
+
+## 6. Drive the real UI with MCP
+
+Use `list_windows`, then `get_window_properties` to obtain the current window
+and root element handles. Inspect `get_element_tree` or look up ids. Window and
+element handles have similar shapes but are not interchangeable; do not paste a
+handle from an earlier run into a new process.
+
+Use `click_element`, `set_element_value` and `dispatch_key_event` to perform real
+actions. Prefer stable accessible roles/labels or ids over absolute coordinates.
+Wait for a meaningful state, not an arbitrary long sleep. Check that element
+trees are not truncated and inspect geometry as well as visible text.
+
+The shared `Preview` helper in `slint-ui/scripts/review.py` already implements
+this HTTP workflow and process cleanup. Extend existing flows for regressions
+rather than creating an independent automation framework. Where direct API calls
+are needed, discover the tools/schemas supported by the pinned Slint build.
+
+Test Tab/Shift+Tab, arrows, Enter and Escape as applicable. Opening a dialog must
+put focus somewhere useful; closing it must restore focus to the triggering
+control. Scroll a focused control into view. Verify selection cancellation does
+not silently commit a tentative choice. Distinguish row selection from confirming
+an action, and errors from simply having no results.
+
+## 7. Write Slint code to support those decisions
+
+Use the project's existing controls (`StyledButton`, `StyledTextInput`, `Icon`,
+`SignalBars`, `SetupRow`, `ConfigItem`) and the palette/spacing/type/radius tokens
+in `slint-ui/ui/styling.slint`. Read the component API before adding another control or
+hardcoding a new visual convention. Standard widgets remain useful, but replacing
+the shared controls wholesale is not required to fix one page.
+
+- Use `HorizontalLayout`, `VerticalLayout` and `GridLayout` for normal placement.
+  Reserve manual coordinates for overlays/custom drawing. Padding belongs on a
+  layout, not a `Text` element.
+- Distinguish fill, preferred size and minimum size. Use stretch factors for
+  flexible space, and bound metadata/button groups that should keep their size.
+  Avoid making a row's alignment depend on a long label's implicit width.
+- Wrap an entire phase-specific layout in `if`. An always-present empty layout
+  can still consume height even when all its children are hidden.
+- Constrain a scrollable body to the available area. Do not bind its preferred
+  height to the whole content when the parent needs to limit it. Keep footer
+  actions outside that scrolling body, and clip at the body boundary.
+- Center icons within their allocated layout cell; a horizontal wrapper can be
+  necessary inside a vertical layout. Reuse `Icon` and its tint/size behavior.
+- Use meaningful property directions (`in`, `out`, `in-out`, private). A binding
+  reacts to dependencies; imperative assignment can change that relationship.
+  Use two-way bindings only when both sides really own edits. Keep bindings pure.
+- Give custom controls correct accessible roles, labels, enabled/selected state,
+  focus behavior and keyboard activation. New icons must not remove action text
+  where that text explains the action.
+- Keep presentation state in Slint globals/adapters and business operations in
+  Rust controllers/core. Do not put disk or network operations in layout code.
+  Run blocking work away from the UI thread and return updates through Slint's
+  event-loop mechanism. Follow existing weak-handle and cancellation patterns.
+- Guard async searches, scans and validation against stale responses after a
+  newer request, clearing a field, switching modes or closing a dialog. Invalid
+  submissions should retain the user's input for correction.
+
+When a bug only appears with real data, extend `slint-ui/src/preview.rs` and its
+fixtures to represent that shape. Drive the same component/controller paths;
+do not fix only the preview or manually force final globals to bypass the
+interaction being tested. Keep all simulated operations inside preview mode.
+
+## 8. Keep hardware verification separate
+
+Headless previews cannot validate LinuxKMS partial redraw, physical cursor
+damage, touchpad acceleration, VT keyboard isolation, real Wi-Fi timing or a
+post-install chroot. Use the default LinuxKMS build for those. The
+[developer guide](development.md) and
+[post-install shell guide](../slint-ui/POST_INSTALL_SHELL.md) describe the paths.
+
+For VT isolation, use disposable marker input, never real credentials. Test that
+typing in the GUI does not become a shell command after normal exit or a GUI
+child crash, and that the console works after restoration. Mouse/touchpad speed
+must be judged on the target device; a static screenshot cannot establish it.
+
+For backend changes, test incremental redraw against full repaint where possible,
+then check cursor movement, clipping at edges, hiding/showing and scale changes
+on KMS. Do not change renderer internals to compensate for an application layout
+mistake without evidence that the backend is responsible.
+
+## 9. Finish with evidence and a bounded claim
+
+After implementation, run the appropriate Rust checks from
+[AGENTS.md](../AGENTS.md), review the changed diff, and save the screenshots.
+For shared controls, revisit their affected consumers and state variants.
+
+Report the source revision/features, tested display sizes/scales, interactions,
+findings fixed, artifact paths, and what remains untested. Keep dated reports such
+as [Design review](../slint-ui/DESIGN_REVIEW.md) distinct from this living workflow.
+Do not recycle an old screenshot as evidence of a new build. Documentation-only
+edits do not constitute another visual review of the application.

--- a/gen_iso/LIVE_UPDATE.md
+++ b/gen_iso/LIVE_UPDATE.md
@@ -1,0 +1,58 @@
+# Updating the live installer from Ventoy
+
+ISOs built with `azfs-live-update.service` can load a newer GUI installer from
+the Ventoy data partition at boot. Place your trusted, LinuxKMS release binary
+at `/azfs-update/azfs` on that partition (alongside the ISO, outside it).
+
+For example, after `just cargo-build`, with Ventoy already mounted:
+
+```sh
+mkdir -p /run/media/$USER/Ventoy/azfs-update
+cp target/release/azfs /run/media/$USER/Ventoy/azfs-update/azfs.part
+mv /run/media/$USER/Ventoy/azfs-update/azfs.part /run/media/$USER/Ventoy/azfs-update/azfs
+```
+
+Safely unmount/eject the USB drive before booting it. Publishing with the final
+rename avoids picking up an incomplete transfer. Remove or rename `azfs-update`
+to use the installer embedded in the ISO again.
+
+The oneshot service runs before login consoles and a display manager. The
+current ISO starts at a console: run `azfs` as usual. The service does not launch
+the GUI itself. Any future GUI unit must also order itself after
+`azfs-live-update.service`.
+
+The helper follows `/dev/mapper/ventoy` to its backing disk and reads partition
+1 in a private, read-only mount. It does not search other disks by label. Booting
+the ISO directly, or booting without a discoverable Ventoy mapping, does not
+load an external binary.
+
+On current Ventoy versions the helper uses the partition's
+`/dev/mapper/<partition>` device, after checking that it maps the complete
+selected partition. See [Ventoy Linux Remount](https://www.ventoy.net/en/doc_linux_remount.html).
+
+The binary is staged next to `/usr/local/bin/azfs`, checked for an ELF header,
+and run with `--help` under a timeout to check runtime compatibility. Only then
+is it atomically renamed over the existing file. A failed copy or check keeps
+the built-in installer. These are integrity/startup checks, not authentication:
+putting a binary in this directory authorizes running it as root. The service
+logs the loaded binary's SHA-256 and any errors:
+
+```sh
+journalctl -b -u azfs-live-update.service
+```
+
+The destination is the live root's writable OverlayFS layer, normally backed
+by tmpfs. The ISO and the Ventoy filesystem are never modified by the service.
+With the standard non-persistent boot, the replacement disappears on reboot
+and is loaded again from USB. No separate executable mount on exFAT is needed.
+
+This updates only `azfs`, not the TUI, kernel, ZFS or shared libraries. Build a
+new base ISO when those dependencies change incompatibly. An older ISO without
+this service needs one initial update before binary-only updates work.
+
+Run the unprivileged regression checks with:
+
+```sh
+uv run python gen_iso/test_live_update.py
+shellcheck gen_iso/profile/airootfs/usr/local/libexec/azfs-live-update
+```

--- a/gen_iso/LIVE_UPDATE.md
+++ b/gen_iso/LIVE_UPDATE.md
@@ -4,17 +4,50 @@ ISOs built with `azfs-live-update.service` can load a newer GUI installer from
 the Ventoy data partition at boot. Place your trusted, LinuxKMS release binary
 at `/azfs-update/azfs` on that partition (alongside the ISO, outside it).
 
-For example, after `just cargo-build`, with Ventoy already mounted:
+## Publish an update
 
-```sh
-mkdir -p /run/media/$USER/Ventoy/azfs-update
-cp target/release/azfs /run/media/$USER/Ventoy/azfs-update/azfs.part
-mv /run/media/$USER/Ventoy/azfs-update/azfs.part /run/media/$USER/Ventoy/azfs-update/azfs
+From the repository root, run `just cargo-build` to produce the default
+LinuxKMS/iwd release binary. Do not use a desktop-mock or MCP preview build.
+Confirm the mounted data partition belongs to the intended USB drive with
+`lsblk -o NAME,PATH,MODEL,SERIAL,FSTYPE,LABEL,MOUNTPOINTS` and `findmnt`.
+Do not reuse a device name from a previous connection without checking it.
+
+With Ventoy already mounted, adjust the path and run this block:
+
+```bash
+(
+    set -euo pipefail
+    VENTOY_MOUNT="/run/media/$USER/Ventoy"
+    mountpoint -q "$VENTOY_MOUNT"
+    UPDATE_DIR="$VENTOY_MOUNT/azfs-update"
+    mkdir -p "$UPDATE_DIR"
+    cp target/release/azfs "$UPDATE_DIR/azfs.part"
+    sync -f "$UPDATE_DIR/azfs.part"
+    SOURCE_HASH=$(sha256sum target/release/azfs | cut -d ' ' -f 1)
+    COPY_HASH=$(sha256sum "$UPDATE_DIR/azfs.part" | cut -d ' ' -f 1)
+    test "$SOURCE_HASH" = "$COPY_HASH"
+    mv "$UPDATE_DIR/azfs.part" "$UPDATE_DIR/azfs"
+    printf '%s  azfs\n' "$SOURCE_HASH" > "$UPDATE_DIR/azfs.sha256"
+    sync -f "$UPDATE_DIR"
+)
 ```
 
-Safely unmount/eject the USB drive before booting it. Publishing with the final
-rename avoids picking up an incomplete transfer. Remove or rename `azfs-update`
-to use the installer embedded in the ISO again.
+Wait for both flushes to finish. If any command fails, investigate before
+reporting the transfer complete. The checksum file is for manual verification;
+the boot service does not use it as a signature or trust source. Publishing with
+the final rename avoids picking up an incomplete transfer.
+
+Unmount the data partition using the desktop's safe removal action or
+`udisksctl unmount -b <verified-data-partition>`. For stronger delivery validation,
+remount it read-only and compare the destination hash again, then unmount all USB
+partitions and eject/power off the verified drive. Stop any VM using it first.
+See [ISO and USB delivery](../docs/development.md#iso-and-usb-delivery).
+
+Boot the existing base ISO normally. Remove or rename `azfs-update` to use the
+installer embedded in the ISO again. A base ISO without this service needs one
+initial replacement; copying a binary beside such an ISO cannot enable updates.
+
+## Boot behavior and limits
 
 The oneshot service runs before login consoles and a display manager. The
 current ISO starts at a console: run `azfs` as usual. The service does not launch
@@ -38,7 +71,8 @@ putting a binary in this directory authorizes running it as root. The service
 logs the loaded binary's SHA-256 and any errors:
 
 ```sh
-journalctl -b -u azfs-live-update.service
+journalctl -b -u azfs-live-update.service --no-pager
+sha256sum /usr/local/bin/azfs
 ```
 
 The destination is the live root's writable OverlayFS layer, normally backed
@@ -50,9 +84,27 @@ This updates only `azfs`, not the TUI, kernel, ZFS or shared libraries. Build a
 new base ISO when those dependencies change incompatibly. An older ISO without
 this service needs one initial update before binary-only updates work.
 
+## Implementation and validation
+
+The source lives in the ISO profile:
+
+- [Loader](profile/airootfs/usr/local/libexec/azfs-live-update)
+- [Oneshot service](profile/airootfs/etc/systemd/system/azfs-live-update.service)
+- [Regression tests](test_live_update.py)
+
+The unit pulls in the passive `getty-pre.target` with `Wants=` as well as ordering
+itself `Before=` that target. Keep both: ordering alone does not start a passive
+target and cannot establish the intended login ordering in that case.
+
 Run the unprivileged regression checks with:
 
 ```sh
 uv run python gen_iso/test_live_update.py
 shellcheck gen_iso/profile/airootfs/usr/local/libexec/azfs-live-update
 ```
+
+`just test-live-update` runs the same Python tests. Also boot with Ventoy and
+exercise an accepted update, no update and a rejected update. Confirm that the
+console remains available, the loaded SHA-256 matches, and the service finishes
+before getty. The [boot guide](../docs/debugging-boot.md#testing-a-physical-ventoy-drive-without-writing-to-it)
+shows a VM setup that protects the physical medium while allowing guest writes.

--- a/gen_iso/profile/airootfs/etc/systemd/system/azfs-live-update.service
+++ b/gen_iso/profile/airootfs/etc/systemd/system/azfs-live-update.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load an installer update from the Ventoy boot medium
+After=local-fs.target
+Wants=getty-pre.target
+Before=getty-pre.target display-manager.service
+ConditionPathIsDirectory=/run/archiso/cowspace
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/libexec/azfs-live-update
+RemainAfterExit=yes
+TimeoutStartSec=30s
+TimeoutStopSec=5s
+RuntimeDirectory=azfs-live-update
+PrivateMounts=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/gen_iso/profile/airootfs/etc/systemd/system/multi-user.target.wants/azfs-live-update.service
+++ b/gen_iso/profile/airootfs/etc/systemd/system/multi-user.target.wants/azfs-live-update.service
@@ -1,0 +1,1 @@
+../azfs-live-update.service

--- a/gen_iso/profile/airootfs/usr/local/libexec/azfs-live-update
+++ b/gen_iso/profile/airootfs/usr/local/libexec/azfs-live-update
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Replace the live installer in its RAM overlay, before any login shell starts.
+set -euo pipefail
+
+log() { printf 'azfs-live-update: %s\n' "$*"; }
+
+partition_number() {
+    cat "/sys/class/block/${1##*/}/partition"
+}
+
+find_update_partition() {
+    # Follow the ISO mapping, not a filesystem label shared by unrelated disks.
+    # Ventoy keeps this mapping when archiso copies the root image to RAM too.
+    local topology type path disk="" partitions
+    topology=$(lsblk --inverse --noheadings --raw --paths --output TYPE,PATH /dev/mapper/ventoy) || return 1
+    while read -r type path; do
+        if [[ "$type" == disk ]]; then
+            [[ -z "$disk" || "$disk" == "$path" ]] || return 1
+            disk=$path
+        fi
+    done <<< "$topology"
+    [[ -n "$disk" ]] || return 1
+    partitions=$(lsblk --noheadings --raw --paths --output TYPE,PATH "$disk") || return 1
+    while read -r type path; do
+        if [[ "$type" == part ]] && [[ $(partition_number "$path") == 1 ]]; then
+            printf '%s\n' "$path"
+            return 0
+        fi
+    done <<< "$partitions"
+    return 1
+}
+
+mount_source() {
+    local partition=$1 table sectors device
+    # Recent Ventoy releases hold the partition open exclusively. They provide
+    # a linear mapping of the full partition for filesystem access instead.
+    if table=$(dmsetup table -- "${partition##*/}" 2>/dev/null); then
+        sectors=$(blockdev --getsz "$partition") || return 1
+        device=$(lsblk --nodeps --noheadings --raw --output MAJ:MIN "$partition") || return 1
+        [[ "$table" == "0 $sectors linear $device 0" ]] || return 1
+        printf '/dev/mapper/%s\n' "${partition##*/}"
+    else
+        printf '%s\n' "$partition"
+    fi
+}
+
+install_update() (
+    # A subshell owns the temporary file even if validation fails or is killed.
+    set -euo pipefail
+    local source=$1 destination=$2 staged="" digest
+    trap '[[ -z "$staged" ]] || rm -f -- "$staged"' EXIT
+    trap 'exit 143' TERM
+    [[ -f "$source" && ! -L "$source" && -s "$source" ]] || {
+        log "Invalid update file; keeping the built-in installer."
+        exit 1
+    }
+    staged=$(mktemp "${destination}.update.XXXXXX")
+    cp --reflink=never -- "$source" "$staged"
+    chmod 0755 "$staged"
+    [[ $(od -An -tx1 -N4 "$staged" | tr -d ' \n') == 7f454c46 ]] || {
+        log "Update is not an ELF executable; keeping the built-in installer."
+        exit 1
+    }
+    # Exercise the dynamic loader and CLI without opening the UI or touching disks.
+    if ! timeout --kill-after=2s 10s "$staged" --help >/dev/null; then
+        log "Update cannot start on this ISO; keeping the built-in installer."
+        exit 1
+    fi
+    digest=$(sha256sum "$staged")
+    mv -fT -- "$staged" "$destination"
+    staged=""
+    log "Installed $destination from $source (sha256 ${digest%% *})."
+)
+
+is_live_root() {
+    [[ -d /run/archiso/cowspace ]] && [[ $(findmnt -n -o FSTYPE /) == overlay ]]
+}
+
+main() {
+    local partition source mount_dir=/run/azfs-live-update/media
+    if ! is_live_root; then
+        log "Not an archiso RAM overlay; skipping."
+        return 0
+    fi
+    if [[ ! -b /dev/mapper/ventoy ]]; then
+        log "Not booted through Ventoy; using the built-in installer."
+        return 0
+    fi
+    partition=$(find_update_partition) || {
+        log "Cannot identify the Ventoy data partition; keeping the built-in installer."
+        return 1
+    }
+    source=$(mount_source "$partition") || {
+        log "Unexpected mapping for $partition; keeping the built-in installer."
+        return 1
+    }
+    mkdir -p "$mount_dir"
+    # This is a private service mount; never unmount an existing archiso mount.
+    log "Reading updates from $source."
+    mount -o ro,nosuid,nodev,noexec -- "$source" "$mount_dir"
+    trap 'umount /run/azfs-live-update/media || true' EXIT
+    trap 'exit 143' TERM
+    if [[ ! -e "$mount_dir/azfs-update/azfs" ]]; then
+        log "No /azfs-update/azfs on the boot medium; using the built-in installer."
+        return 0
+    fi
+    install_update "$mount_dir/azfs-update/azfs" /usr/local/bin/azfs
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    main "$@"
+fi

--- a/gen_iso/profile/profiledef.sh.j2
+++ b/gen_iso/profile/profiledef.sh.j2
@@ -25,6 +25,7 @@ file_permissions=(
   ["/root"]="0:0:750"
   ["/usr/local/bin/azfs-tui"]="0:0:755"
   ["/usr/local/bin/azfs"]="0:0:755"
+  ["/usr/local/libexec/azfs-live-update"]="0:0:755"
   ["/usr/local/bin/choose-mirror"]="0:0:755"
   ["/usr/local/bin/Installation_guide"]="0:0:755"
   ["/usr/local/bin/livecd-sound"]="0:0:755"

--- a/gen_iso/test_live_update.py
+++ b/gen_iso/test_live_update.py
@@ -1,0 +1,142 @@
+"""Unprivileged regression tests: uv run python gen_iso/test_live_update.py."""
+
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).parent / "profile/airootfs/usr/local/libexec/azfs-live-update"
+
+
+class LiveUpdateTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.source = self.root / "USB with spaces" / "azfs"
+        self.source.parent.mkdir()
+        self.destination = self.root / "azfs"
+        self.destination.write_bytes(b"built-in installer")
+
+    def run_shell(self, body, *args):
+        return subprocess.run(
+            ["bash", "-c", 'source "$1"; shift; ' + body, "test", str(SCRIPT), *map(str, args)],
+            text=True, capture_output=True, timeout=20,
+        )
+
+    def update(self, prefix=""):
+        return self.run_shell(prefix + 'install_update "$1" "$2"', self.source, self.destination)
+
+    def assert_preserved(self, result):
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.destination.read_bytes(), b"built-in installer")
+        self.assertEqual(list(self.root.glob("azfs.update.*")), [])
+
+    def test_update_is_atomic_and_works_without_usb_execute_permission(self):
+        shutil.copyfile("/usr/bin/true", self.source)
+        self.source.chmod(0o644)
+        with self.destination.open("rb") as old_inode:
+            result = self.update()
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(old_inode.read(), b"built-in installer")
+        self.assertEqual(self.destination.read_bytes(), self.source.read_bytes())
+        self.assertEqual(self.destination.stat().st_mode & 0o777, 0o755)
+        self.assertIn("sha256", result.stdout)
+        self.assertEqual(list(self.root.glob("azfs.update.*")), [])
+
+    def test_missing_or_empty_update_preserves_original(self):
+        self.assert_preserved(self.update())
+        self.source.touch()
+        self.assert_preserved(self.update())
+
+    def test_script_is_rejected_without_execution(self):
+        marker = self.root / "executed"
+        self.source.write_text(f"#!/bin/sh\ntouch '{marker}'\n")
+        self.assert_preserved(self.update())
+        self.assertFalse(marker.exists())
+
+    def test_broken_elf_preserves_original(self):
+        self.source.write_bytes(b"\x7fELF" + bytes(128))
+        self.assert_preserved(self.update())
+
+    def test_symlink_is_rejected(self):
+        self.source.symlink_to("/usr/bin/true")
+        self.assert_preserved(self.update())
+
+    def test_partial_copy_failure_preserves_original(self):
+        shutil.copyfile("/usr/bin/true", self.source)
+        self.assert_preserved(self.update('cp() { printf partial > "${@: -1}"; return 1; }; '))
+
+    def test_rename_failure_preserves_original(self):
+        shutil.copyfile("/usr/bin/true", self.source)
+        self.assert_preserved(self.update('mv() { return 1; }; '))
+
+    def test_failed_startup_probe_preserves_original(self):
+        shutil.copyfile("/usr/bin/true", self.source)
+        self.assert_preserved(self.update('timeout() { return 124; }; '))
+
+    def discover(self, topology, partitions):
+        # Only device enumeration is simulated; selection runs the real helper.
+        return self.run_shell(
+            '''fixture_topology=$1; fixture_partitions=$2
+            lsblk() {
+                case "${@: -1}" in
+                    /dev/mapper/ventoy) printf '%s\\n' "$fixture_topology" ;;
+                    /dev/sdb|/dev/nvme1n1) printf '%s\\n' "$fixture_partitions" ;;
+                    *) return 1 ;;
+                esac
+            }
+            partition_number() { printf '%s\\n' "${1: -1}"; }
+            find_update_partition''', topology, partitions,
+        )
+
+    def test_follows_boot_mapping_for_sata_and_nvme(self):
+        for disk, part in [("sdb", "sdb1"), ("nvme1n1", "nvme1n1p1")]:
+            with self.subTest(disk=disk):
+                result = self.discover(
+                    f"dm /dev/mapper/ventoy\ndisk /dev/{disk}",
+                    f"disk /dev/{disk}\npart /dev/{part}\npart /dev/{disk}2",
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), f"/dev/{part}")
+
+    def test_ambiguous_or_missing_boot_disk_is_rejected(self):
+        for topology in ["", "dm /dev/mapper/ventoy", "disk /dev/sdb\ndisk /dev/sdc"]:
+            self.assertNotEqual(self.discover(topology, "part /dev/sdb1").returncode, 0)
+
+    def test_missing_data_partition_is_rejected(self):
+        self.assertNotEqual(self.discover("disk /dev/sdb", "part /dev/sdb2").returncode, 0)
+
+    def test_installed_system_is_untouched(self):
+        result = self.run_shell('is_live_root() { return 1; }; main')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("skipping", result.stdout)
+
+    def mapping(self, table):
+        return self.run_shell(
+            '''fixture_table=$1
+            dmsetup() { [[ -n "$fixture_table" ]] || return 1; printf '%s\\n' "$fixture_table"; }
+            blockdev() { echo 8192; }
+            lsblk() { echo 8:17; }
+            mount_source /dev/sdb1''', table,
+        )
+
+    def test_ventoy_partition_mapping(self):
+        result = self.mapping("0 8192 linear 8:17 0")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "/dev/mapper/sdb1")
+
+    def test_mapping_of_another_partition_or_range_is_rejected(self):
+        for table in ["0 8192 linear 8:33 0", "0 4096 linear 8:17 0", "0 8192 linear 8:17 1"]:
+            self.assertNotEqual(self.mapping(table).returncode, 0)
+
+    def test_direct_partition_without_ventoy_remount_mapping(self):
+        result = self.mapping("")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "/dev/sdb1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/justfile
+++ b/justfile
@@ -73,6 +73,10 @@ check: fmt-check lint cargo-test check-features audit
 
 # ─── ISO Building ──────────────────────────────────────
 
+# Test the live ISO's binary replacement and boot-medium selection.
+test-live-update:
+    uv run python gen_iso/test_live_update.py
+
 # Internal: render profile templates using the prebuilt xtask binary.
 # Requires cargo-build or cargo-build-container to have run first.
 _render-profile MODE="precompiled" KERNEL="linux-lts" FAST="":

--- a/slint-ui/Cargo.toml
+++ b/slint-ui/Cargo.toml
@@ -46,7 +46,7 @@ crossbeam-channel = "0.5.16"
 nix.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-slint = { git = "https://github.com/okhsunrog/slint.git", rev = "d6b44e120", default-features = false, features = ["std", "compat-1-2"], version = "1.18.0" }
+slint = { git = "https://github.com/okhsunrog/slint.git", default-features = false, features = ["std", "compat-1-2"], version = "1.18.0", branch = "feat/linuxkms-integration" }
 sublime_fuzzy.workspace = true
 tempfile = "3.27.0"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros"] }
@@ -58,4 +58,4 @@ zfskit = "0.2.0"
 zxcvbn.workspace = true
 
 [build-dependencies]
-slint-build = { git = "https://github.com/okhsunrog/slint.git", rev = "d6b44e120", version = "1.18.0" }
+slint-build = { git = "https://github.com/okhsunrog/slint.git", version = "1.18.0", branch = "feat/linuxkms-integration" }

--- a/slint-ui/DESIGN_REVIEW.md
+++ b/slint-ui/DESIGN_REVIEW.md
@@ -1,5 +1,8 @@
 # Installer design review — 2026-09-09
 
+This is a dated result, not a claim that later changes have been reviewed.
+For the current procedure, see [Slint coding and visual review](../docs/slint-ui-review.md).
+
 This pass follows the storage redesign and reviews the remaining screens as
 user interfaces: hierarchy, decision clarity, action placement, density, and
 feedback. The primary reference is 1920×1080 at 100%. Secondary checks use

--- a/slint-ui/DESIGN_REVIEW.md
+++ b/slint-ui/DESIGN_REVIEW.md
@@ -1,0 +1,71 @@
+# Installer design review — 2026-09-09
+
+This pass follows the storage redesign and reviews the remaining screens as
+user interfaces: hierarchy, decision clarity, action placement, density, and
+feedback. The primary reference is 1920×1080 at 100%. Secondary checks use
+1366×768 at 100% and 1920×1080 at 200%. Screenshots come from the running Slint
+application with deterministic preview fixtures, not image mockups.
+
+## Findings and changes
+
+| Area | Problem | Result |
+| --- | --- | --- |
+| System, Users, Desktop | Values drifted to the far side of rows; chevrons hid the editing action; ordinary values looked like success statuses. | Stable label/value columns, neutral values, explicit outlined Change/Manage buttons, and real checkboxes for toggles. |
+| System | Repeated section labels and a long city list made regional setup harder to scan. | Base system and Language and region groups; city search and current timezone selection. |
+| Users | Administrator rights were toggled by clicking an otherwise unlabelled account row. Invalid input silently disappeared. | Labelled administrator checkboxes, explicit Remove buttons, inline validation that preserves input, and explanations of account/password behavior. |
+| Account form | At 200% scale Add user could scroll away while Done remained visible. | Both actions stay in the footer. Done reports an unfinished account instead of silently discarding it. |
+| Desktop | Audio and seat access expanded into repeated radio rows, dominating the page. | Compact choices and separate environment, profile, sound, hardware, and software groups. Console only explicitly describes the profile without a graphical environment. |
+| Packages | Selection and removal depended on clicking small result/chip text. Async searches could overwrite newer queries. | Separate result and selected-package lists, explicit Add/Remove controls, source labels, empty/error feedback, and stale-result rejection. |
+| Services and optional packages | Actions, descriptions, and inputs lacked a consistent hierarchy. | Persistent field labels, readable descriptions, explicit service removal, and consistent dialog footers. |
+| Selection and text dialogs | Small headings/actions, ambiguous OK, poor Escape/focus behavior, and truncated short lists. | Consistent headings and controls, Save/Cancel, bounded scrolling, keyboard focus recovery, and adequate short-list height. |
+| Welcome | An offline user had no prominent action to configure networking; retry competed with the status row. | Network settings is prominent when offline. Status rows align; preparation/failure explanations sit below them. |
+| Wi-Fi | Empty and unavailable states gave the same unhelpful message; error actions lacked a clear priority. | Distinct explanations, readable feedback, consistent password controls, and Back to networks as the primary error action. Successful connection retains Done as the primary action. |
+| Installation | Reconsidered log/action balance against the accepted design. | Retained logs above the lower action card; checked progress, completion, failure, cancellation, and simulated return from the shell. |
+
+## Coverage and reproduction
+
+Build with `SLINT_EMIT_DEBUG_INFO=1`, `desktop-mock,slint/mcp`, then run the
+commands in [README](README.md). The complementary checks are:
+
+- `scripts/review.py`: page composition and ready/offline, missing UEFI, ZFS
+  preparation/failure, empty/unavailable Wi-Fi, connection verification,
+  no-internet, installation and cancellation states.
+- `scripts/interactions.py`: editing, keyboard navigation/focus recovery,
+  Wi-Fi password entry and connection management, pool inspection, simulated
+  installation, completion, cancellation, shell return, log scrolling, and
+  invalid-configuration blocking.
+- `scripts/design_review.py`: account validation, duplicate names, administrator
+  changes, pending input, removal/empty lists; distribution/timezone/locale/
+  keyboard/download editors; optional packages, display manager and GPU lists;
+  KDE, Sway and console-only page variants; empty services, repository/AUR
+  searches, and adding/removing packages.
+- `scripts/storage_review.py`: regression coverage of the earlier storage
+  redesign after shared component and focus changes.
+
+The scripts save individual PNGs and element trees for visual inspection.
+Passing assertions alone is not a design verdict. Layout decisions were checked
+on individual screenshots, including long text, errors, empty lists, open
+menus, and 200% scale; small overview thumbnails are insufficient for this.
+
+Validation completed for this pass: the 10 standard interaction flows at all
+three configurations, the three extended editor flows at all three
+configurations, and storage interaction at Full HD (mouse at 100%, keyboard at
+200%). Formatting, workspace tests (314 passed, two ignored), and workspace
+clippy with warnings denied passed. Visual artifacts from this local run are
+under `target/ui-design-rest/index.html`; the scripts regenerate them after a
+clean checkout.
+
+## Boundaries
+
+The scope covers all installer sections and the listed dialog/state families.
+It is not an exhaustive combination of every distribution, desktop profile,
+package inventory, text length, font, and display size. The graphical choices
+were inspected with KDE, Sway, and console-only fixtures; this does not establish
+that every desktop package set installs successfully.
+
+Preview mode retains real UI callbacks and editing validation, but substitutes
+hardware inventory, networking/package results, installation, and reboot. This
+pass does not retest LinuxKMS cursor/input isolation on hardware, real Wi-Fi
+timing, destructive installation, post-install chroot, or USB image writing.
+The earlier [UI and LinuxKMS review](UI_REVIEW.md) is a historical record of those
+separate checks, not evidence that they were repeated here.

--- a/slint-ui/README.md
+++ b/slint-ui/README.md
@@ -19,8 +19,10 @@ checks for clipping and accessibility, not the main design reference.
 Omit `SLINT_BACKEND=headless` to interact in a desktop window. To reproduce a
 1920×1080 display with a 200% UI scale, use `--preview-size 1920x1080 --ui-scale 2`.
 
-Preview scenes: `welcome`, `offline`, `disk`, `new-pool`, `existing-pool`, `zfs`,
-`system`, `users`, `desktop`, `review`, `install`, `done`, `failed`, `cancelled`,
+Preview scenes: `welcome`, `offline`, `no-uefi`, `zfs-preparing`, `zfs-failed`,
+`wifi-empty`, `wifi-unavailable`, `wifi-no-internet`, `wifi-verifying`,
+`disk`, `new-pool`, `existing-pool`, `zfs`, `system`, `users`, `desktop`, `review`,
+`install`, `done`, `failed`, `cancelling`, `cancelled`,
 `inspect` (simulated pool import, export, and selection), and `invalid` (an
 incomplete configuration for validation checks).
 The three simulated drives include NVMe, SATA, and removable USB, with long serials
@@ -46,7 +48,7 @@ The output contains PNG screenshots, JSON element trees, process logs, and an
 establish that a layout is correct. Use `--scenes disk review` or
 `--sizes 1920x1080@1` to review only the primary configuration.
 
-Run repeatable interaction checks at Full HD with 100% and 200% scale and at 800×600:
+Run repeatable interaction checks at Full HD with 100% and 200% scale and at 1366×768:
 
 ```sh
 uv run slint-ui/scripts/interactions.py --output /tmp/azfs-ui-interactions
@@ -55,6 +57,20 @@ uv run slint-ui/scripts/interactions.py --output /tmp/azfs-ui-interactions
 These cover editing, focus recovery, keyboard scrolling, Wi-Fi credentials,
 forget/reconnect/disconnect, enterprise errors, pool inspection, installation
 progress, completion, and cancellation. All input values are disposable fixtures.
+
+Review the remaining editor decisions and their error/empty states at the same three configurations:
+
+```sh
+uv run slint-ui/scripts/design_review.py --output /tmp/azfs-design-review
+```
+
+This adds account validation without losing entered values, administrator controls,
+unsaved-account feedback, timezone city search, locale/keyboard filtering,
+optional packages, display manager and GPU choices, Wayland/console profiles,
+service removal, and repository/AUR package selection. These scripts drive real
+callbacks and save individual screenshots; their assertions supplement visual
+inspection rather than scoring the design. The review findings and boundaries
+are recorded in [Design review](DESIGN_REVIEW.md).
 
 Exercise the storage decision flow, including search, disabled partitions,
 cancel/confirm, keyboard focus, encryption, swap, pool selection, and Review:

--- a/slint-ui/README.md
+++ b/slint-ui/README.md
@@ -24,7 +24,8 @@ Preview scenes: `welcome`, `offline`, `disk`, `new-pool`, `existing-pool`, `zfs`
 `inspect` (simulated pool import, export, and selection), and `invalid` (an
 incomplete configuration for validation checks).
 The three simulated drives include NVMe, SATA, and removable USB, with long serials
-and persistent paths. Each drive has two simulated partitions. The wizard starts
+and persistent paths. The SATA drive has four partitions; NVMe and USB have two each. Filesystem, label,
+EFI type, and installer-media usage are included. The wizard starts
 with a configured user, KDE Plasma, packages, and services; edits remain interactive.
 Wi-Fi uses the existing mock backend, including known, secured, open, and enterprise
 networks. Installation advances through simulated phases and supports cancellation.
@@ -54,6 +55,26 @@ uv run slint-ui/scripts/interactions.py --output /tmp/azfs-ui-interactions
 These cover editing, focus recovery, keyboard scrolling, Wi-Fi credentials,
 forget/reconnect/disconnect, enterprise errors, pool inspection, installation
 progress, completion, and cancellation. All input values are disposable fixtures.
+
+Exercise the storage decision flow, including search, disabled partitions,
+cancel/confirm, keyboard focus, encryption, swap, pool selection, and Review:
+
+```sh
+uv run slint-ui/scripts/storage_review.py --output /tmp/azfs-storage-review
+uv run slint-ui/scripts/storage_review.py --size 1920x1080 --scale 1.5 \
+  --output /tmp/azfs-storage-review-scaled
+uv run slint-ui/scripts/storage_review.py --keyboard-only --size 1920x1080 --scale 2 \
+  --output /tmp/azfs-storage-keyboard
+AZFS_PREVIEW_STORAGE=many uv run slint-ui/scripts/storage_review.py \
+  --fixture many --output /tmp/azfs-storage-many
+```
+
+`AZFS_PREVIEW_STORAGE` accepts `empty` (no disks), `many` (20 partitions per disk),
+and `missing` (unknown filesystems and labels). Pass the matching `--fixture`
+argument to the storage script. These overrides only affect preview fixtures.
+Storage discovery in the production picker is read-only; choosing an existing
+pool does not import it. Space and dataset details for unimported pools remain
+unknown until installation imports them.
 
 For additional interaction checks, use Slint MCP's `get_element_tree`, `click_element`,
 `set_element_value`, and `dispatch_key_event`. Check password entry, Wi-Fi connect,

--- a/slint-ui/README.md
+++ b/slint-ui/README.md
@@ -72,6 +72,14 @@ SIGINT, SIGTERM, SIGHUP, and SIGQUIT to the GUI. Run this before starting any th
 The supervisor must remain alive for crash recovery; SIGKILL of both processes
 cannot run userspace cleanup.
 
+Slint is built from the `feat/linuxkms-integration` branch of the fork, with the
+exact revision recorded in `Cargo.lock`. This combines the independent Skia
+software, cursor damage, pointer input, and console isolation changes.
+
+When started from a VT, the installer enables tap-to-click for its GUI child.
+Set `SLINT_LIBINPUT_TAP_TO_CLICK=0` to disable it. Explicit values are preserved
+when returning from the post-install shell.
+
 Libinput uses neutral pointer acceleration by default. Override it with
 `SLINT_LIBINPUT_ACCEL_SPEED=0.3` (finite values from -1 to 1). Test the resulting
 feel on the target mouse or touchpad; headless rendering cannot validate it.

--- a/slint-ui/README.md
+++ b/slint-ui/README.md
@@ -1,12 +1,17 @@
 # Graphical installer development
 
+Follow [Slint coding and visual review](../docs/slint-ui-review.md) for design
+criteria, coverage, full-size screenshot inspection and implementation rules.
+This page is the executable preview/fixture reference; the
+[developer guide](../docs/development.md) covers production and VM workflows.
+
 Use the deterministic preview to review the installer without root, ZFS, disks,
 iwd, NetworkManager, or internet access. The preview uses the real components and
 editing controllers with simulated inventory and installation callbacks.
 
 ```sh
 SLINT_EMIT_DEBUG_INFO=1 cargo build -p archinstall-zfs-slint \
-  --no-default-features --features desktop-mock,slint/mcp
+  --no-default-features --features desktop-mock,slint/mcp --locked
 SLINT_BACKEND=headless SLINT_MCP_PORT=9315 target/debug/azfs \
   --preview welcome --preview-size 1920x1080 --ui-scale 1
 ```
@@ -31,6 +36,9 @@ EFI type, and installer-media usage are included. The wizard starts
 with a configured user, KDE Plasma, packages, and services; edits remain interactive.
 Wi-Fi uses the existing mock backend, including known, secured, open, and enterprise
 networks. Installation advances through simulated phases and supports cancellation.
+
+**The `desktop-mock` feature alone mocks only Wi-Fi; always pass `--preview` for
+UI review on the development host.**
 
 `--preview` is accepted only by a `desktop-mock` build and conflicts with `--config`,
 `--secrets`, `--silent`, and `--demo`. It replaces system probes, storage enumeration,
@@ -76,7 +84,7 @@ Exercise the storage decision flow, including search, disabled partitions,
 cancel/confirm, keyboard focus, encryption, swap, pool selection, and Review:
 
 ```sh
-uv run slint-ui/scripts/storage_review.py --output /tmp/azfs-storage-review
+uv run slint-ui/scripts/storage_review.py --size 1920x1080 --output /tmp/azfs-storage-review
 uv run slint-ui/scripts/storage_review.py --size 1920x1080 --scale 1.5 \
   --output /tmp/azfs-storage-review-scaled
 uv run slint-ui/scripts/storage_review.py --keyboard-only --size 1920x1080 --scale 2 \
@@ -87,7 +95,9 @@ AZFS_PREVIEW_STORAGE=many uv run slint-ui/scripts/storage_review.py \
 
 `AZFS_PREVIEW_STORAGE` accepts `empty` (no disks), `many` (20 partitions per disk),
 and `missing` (unknown filesystems and labels). Pass the matching `--fixture`
-argument to the storage script. These overrides only affect preview fixtures.
+argument to the storage script: the flag selects assertions, and the environment
+variable selects inventory data. These overrides only affect preview fixtures.
+The storage script defaults to 1366×768; specify Full HD for the primary review.
 Storage discovery in the production picker is read-only; choosing an existing
 pool does not import it. Space and dataset details for unimported pools remain
 unknown until installation imports them.

--- a/slint-ui/UI_REVIEW.md
+++ b/slint-ui/UI_REVIEW.md
@@ -1,8 +1,9 @@
 # UI and LinuxKMS review — 2026-09-09
 
 This is the historical first pass, before the later storage and editor redesigns.
-For the subsequent design findings, current coverage, and validation boundaries,
-see [Design review](DESIGN_REVIEW.md).
+For the subsequent design findings and their validation boundaries, see
+[Design review](DESIGN_REVIEW.md). For the current process and display matrix,
+see [Slint coding and visual review](../docs/slint-ui-review.md).
 
 The original LinuxKMS build reproduced the reported console input leak in an
 UEFI QEMU guest: text entered while the GUI was running became a shell command
@@ -37,7 +38,8 @@ The installer changes address:
 - Password-strength scoring moved off the UI thread, with debouncing and stale
   result checks after editing, clearing, and reopening dialogs.
 
-`scripts/review.py` captures the actual Slint components for all preview scenes
+At the time of this pass, `scripts/review.py` captured the actual Slint components
+for all preview scenes
 at 800×600 and 1280×800 with scale 1, and 1920×1080 with scales 1.5 and 2.
 Window metadata is saved and the actual scale is asserted: the headless backend
 requires an explicit scale-change event, unlike desktop backends.

--- a/slint-ui/UI_REVIEW.md
+++ b/slint-ui/UI_REVIEW.md
@@ -1,5 +1,9 @@
 # UI and LinuxKMS review — 2026-09-09
 
+This is the historical first pass, before the later storage and editor redesigns.
+For the subsequent design findings, current coverage, and validation boundaries,
+see [Design review](DESIGN_REVIEW.md).
+
 The original LinuxKMS build reproduced the reported console input leak in an
 UEFI QEMU guest: text entered while the GUI was running became a shell command
 after the GUI closed. A disposable marker-file command was used, never a real

--- a/slint-ui/scripts/design_review.py
+++ b/slint-ui/scripts/design_review.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env -S uv run
+"""Additional design-review scenarios for editor decisions, empty states and errors.
+
+Uses the real Slint callbacks with desktop-mock fixtures. No installation is run.
+"""
+import argparse
+from pathlib import Path
+
+from review import Preview
+from interactions import reveal_by_tab
+
+
+def click_setting(p, name):
+    reveal_by_tab(p, 'Button', name)
+    p.click('Button', name)
+
+
+def choice(p, label):
+    for _ in range(100):
+        e = p.element('ListItem', label)
+        groups = [e for e in p.tree()['elements'] if e.get('accessibleRole') == 'Groupbox']
+        panel = groups[-1]
+        if e and e['absolutePosition']['y'] >= panel['absolutePosition']['y'] + 55 and e['absolutePosition']['y'] + e['size']['height'] <= panel['absolutePosition']['y'] + panel['size']['height'] - 60:
+            p.click('ListItem', label)
+            return
+        p.key('\uf701')
+    raise AssertionError(f'Could not reach choice {label}')
+
+
+def accounts(p):
+    p.click('Button', 'User accounts')
+    p.click('Checkbox', 'Administrator alex')
+    assert not p.element('Checkbox', 'Administrator alex').get('accessibleChecked', False)
+    p.click('Checkbox', 'Administrator alex')
+    assert p.element('Checkbox', 'Administrator alex').get('accessibleChecked', False)
+    p.fill(0, 'Bad Name')
+    p.fill(1, 'preview passphrase only')
+    p.click('Button', 'Add user')
+    p.wait('Text', 'Use up to 32')
+    assert p.element('TextInput', 'Username').get('accessibleValue') == 'Bad Name'
+    p.screenshot('invalid-username-preserved')
+    p.fill(0, 'alex')
+    p.click('Button', 'Add user')
+    p.wait('Text', 'This username is already')
+    p.screenshot('duplicate-username')
+    p.fill(0, 'newuser')
+    p.click('Button', 'Done')
+    p.wait('Text', 'Click Add user')
+    p.click('Button', 'Add user')
+    p.wait('Button', 'Remove user newuser')
+    p.screenshot('account-added')
+    # Reopen to inspect and edit the saved account list at the top of the scroll view.
+    p.click('Button', 'Done')
+    p.click('Button', 'User accounts')
+    p.click('Button', 'Remove user alex')
+    p.click('Button', 'Remove user newuser')
+    p.wait('Text', 'No user accounts yet')
+    p.screenshot('empty-account-list')
+    p.key('\u001b')
+    assert p.element('Groupbox', 'User accounts') is None
+
+
+def system(p):
+    click_setting(p, 'Distribution')
+    p.screenshot('distributions')
+    p.click('Button', 'Cancel')
+    click_setting(p, 'Timezone')
+    p.screenshot('timezone-region')
+    choice(p, 'Europe')
+    p.fill(0, 'Mosc')
+    p.wait('ListItem', 'Moscow')
+    p.screenshot('timezone-city')
+    choice(p, 'Moscow')
+    p.wait('Text', 'Europe/Moscow')
+    click_setting(p, 'Keyboard layout')
+    p.fill(0, 'ru')
+    p.screenshot('keyboard-filter')
+    p.key('\u001b')
+    assert p.element('Groupbox', 'Keyboard layout') is None
+    click_setting(p, 'Locale')
+    p.fill(0, 'does-not-exist-zzzzz')
+    p.wait('Text', 'No matching choices')
+    p.screenshot('empty-locale-search')
+    p.key('\u001b')
+    assert p.element('Groupbox', 'Locale') is None
+    click_setting(p, 'Parallel downloads')
+    p.screenshot('download-concurrency')
+    p.key('\u001b')
+    p.screenshot('system')
+
+
+def desktop(p):
+    click_setting(p, 'Optional packages')
+    p.click('Checkbox', 'flatpak')
+    assert p.element('Checkbox', 'flatpak').get('accessibleChecked', False)
+    p.screenshot('optional-package-selected')
+    p.click('Button', 'Done')
+    click_setting(p, 'Display manager')
+    p.screenshot('display-managers')
+    p.click('Button', 'Cancel')
+    click_setting(p, 'GPU driver')
+    p.screenshot('gpu-drivers')
+    p.click('Button', 'Cancel')
+    click_setting(p, 'Profile')
+    choice(p, 'Sway')
+    p.screenshot('wayland-profile')
+    reveal_by_tab(p, 'Combobox', 'Seat access')
+    p.click('Combobox', 'Seat access')
+    p.screenshot('seat-access-choices')
+    p.key('\u001b')
+    click_setting(p, 'Profile')
+    choice(p, 'Console only')
+    assert p.element('Button', 'GPU driver') is None
+    assert p.element('Button', 'Display manager') is None
+    p.screenshot('console-profile')
+    click_setting(p, 'Extra services')
+    p.click('Button', 'Remove service sshd')
+    p.wait('Text', 'No extra services selected')
+    p.screenshot('empty-services')
+    p.key('\u001b')
+    click_setting(p, 'Extra packages')
+    p.fill(0, 'no-such-package-zzzzz')
+    p.wait('Text', 'No matching packages')
+    p.screenshot('empty-package-search')
+    p.fill(0, 'visual')
+    p.click('Button', 'Search AUR')
+    p.wait('Button', 'Add package visual-studio-code-bin')
+    p.screenshot('aur-search')
+    p.click('Button', 'Add package visual-studio-code-bin')
+    # Remove the first entries to bring the newly added package into view.
+    for name in ['firefox', 'git', 'htop', 'visual-studio-code-bin']:
+        p.click('Button', 'Remove package ' + name)
+    p.wait('Text', 'No extra packages selected')
+    p.screenshot('empty-selected-packages')
+    p.fill(0, 'fire')
+    p.click('Button', 'Add package firefox')
+    p.wait('Button', 'Remove package firefox')
+    assert p.element('TextInput', 'Search packages').get('accessibleValue', '') == ''
+    p.screenshot('package-added')
+    p.click('Button', 'Done')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--sizes', nargs='+', default=['1920x1080@1', '1366x768@1', '1920x1080@2'])
+    parser.add_argument('--flows', nargs='+', choices=['accounts', 'system', 'desktop'], default=['accounts', 'system', 'desktop'])
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    for spec in args.sizes:
+        size, scale = spec.split('@')
+        for flow in args.flows:
+            output = args.output / spec / flow
+            output.mkdir(parents=True, exist_ok=True)
+            p = Preview(Path('target/debug/azfs').resolve(), 'users' if flow == 'accounts' else flow, size, scale, output)
+            try:
+                p.ready()
+                globals()[flow](p)
+                print(f'PASS {spec} {flow}', flush=True)
+            except Exception:
+                p.screenshot('failure')
+                raise
+            finally:
+                p.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/slint-ui/scripts/interactions.py
+++ b/slint-ui/scripts/interactions.py
@@ -200,8 +200,8 @@ def installation_layout(p):
 
 
 def invalid(p):
-    p.click('Button', 'Install')
-    p.wait('Text', 'Validation:')
+    assert not p.data('get_element_properties', elementHandle=p.wait('Button', 'Install')['handle']).get('accessibleEnabled', False)
+    p.wait('Text', 'Complete setup before installing')
     assert p.element('Button', 'Cancel installation') is None
     p.screenshot('validation-blocks-installation')
 

--- a/slint-ui/scripts/interactions.py
+++ b/slint-ui/scripts/interactions.py
@@ -7,14 +7,25 @@ import time
 from review import Preview
 
 
+def reveal_by_tab(p, role, label):
+    """Navigate real focusable controls so an offscreen target scrolls into view."""
+    for _ in range(50):
+        e = p.element(role, label)
+        if e and 100 <= e['absolutePosition']['y'] and e['absolutePosition']['y'] + e['size']['height'] < p.size[1] / p.scale - 70:
+            return
+        p.key('\t')
+    raise AssertionError(f'Cannot reach {label} by Tab')
+
+
 def system(p):
     p.click('Button', 'Hostname')
     p.fill(0, 'arch-workstation-long-name')
     p.screenshot('hostname')
-    p.click('Button', 'OK')
+    p.click('Button', 'Save')
     p.click('Button', 'Kernel')
     p.screenshot('kernel')
     p.click('ListItem', 'linux — compatible')
+    reveal_by_tab(p, 'Button', 'Locale')
     p.click('Button', 'Locale')
     p.fill(0, 'ru_RU')
     p.screenshot('locale-filter')
@@ -54,14 +65,14 @@ def desktop(p):
     p.click('Button', 'Optional packages')
     p.screenshot('optional-packages')
     p.click('Button', 'Done')
-    for _ in range(9):
-        p.key('j')
+    reveal_by_tab(p, 'Button', 'Extra packages')
     p.screenshot('desktop-scrolled')
     p.click('Button', 'Extra packages')
     p.fill(0, 'fire')
     p.wait('Text', 'firefox')
     p.screenshot('packages')
     p.click('Button', 'Done')
+    reveal_by_tab(p, 'Button', 'Extra services')
     p.click('Button', 'Extra services')
     p.fill(0, 'cups')
     p.click('Button', 'Add')
@@ -210,7 +221,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--binary', type=Path, default=Path('target/debug/azfs'))
     parser.add_argument('--output', type=Path, required=True)
-    parser.add_argument('--sizes', nargs='+', default=['1920x1080@1', '800x600@1', '1920x1080@2'])
+    parser.add_argument('--sizes', nargs='+', default=['1920x1080@1', '1366x768@1', '1920x1080@2'])
     flows = ['system', 'users', 'desktop', 'wifi', 'inspect', 'install', 'cancel', 'shell', 'logs', 'invalid']
     parser.add_argument('--flows', nargs='+', choices=flows, default=flows)
     args = parser.parse_args()

--- a/slint-ui/scripts/interactions.py
+++ b/slint-ui/scripts/interactions.py
@@ -82,7 +82,8 @@ def desktop(p):
 
 
 def wifi(p):
-    p.click('Button', 'Network settings')
+    p.screenshot('welcome-offline')
+    p.click('Button', 'Wi-Fi & network')
     p.wait('ListItem', 'HomeNetwork')
     p.screenshot('wifi-picking')
     p.click('Button', 'Forget HomeNetwork')
@@ -103,7 +104,8 @@ def wifi(p):
     p.screenshot('wifi-connected')
     p.click('Button', 'Done')
     assert p.element('Groupbox', 'Network management') is None
-    p.click('Button', 'Network settings')
+    p.screenshot('welcome-connected')
+    p.click('Button', 'Wi-Fi & network')
     p.wait('Button', 'Disconnect')
     p.screenshot('wifi-management')
     p.click('Button', 'Disconnect')

--- a/slint-ui/scripts/review.py
+++ b/slint-ui/scripts/review.py
@@ -16,7 +16,7 @@ import time
 import urllib.error
 import urllib.request
 
-SCENES = 'welcome offline disk new-pool existing-pool zfs system users desktop review install done failed cancelled inspect invalid'.split()
+SCENES = 'welcome offline no-uefi zfs-preparing zfs-failed wifi-empty wifi-unavailable wifi-no-internet wifi-verifying cancelling disk new-pool existing-pool zfs system users desktop review install done failed cancelled inspect invalid'.split()
 
 class Preview:
     def __init__(self, binary, scene, size, scale, output):
@@ -108,7 +108,7 @@ def main():
     parser.add_argument('--binary', type=Path, default=Path('target/debug/azfs'))
     parser.add_argument('--output', type=Path, required=True)
     parser.add_argument('--scenes', nargs='+', choices=SCENES, default=SCENES)
-    parser.add_argument('--sizes', nargs='+', default=['1920x1080@1', '800x600@1', '1280x800@1', '1920x1080@1.5', '1920x1080@2'])
+    parser.add_argument('--sizes', nargs='+', default=['1920x1080@1', '1366x768@1', '1280x800@1', '1920x1080@1.5', '1920x1080@2'])
     args = parser.parse_args()
     args.output.mkdir(parents=True, exist_ok=True)
     labels = []

--- a/slint-ui/scripts/storage_review.py
+++ b/slint-ui/scripts/storage_review.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env -S uv run
+"""Exercise storage decisions through the actual preview UI; never installs.
+
+Build desktop-mock,slint/mcp with SLINT_EMIT_DEBUG_INFO=1 first.
+AZFS_PREVIEW_STORAGE=empty|many|missing adds discovery edge cases (preview only).
+"""
+import argparse
+from pathlib import Path
+from review import Preview
+
+
+def properties(p, role, label):
+    return p.data("get_element_properties", elementHandle=p.wait(role, label)["handle"])
+
+
+def fill(p, label, value):
+    p.data("set_element_value", elementHandle=p.wait("TextInput", label)["handle"], value=value)
+
+
+def select(p, label, option):
+    p.click('Combobox', label)
+    p.click('ListItem', option)
+
+
+def assign(p, label, device):
+    p.click('Button', label)
+    fill(p, 'Search storage', device)
+    p.click('ListItem', device)
+    p.click('Button', 'Use this device')
+
+
+def storage(p):
+    p.click('Button', 'Change New ZFS pool')
+    p.wait('ListItem', '/dev/nvme0n1p2')
+    p.screenshot('partition-picker')
+    fill(p, 'Search storage', '/dev/sdb')
+    p.wait('ListItem', '/dev/sdb1')
+    assert properties(p, 'ListItem', '/dev/sdb1').get('accessibleEnabled', False) is False
+    p.screenshot('installer-media-unavailable')
+    fill(p, 'Search storage', '/dev/nvme0n1p1')
+    p.wait('ListItem', '/dev/nvme0n1p1')
+    assert properties(p, 'ListItem', '/dev/nvme0n1p1').get('accessibleEnabled', False) is False
+    p.screenshot('efi-role-unavailable')
+    fill(p, 'Search storage', '/dev/sda4')
+    p.click('ListItem', '/dev/sda4')
+    p.click('Button', 'Details')
+    p.screenshot('selected-partition-details')
+    p.click('Button', 'Use this device')
+    p.wait('Text', '/dev/sda4')
+    p.screenshot('new-pool-assigned')
+    p.click('Button', 'Change EFI boot partition')
+    fill(p, 'Search storage', '/dev/sda4')
+    p.wait('ListItem', '/dev/sda4')
+    assert properties(p, 'ListItem', '/dev/sda4').get('accessibleEnabled', False) is False
+    p.key('\u001b')
+    p.wait('Button', 'Change EFI boot partition')
+    p.screenshot('cancel-preserves-selection')
+    p.click('Button', 'ZFS')
+    p.click('TextInput', 'New pool name')
+    p.key('\t')
+    p.key('reviewbe')
+    assert properties(p, 'TextInput', 'Boot environment')['accessibleValue'] == 'reviewbe'
+    p.wait('Text', '2 / 6')  # Tab moves through fields, not wizard steps.
+    select(p, 'Encryption', 'Encrypt base dataset only')
+    p.click('TextInput', 'Encryption passphrase')
+    fill(p, 'Encryption passphrase', 'a preview passphrase 123 qjk')
+    p.key('\t')
+    select(p, 'Swap method', 'Swap partition (encrypted)')
+    p.key('\t')
+    assign(p, 'Choose Swap partition', '/dev/sda2')
+    p.screenshot('zfs-encryption-swap')
+    p.key('\t')
+    p.click('Button', 'Additional settings')
+    p.screenshot('zfs-additional-settings')
+    p.click('Button', 'Review')
+    p.wait('Text', 'Storage changes during installation')
+    assert properties(p, 'Button', 'Install').get('accessibleEnabled', False) is True
+    p.screenshot('new-pool-review')
+    p.click('Button', 'Edit ZFS')
+    p.wait('Text', '2 / 6')
+    p.click('Button', 'Disk')
+    p.click('RadioButton', 'Use an existing pool')
+    p.wait('Button', 'Choose Existing ZFS pool')
+    p.screenshot('existing-pool-empty')
+    p.click('Button', 'Choose Existing ZFS pool')
+    p.wait('ListItem', 'zroot')
+    p.screenshot('pool-picker')
+    p.click('ListItem', 'zroot')
+    p.click('Button', 'Use this pool')
+    assign(p, 'Choose EFI boot partition', '/dev/nvme0n1p1')
+    p.click('Button', 'ZFS')
+    p.click('TextInput', 'Boot environment')
+    p.key('\t'); p.key('\t'); p.key('\t')
+    select(p, 'Swap method', 'None')
+    fill(p, 'Boot environment', 'previous')  # Existing mode has one inline name: the environment.
+    p.click('Button', 'Review')
+    assert properties(p, 'Button', 'Install').get('accessibleEnabled', False) is False
+    p.screenshot('existing-environment-conflict')
+    p.click('Button', 'Edit ZFS')
+    fill(p, 'Boot environment', 'freshbe')
+    p.click('Button', 'Review')
+    assert properties(p, 'Button', 'Install').get('accessibleEnabled', False) is True
+    p.screenshot('existing-pool-review')
+    p.click('Button', 'Disk')
+    p.click('RadioButton', 'Erase a disk')
+    p.click('Button', 'Choose Disk to erase')
+    p.wait('ListItem', '/dev/sdb')
+    assert not properties(p, 'ListItem', '/dev/sdb').get('accessibleEnabled', False)
+    p.screenshot('disk-picker')
+    fill(p, 'Search storage', '/dev/sda')
+    p.click('ListItem', '/dev/sda')
+    p.click('Button', 'Details')
+    p.screenshot('disk-details')
+    p.click('Button', 'Use this device')
+    p.wait('Text', '/dev/sda')
+    p.screenshot('full-disk-assigned')
+    p.click('Button', 'ZFS')
+    fill(p, 'New pool name', 'newroot')
+    p.click('Button', 'Review')
+    assert properties(p, 'Button', 'Install').get('accessibleEnabled', False) is True
+    p.screenshot('full-disk-review')
+
+
+def keyboard(p):
+    p.click('Button', 'Change EFI boot partition')
+    fill(p, 'Search storage', '/dev/sda1')
+    p.click('ListItem', '/dev/sda1')
+    p.click('TextInput', 'Search storage')
+    for _ in range(6):
+        p.key('\t')
+    p.key('no-match')
+    assert 'no-match' in properties(p, 'TextInput', 'Search storage')['accessibleValue']
+    p.wait('Text', 'No matches.')
+    p.key('\u001b')
+    p.key('\t')
+    p.key('\n')  # Cancel returns to EFI; Tab reaches the ZFS assignment below it.
+    p.wait('Text', 'Choose a ZFS partition')
+    fill(p, 'Search storage', '/dev/sda4')
+    p.key('\t'); p.key('\t')  # Focus the list, then select by arrows.
+    p.key('\uf701')
+    p.wait('Text', 'Selected: /dev/sda4')
+    p.screenshot('keyboard-picker')
+    p.key('\n')
+    p.wait('Text', '/dev/sda4')
+    p.screenshot('keyboard-assigned')
+
+
+def edge(p, fixture):
+    p.click('Button', 'Choose New ZFS pool' if fixture == 'empty' else 'Change New ZFS pool')
+    if fixture == 'empty':
+        p.wait('Text', 'No devices found.')
+        assert properties(p, 'Button', 'Use this device').get('accessibleEnabled', False) is False
+    elif fixture == 'many':
+        fill(p, 'Search storage', '/dev/sda20')
+        p.click('ListItem', '/dev/sda20')
+        p.click('Button', 'Use this device')
+        p.wait('Text', '/dev/sda20')
+    else:
+        fill(p, 'Search storage', '/dev/sda4')
+        p.wait('ListItem', '/dev/sda4')
+    p.screenshot('fixture-' + fixture)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--size', default='1366x768')
+    parser.add_argument('--scale', default='1')
+    parser.add_argument('--keyboard-only', action='store_true')
+    parser.add_argument('--fixture', choices=['empty', 'many', 'missing'])
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    p = Preview(Path('target/debug/azfs').resolve(), 'new-pool', args.size, args.scale, args.output)
+    try:
+        p.ready()
+        if args.keyboard_only:
+            keyboard(p)
+        elif args.fixture:
+            edge(p, args.fixture)
+        else:
+            storage(p)
+        print('Storage UI flow passed', flush=True)
+    except Exception:
+        p.screenshot('failure')
+        raise
+    finally:
+        p.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -32,6 +32,26 @@ pub fn build_step_items(step: usize, c: &GlobalConfig) -> Vec<ConfigItem> {
         6 => build_review_items(c),
         _ => vec![],
     };
+    if step != 6 {
+        for item in &mut items {
+            let description = match item.key.as_str() {
+                "root_password" => {
+                    "Controls direct login as root. A regular administrator account can use sudo instead."
+                }
+                "users" => {
+                    "Create a daily-use account and choose who can run administrator commands with sudo."
+                }
+                "profile" => {
+                    "Choose a desktop environment, a window manager, or a console-only system."
+                }
+                "display_manager" => {
+                    "The graphical sign-in screen. The profile default is used unless you override it."
+                }
+                _ => continue,
+            };
+            item.description = description.into();
+        }
+    }
     mark_section_boundaries(&mut items);
     items
 }
@@ -285,7 +305,7 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 
 fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     vec![
-        section_header("System"),
+        section_header("Base system"),
         // Before the kernel row on purpose: which kernels exist is the
         // distribution's answer, so choosing one first is the order that makes
         // sense on screen.
@@ -321,7 +341,7 @@ fn build_system_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             &c.parallel_downloads.to_string(),
             ItemType::Text,
         ),
-        section_header("Locale"),
+        section_header("Language and region"),
         ci_opt("locale", "Locale", c.locale.as_deref(), ItemType::Select),
         ci_opt(
             EditorSetting::Timezone.as_str(),
@@ -385,11 +405,14 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 
     let profile_name = profile_def.as_ref().map(|p| p.display_name.to_string());
     let mut items = vec![
-        section_header("Desktop"),
+        section_header("Environment"),
         ConfigItem {
             key: "profile".into(),
             label: "Profile".into(),
-            value: profile_name.clone().unwrap_or_else(|| "None".into()).into(),
+            value: profile_name
+                .clone()
+                .unwrap_or_else(|| "Console only".into())
+                .into(),
             item_type: ItemType::Select,
             is_empty: profile_name.is_none(),
             ..Default::default()
@@ -434,23 +457,23 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             ..Default::default()
         });
 
-        // Seat access (Wayland compositors). Its own section card via
-        // radio_group, like Audio.
+        // Seat access is only relevant to Wayland compositor profiles.
         if p.needs_seat_access() {
-            items.extend(choice_group_with_off(
+            items.push(compact_choice(
                 ChoiceSetting::SeatAccess,
                 "Seat access",
                 sel.seat_access,
-                None,
+                "How the compositor accesses input and display devices.",
             ));
         }
     }
 
-    items.extend(choice_group_with_off(
+    items.push(section_header("Sound"));
+    items.push(compact_choice(
         ChoiceSetting::Audio,
         "Audio",
         c.audio,
-        None,
+        "Choose the sound server installed with the system.",
     ));
 
     items.push(section_header("Hardware"));
@@ -743,66 +766,6 @@ fn section_header(label: &str) -> ConfigItem {
         item_type: ItemType::SectionHeader,
         ..Default::default()
     }
-}
-
-/// [`choice_group`] for lists with a semantic "off" alternative, named by
-/// value rather than by index.
-fn choice_group_with_off<T: Choice>(
-    setting: ChoiceSetting,
-    label: &str,
-    current: T,
-    off: T,
-) -> Vec<ConfigItem> {
-    radio_group_with_off(
-        setting.as_str(),
-        label,
-        &T::labels(),
-        current.index() as i32,
-        off.index(),
-    )
-}
-
-/// Variant of [`radio_group`] that marks one option as the semantic "off"
-/// state (e.g. compression "off", audio "None"). The off row's `is_empty`
-/// flag is propagated to the review screen's collapsed Readonly row when
-/// it's the selected option, so it renders muted instead of green.
-fn radio_group_with_off(
-    key: &str,
-    label: &str,
-    options: &[&str],
-    selected: i32,
-    off_index: usize,
-) -> Vec<ConfigItem> {
-    radio_group_inner(key, label, options, selected, Some(off_index))
-}
-
-fn radio_group_inner(
-    key: &str,
-    label: &str,
-    options: &[&str],
-    selected: i32,
-    off_index: Option<usize>,
-) -> Vec<ConfigItem> {
-    let mut items = vec![ConfigItem {
-        label: label.into(),
-        item_type: ItemType::RadioHeader,
-        ..Default::default()
-    }];
-    for (i, opt) in options.iter().enumerate() {
-        items.push(ConfigItem {
-            key: format!("radio:{key}:{i}").into(),
-            label: (*opt).into(),
-            value: if i as i32 == selected {
-                "selected".into()
-            } else {
-                SharedString::default()
-            },
-            item_type: ItemType::RadioOption,
-            is_empty: off_index == Some(i),
-            ..Default::default()
-        });
-    }
-    items
 }
 
 fn mark_section_boundaries(items: &mut [ConfigItem]) {

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -2,81 +2,22 @@
 //! coming back from radio/select/text widgets to the canonical `GlobalConfig`.
 
 use slint::SharedString;
-use std::path::PathBuf;
 
 use archinstall_zfs_core::config::choices::Choice;
-use archinstall_zfs_core::config::edit::{
-    ChoiceSetting, DeviceSetting, EditorSetting, TextSetting,
-};
+use archinstall_zfs_core::config::edit::{ChoiceSetting, EditorSetting, TextSetting};
 use archinstall_zfs_core::config::types::{
-    CompressionAlgo, GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode,
+    GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode,
 };
-use archinstall_zfs_core::disk::device::DeviceChoice;
 
 use crate::ui::{ConfigItem, ItemType};
+#[cfg(test)]
+use archinstall_zfs_core::config::edit::DeviceSetting;
 
 pub const TOTAL_STEPS: usize = 7;
 
 pub const STEP_LABELS: [&str; TOTAL_STEPS] = [
     "Welcome", "Disk", "ZFS", "System", "Users", "Desktop", "Review",
 ];
-
-#[derive(Debug, Clone)]
-struct ChoiceRow {
-    path: PathBuf,
-    label: String,
-    icon: String,
-    model: String,
-    serial: String,
-    size: String,
-    transport: String,
-    media: String,
-    removable: bool,
-    persistent_path: String,
-    persistent_kind: String,
-    group_label: String,
-    group_model: String,
-    group_serial: String,
-    group_size: String,
-    group_transport: String,
-    group_media: String,
-    group_removable: bool,
-}
-
-impl From<DeviceChoice> for ChoiceRow {
-    fn from(choice: DeviceChoice) -> Self {
-        Self {
-            path: choice.path,
-            label: choice.label,
-            icon: choice.icon,
-            model: choice.model,
-            serial: choice.serial,
-            size: choice.size,
-            transport: choice.transport,
-            media: choice.media,
-            removable: choice.removable,
-            persistent_path: choice.persistent_path,
-            persistent_kind: choice.persistent_kind,
-            group_label: choice.group_label,
-            group_model: choice.group_model,
-            group_serial: choice.group_serial,
-            group_size: choice.group_size,
-            group_transport: choice.group_transport,
-            group_media: choice.group_media,
-            group_removable: choice.group_removable,
-        }
-    }
-}
-
-impl ChoiceRow {
-    fn group_key(&self) -> &str {
-        if self.group_label.is_empty() {
-            self.label.as_str()
-        } else {
-            self.group_label.as_str()
-        }
-    }
-}
 
 // ── Per-step item building ──────────────────────────
 
@@ -101,161 +42,244 @@ fn build_welcome_items(_c: &GlobalConfig) -> Vec<ConfigItem> {
 }
 
 fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
-    let mode = c.installation_mode;
-
-    let mut items = choice_group(
-        ChoiceSetting::InstallationMode,
-        "Installation mode",
-        mode.unwrap_or(InstallationMode::FullDisk),
-    );
-    for (row, description) in items
-        .iter_mut()
-        .filter(|row| row.item_type == ItemType::RadioOption)
-        .zip([
-            "Erase the selected disk and create a ZFS root pool",
-            "Create a ZFS pool using existing partitions",
-            "Install into an existing ZFS pool",
-        ])
-    {
-        row.description = description.into();
-    }
-
-    if matches!(mode, Some(InstallationMode::FullDisk) | None) {
-        let disks = disk_choices();
-        let selected = c
-            .disk
-            .as_ref()
-            .and_then(|sel| disks.iter().position(|choice| &choice.path == sel))
-            .map(|i| i as i32)
-            .unwrap_or(-1);
-        items.extend(radio_choice_group(
-            DeviceSetting::Disk,
-            "Disk",
-            &disks,
-            selected,
-        ));
-    }
-
-    if matches!(
-        mode,
-        Some(InstallationMode::NewPool) | Some(InstallationMode::ExistingPool)
-    ) {
-        let parts = partition_choices();
-
-        let efi_selected = c
-            .efi_partition
-            .as_ref()
-            .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
-            .map(|i| i as i32)
-            .unwrap_or(-1);
-        items.extend(radio_partition_choice_group(
-            DeviceSetting::EfiPartition,
-            "EFI partition",
-            &parts,
-            efi_selected,
-        ));
-
-        if matches!(mode, Some(InstallationMode::NewPool)) {
-            let zfs_selected = c
-                .zfs_partition
-                .as_ref()
-                .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
-                .map(|i| i as i32)
-                .unwrap_or(-1);
-            items.extend(radio_partition_choice_group(
-                DeviceSetting::ZfsPartition,
-                "ZFS partition",
-                &parts,
-                zfs_selected,
-            ));
+    let mut items = vec![section_header("Storage assignments")];
+    match c.installation_mode {
+        Some(InstallationMode::FullDisk) => {
+            items.push(storage_item("disk", "Disk to erase", c.disk.as_deref(), c))
         }
+        Some(InstallationMode::NewPool) | Some(InstallationMode::ExistingPool) => {
+            if c.installation_mode == Some(InstallationMode::ExistingPool) {
+                items.push(ConfigItem {
+                    key: "storage:pool".into(),
+                    label: "Existing ZFS pool".into(),
+                    value: c.pool_name.as_deref().unwrap_or("Choose a pool").into(),
+                    description: "Create a new boot environment in this pool".into(),
+                    item_type: ItemType::Storage,
+                    is_empty: c.pool_name.is_none(),
+                    ..Default::default()
+                });
+            }
+            items.push(storage_item(
+                "efi_partition",
+                "EFI boot partition",
+                c.efi_partition.as_deref(),
+                c,
+            ));
+            if c.installation_mode == Some(InstallationMode::NewPool) {
+                items.push(storage_item(
+                    "zfs_partition",
+                    "New ZFS pool",
+                    c.zfs_partition.as_deref(),
+                    c,
+                ));
+            }
+        }
+        None => {}
     }
-
     items
 }
 
+fn storage_item(
+    role: &str,
+    label: &str,
+    selected: Option<&std::path::Path>,
+    c: &GlobalConfig,
+) -> ConfigItem {
+    let choices = crate::storage::choices(role);
+    let choice = selected.and_then(|p| choices.iter().find(|d| d.path == p));
+    let consequence = match role {
+        "disk"
+            if matches!(
+                c.swap_mode,
+                SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+            ) =>
+        {
+            "Erase all partitions; create EFI, ZFS and swap partitions"
+        }
+        "disk" => "Erase all partitions; create EFI and ZFS partitions",
+        "efi_partition" => "Reuse filesystem; write bootloader files",
+        "zfs_partition" => "Replace this partition's contents with a new ZFS pool",
+        _ => "Replace this partition's contents with swap",
+    };
+    let mut item = ConfigItem {
+        key: format!("storage:{role}").into(),
+        label: label.into(),
+        value: choice
+            .map(|d| d.label.clone())
+            .or_else(|| selected.map(|p| p.display().to_string()))
+            .unwrap_or_else(|| "Choose a device".into())
+            .into(),
+        description: consequence.into(),
+        destructive: role != "efi_partition",
+        item_type: ItemType::Storage,
+        is_empty: selected.is_none(),
+        ..Default::default()
+    };
+    if let Some(d) = choice {
+        item.detail_model = format!("{}  {}  {}", d.model, d.usage.filesystem, d.usage.label)
+            .trim()
+            .into();
+        item.detail_size = d.size.clone().into();
+        item.persistent_path = d.path.display().to_string().into();
+        let blocked = crate::storage::unavailable(d, role, c);
+        if !blocked.is_empty() {
+            item.description = format!("Unavailable: {blocked}").into();
+            item.destructive = true;
+        }
+    }
+    item
+}
+
+fn inline_text(key: TextSetting, label: &str, value: &str, description: &str) -> ConfigItem {
+    ConfigItem {
+        key: key.as_str().into(),
+        label: label.into(),
+        value: value.into(),
+        description: description.into(),
+        item_type: ItemType::InlineText,
+        ..Default::default()
+    }
+}
+fn compact_choice<T: Choice>(
+    key: ChoiceSetting,
+    label: &str,
+    current: T,
+    description: &str,
+) -> ConfigItem {
+    ConfigItem {
+        key: key.as_str().into(),
+        label: label.into(),
+        value: T::labels()[current.index()].into(),
+        choices: slint::ModelRc::new(slint::VecModel::from(
+            T::labels()
+                .into_iter()
+                .map(SharedString::from)
+                .collect::<Vec<_>>(),
+        )),
+        choice_index: current.index() as i32,
+        description: description.into(),
+        item_type: ItemType::CompactChoice,
+        ..Default::default()
+    }
+}
 fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
-    let mode = c.installation_mode;
-    let has_swap_partition = matches!(
-        c.swap_mode,
-        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-    );
-
-    let mut items = vec![
-        section_header("Pool"),
-        ci_opt(
-            TextSetting::PoolName.as_str(),
-            "Pool name",
-            c.pool_name.as_deref(),
-            ItemType::Text,
+    let mut items = vec![section_header("Pool and boot environment")];
+    if c.installation_mode == Some(InstallationMode::ExistingPool) {
+        items.push(ConfigItem {
+            key: "storage:pool".into(),
+            label: "Existing pool".into(),
+            value: c.pool_name.as_deref().unwrap_or("Choose a pool").into(),
+            description: "Select the existing pool; its name will not be changed".into(),
+            is_empty: c.pool_name.is_none(),
+            item_type: ItemType::Storage,
+            ..Default::default()
+        });
+    } else {
+        items.push(inline_text(
+            TextSetting::PoolName,
+            "New pool name",
+            c.pool_name.as_deref().unwrap_or(""),
+            "",
+        ));
+    }
+    items.push(inline_text(
+        TextSetting::DatasetPrefix,
+        "Boot environment",
+        &c.dataset_prefix,
+        &format!(
+            "Create {}",
+            archinstall_zfs_core::boot_environment::BootEnvironment::new(
+                c.pool_name.as_deref().unwrap_or("?"),
+                &c.dataset_prefix
+            )
+            .base()
         ),
-        ci(
-            TextSetting::DatasetPrefix.as_str(),
-            "Dataset prefix",
-            &c.dataset_prefix,
-            ItemType::Text,
-        ),
-    ];
-
-    items.extend(choice_group_with_off(
-        ChoiceSetting::Compression,
-        "Compression",
-        c.compression,
-        CompressionAlgo::Off,
     ));
-
-    items.extend(choice_group(
+    items.push(section_header("Data protection"));
+    let mut encryption = compact_choice(
         ChoiceSetting::Encryption,
         "Encryption",
         c.zfs_encryption_mode,
-    ));
-
+        if c.installation_mode == Some(InstallationMode::ExistingPool) {
+            "Use the existing pool passphrase, or give the new boot environment its own encryption."
+        } else {
+            "Encrypt the entire pool, or just this boot environment."
+        },
+    );
+    if c.installation_mode == Some(InstallationMode::ExistingPool) {
+        let labels = [
+            "No additional encryption",
+            "Unlock encrypted pool",
+            "Encrypt new boot environment",
+        ];
+        encryption.choices = slint::ModelRc::new(slint::VecModel::from(
+            labels
+                .into_iter()
+                .map(SharedString::from)
+                .collect::<Vec<_>>(),
+        ));
+        encryption.value = labels[c.zfs_encryption_mode.index()].into();
+    }
+    items.push(encryption);
     if c.zfs_encryption_mode != ZfsEncryptionMode::None {
-        items.push(ci_opt(
-            TextSetting::EncryptionPassword.as_str(),
-            "Encryption password",
-            c.zfs_encryption_password.as_ref().map(|_| "Set"),
-            ItemType::Password,
-        ));
+        items.push(ConfigItem {
+            key: TextSetting::EncryptionPassword.as_str().into(),
+            label: "Encryption passphrase".into(),
+            value: if c.zfs_encryption_password.is_some() {
+                "Set — enter to replace"
+            } else {
+                "Required"
+            }
+            .into(),
+            description:
+                "At least 8 characters. Keep a copy: a lost passphrase cannot be recovered.".into(),
+            item_type: ItemType::InlinePassword,
+            ..Default::default()
+        });
     }
-
-    items.extend(choice_group_with_off(
+    items.push(section_header("Swap"));
+    items.push(compact_choice(
         ChoiceSetting::SwapMode,
-        "Swap",
+        "Swap method",
         c.swap_mode,
-        SwapMode::None,
+        "ZRAM uses compressed RAM. A swap partition uses disk space.",
     ));
-
-    if matches!(mode, Some(InstallationMode::FullDisk)) && has_swap_partition {
-        items.push(ci_opt(
-            TextSetting::SwapPartitionSize.as_str(),
-            "Swap size",
-            c.swap_partition_size.as_deref(),
-            ItemType::Text,
-        ));
+    if matches!(
+        c.swap_mode,
+        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+    ) {
+        if c.installation_mode == Some(InstallationMode::FullDisk) {
+            items.push(inline_text(
+                TextSetting::SwapPartitionSize,
+                "Swap size",
+                c.swap_partition_size.as_deref().unwrap_or(""),
+                "Created on the selected disk, for example 8G",
+            ));
+        } else {
+            items.push(storage_item(
+                "swap_partition",
+                "Swap partition",
+                c.swap_partition.as_deref(),
+                c,
+            ));
+        }
     }
-    if !matches!(mode, Some(InstallationMode::FullDisk) | None) && has_swap_partition {
-        let parts = partition_choices();
-        let swap_selected = c
-            .swap_partition
-            .as_ref()
-            .and_then(|sel| parts.iter().position(|choice| &choice.path == sel))
-            .map(|i| i as i32)
-            .unwrap_or(-1);
-        items.extend(radio_choice_group(
-            DeviceSetting::SwapPartition,
-            "Swap partition",
-            &parts,
-            swap_selected,
-        ));
-    }
-
-    items.extend(choice_group(
+    let mut compression = compact_choice(
+        ChoiceSetting::Compression,
+        "Compression",
+        c.compression,
+        "lz4 prioritizes speed; zstd levels trade CPU time for compression.",
+    );
+    compression.advanced = true;
+    items.push(compression);
+    let mut init = compact_choice(
         ChoiceSetting::InitSystem,
-        "Init system",
+        "Initramfs generator",
         c.init_system,
-    ));
-
+        "Builds the early boot image used to load the system.",
+    );
+    init.advanced = true;
+    items.push(init);
     items
 }
 
@@ -511,11 +535,64 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
 
 fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     let mut items = Vec::new();
+    let mut errors: Vec<String> = c
+        .validate_for_install()
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    errors.extend(crate::storage::issues(c));
+    if !errors.is_empty() {
+        items.push(section_header("Complete setup before installing"));
+        for error in errors {
+            items.push(ConfigItem {
+                value: error.to_string().into(),
+                item_type: ItemType::Warning,
+                ..Default::default()
+            });
+        }
+    }
+    let mut storage_header = section_header("Storage changes during installation");
+    storage_header.key = "edit:1".into();
+    items.push(storage_header);
+    for mut item in build_disk_items(c)
+        .into_iter()
+        .filter(|i| i.item_type == ItemType::Storage)
+    {
+        item.key = "".into();
+        items.push(item);
+    }
+    if c.installation_mode != Some(InstallationMode::FullDisk)
+        && matches!(
+            c.swap_mode,
+            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+        )
+    {
+        let mut item = storage_item(
+            "swap_partition",
+            "Swap partition",
+            c.swap_partition.as_deref(),
+            c,
+        );
+        item.key = "".into();
+        items.push(item);
+    }
+    items.push(ConfigItem {
+        label: "Boot environment".into(),
+        value: archinstall_zfs_core::boot_environment::BootEnvironment::new(
+            c.pool_name.as_deref().unwrap_or("?"),
+            &c.dataset_prefix,
+        )
+        .base()
+        .into(),
+        description: "Create this environment and its child datasets".into(),
+        item_type: ItemType::Readonly,
+        ..Default::default()
+    });
 
-    for (step, &label) in STEP_LABELS.iter().enumerate().take(TOTAL_STEPS - 1).skip(1) {
-        // Each step becomes a section in the review screen.
-        items.push(section_header(label));
-
+    for (step, &label) in STEP_LABELS.iter().enumerate().take(TOTAL_STEPS - 1).skip(2) {
+        let mut header = section_header(label);
+        header.key = format!("edit:{step}").into();
+        items.push(header);
         let step_items = build_step_items(step, c);
         let mut i = 0;
         while i < step_items.len() {
@@ -576,7 +653,7 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                         ..Default::default()
                     });
                 }
-                ItemType::SectionHeader => {
+                ItemType::SectionHeader | ItemType::Storage => {
                     // Visual section divider — the step-level header above
                     // already groups things on the review screen, so the
                     // inner divider would just produce an empty Readonly
@@ -587,7 +664,15 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                     items.push(ConfigItem {
                         key: item.key.clone(),
                         label: item.label.clone(),
-                        value: item.value.clone(),
+                        value: if item.item_type == ItemType::InlinePassword {
+                            if c.zfs_encryption_password.is_some() {
+                                "Set".into()
+                            } else {
+                                "Required".into()
+                            }
+                        } else {
+                            item.value.clone()
+                        },
                         description: item.description.clone(),
                         item_type: ItemType::Readonly,
                         is_empty: item.is_empty,
@@ -596,18 +681,6 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                     i += 1;
                 }
             }
-        }
-    }
-
-    let errors = c.validate_for_install();
-    if !errors.is_empty() {
-        items.push(section_header("Validation"));
-        for error in &errors {
-            items.push(ConfigItem {
-                value: error.to_string().into(),
-                item_type: ItemType::Warning,
-                ..Default::default()
-            });
         }
     }
 
@@ -672,27 +745,6 @@ fn section_header(label: &str) -> ConfigItem {
     }
 }
 
-/// Emit a radio group: a `RadioHeader` followed by clickable `RadioOption`
-/// rows. The header is a distinct `ItemType` from a plain `SectionHeader`
-/// so the review screen knows to collapse the header + options into one
-/// summary row, while bare section headers (used as visual dividers) get
-/// dropped in review entirely.
-fn radio_group(key: &str, label: &str, options: &[&str], selected: i32) -> Vec<ConfigItem> {
-    radio_group_inner(key, label, options, selected, None)
-}
-
-/// Build a radio group from a [`Choice`] enum, so the order, the labels and
-/// the selected index all come from one table rather than being spelled out
-/// here and inverted again in [`apply_radio`].
-fn choice_group<T: Choice>(setting: ChoiceSetting, label: &str, current: T) -> Vec<ConfigItem> {
-    radio_group(
-        setting.as_str(),
-        label,
-        &T::labels(),
-        current.index() as i32,
-    )
-}
-
 /// [`choice_group`] for lists with a semantic "off" alternative, named by
 /// value rather than by index.
 fn choice_group_with_off<T: Choice>(
@@ -753,112 +805,6 @@ fn radio_group_inner(
     items
 }
 
-fn radio_choice_group(
-    setting: DeviceSetting,
-    label: &str,
-    options: &[ChoiceRow],
-    selected: i32,
-) -> Vec<ConfigItem> {
-    let mut items = vec![ConfigItem {
-        label: label.into(),
-        item_type: ItemType::RadioHeader,
-        ..Default::default()
-    }];
-    for (i, option) in options.iter().enumerate() {
-        items.push(ConfigItem {
-            key: device_key(setting, &option.path),
-            label: option.label.as_str().into(),
-            icon: option.icon.as_str().into(),
-            detail_model: option.model.as_str().into(),
-            detail_serial: option.serial.as_str().into(),
-            detail_size: option.size.as_str().into(),
-            detail_transport: option.transport.as_str().into(),
-            detail_media: option.media.as_str().into(),
-            is_removable: option.removable,
-            persistent_path: option.persistent_path.as_str().into(),
-            persistent_kind: option.persistent_kind.as_str().into(),
-            group_label: option.group_label.as_str().into(),
-            group_model: option.group_model.as_str().into(),
-            group_serial: option.group_serial.as_str().into(),
-            group_size: option.group_size.as_str().into(),
-            group_transport: option.group_transport.as_str().into(),
-            group_media: option.group_media.as_str().into(),
-            group_removable: option.group_removable,
-            value: if i as i32 == selected {
-                "selected".into()
-            } else {
-                SharedString::default()
-            },
-            item_type: ItemType::RadioOption,
-            ..Default::default()
-        });
-    }
-    items
-}
-
-fn radio_partition_choice_group(
-    setting: DeviceSetting,
-    label: &str,
-    options: &[ChoiceRow],
-    selected: i32,
-) -> Vec<ConfigItem> {
-    let mut items = vec![ConfigItem {
-        label: label.into(),
-        item_type: ItemType::RadioHeader,
-        ..Default::default()
-    }];
-    let mut current_group = "";
-
-    for (i, option) in options.iter().enumerate() {
-        let group_key = option.group_key();
-        if group_key != current_group {
-            current_group = group_key;
-            items.push(ConfigItem {
-                label: option.group_key().into(),
-                icon: "hard-drive".into(),
-                detail_model: option.group_model.as_str().into(),
-                detail_serial: option.group_serial.as_str().into(),
-                detail_size: option.group_size.as_str().into(),
-                detail_transport: option.group_transport.as_str().into(),
-                detail_media: option.group_media.as_str().into(),
-                is_removable: option.group_removable,
-                item_type: ItemType::RadioSubheader,
-                ..Default::default()
-            });
-        }
-
-        items.push(ConfigItem {
-            key: device_key(setting, &option.path),
-            label: option.label.as_str().into(),
-            detail_size: option.size.as_str().into(),
-            persistent_path: option.persistent_path.as_str().into(),
-            persistent_kind: option.persistent_kind.as_str().into(),
-            group_label: option.group_label.as_str().into(),
-            group_model: option.group_model.as_str().into(),
-            group_serial: option.group_serial.as_str().into(),
-            group_size: option.group_size.as_str().into(),
-            group_transport: option.group_transport.as_str().into(),
-            group_media: option.group_media.as_str().into(),
-            group_removable: option.group_removable,
-            value: if i as i32 == selected {
-                "selected".into()
-            } else {
-                SharedString::default()
-            },
-            item_type: ItemType::RadioOption,
-            ..Default::default()
-        });
-    }
-    items
-}
-
-// ── Section boundary marking ────────────────────────
-
-/// Walk a list of items after it's built and set `is_first_in_section` /
-/// `is_last_in_section` on each field row, based on adjacent SectionHeaders
-/// and Separators. Field types (text/select/password/toggle/radio-option/
-/// readonly) are part of section cards; everything else is a standalone
-/// element and gets neither flag set.
 fn mark_section_boundaries(items: &mut [ConfigItem]) {
     fn is_field(t: ItemType) -> bool {
         matches!(
@@ -901,7 +847,8 @@ pub fn next_selectable_index(items: &[ConfigItem], current: i32, dir: i32) -> i3
     for offset in 1..=len {
         let idx = ((current + dir * offset) % len + len) % len;
         let t = items[idx as usize].item_type;
-        if t != ItemType::Separator
+        if !(t == ItemType::Storage && items[idx as usize].key.is_empty())
+            && t != ItemType::Separator
             && t != ItemType::Readonly
             && t != ItemType::Warning
             && t != ItemType::SectionHeader
@@ -926,32 +873,9 @@ pub fn next_selectable_index(items: &[ConfigItem], current: i32, dir: i32) -> i3
 /// it. For a screen whose next step erases the chosen disk, selecting by
 /// identity rather than by position is the only version that is safe to be
 /// wrong about.
+#[cfg(test)]
 fn device_key(setting: DeviceSetting, path: &std::path::Path) -> SharedString {
     format!("device:{}:{}", setting.as_str(), path.display()).into()
-}
-
-fn disk_choices() -> Vec<ChoiceRow> {
-    if crate::preview::enabled() {
-        return crate::preview::disks()
-            .into_iter()
-            .map(ChoiceRow::from)
-            .collect();
-    }
-    archinstall_zfs_core::disk::device::disk_choices()
-        .map(|choices| choices.into_iter().map(ChoiceRow::from).collect())
-        .unwrap_or_default()
-}
-
-fn partition_choices() -> Vec<ChoiceRow> {
-    if crate::preview::enabled() {
-        return crate::preview::partitions()
-            .into_iter()
-            .map(ChoiceRow::from)
-            .collect();
-    }
-    archinstall_zfs_core::disk::device::partition_choices()
-        .map(|choices| choices.into_iter().map(ChoiceRow::from).collect())
-        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -1132,5 +1056,54 @@ mod tests {
         mark_section_boundaries(&mut items);
         assert!(items[0].is_first_in_section);
         assert!(items[0].is_last_in_section);
+    }
+}
+
+#[cfg(test)]
+mod storage_design_tests {
+    use super::*;
+    #[test]
+    fn assignments_do_not_expand_device_catalogues() {
+        for mode in [
+            InstallationMode::FullDisk,
+            InstallationMode::NewPool,
+            InstallationMode::ExistingPool,
+        ] {
+            let c = GlobalConfig {
+                installation_mode: Some(mode),
+                ..Default::default()
+            };
+            let items = build_disk_items(&c);
+            assert!(!items.iter().any(|i| matches!(
+                i.item_type,
+                ItemType::RadioOption | ItemType::RadioSubheader
+            )));
+            assert_eq!(
+                items
+                    .iter()
+                    .filter(|i| i.item_type == ItemType::Storage)
+                    .count(),
+                if mode == InstallationMode::FullDisk {
+                    1
+                } else {
+                    2
+                }
+            );
+        }
+    }
+    #[test]
+    fn review_uses_canonical_environment_path_and_never_copies_passphrases() {
+        let c = GlobalConfig {
+            installation_mode: Some(InstallationMode::NewPool),
+            pool_name: Some("tank".into()),
+            dataset_prefix: "newbe".into(),
+            zfs_encryption_mode: ZfsEncryptionMode::Dataset,
+            zfs_encryption_password: Some("do-not-display-this".into()),
+            ..Default::default()
+        };
+        let items = build_review_items(&c);
+        assert!(items.iter().any(|i| i.value == "tank/newbe"));
+        assert!(!items.iter().any(|i| i.value.contains("do-not-display")));
+        assert!(items.iter().any(|i| i.item_type == ItemType::Warning));
     }
 }

--- a/slint-ui/src/console_session.rs
+++ b/slint-ui/src/console_session.rs
@@ -222,6 +222,10 @@ fn supervise_console(
             }
         }
         command.env(CHILD_ENV, "1").env(CHANNEL_ENV, fd.to_string());
+        // The installer enables tapping explicitly; Slint preserves libinput defaults.
+        if std::env::var_os("SLINT_LIBINPUT_TAP_TO_CLICK").is_none() {
+            command.env("SLINT_LIBINPUT_TAP_TO_CLICK", "1");
+        }
         // SAFETY: pre_exec only performs async-signal-safe syscalls.
         unsafe { command.pre_exec(move || check(libc::fcntl(fd, libc::F_SETFD, 0))) };
         let mut child = spawn_command(&mut command)?;

--- a/slint-ui/src/controllers/install.rs
+++ b/slint-ui/src/controllers/install.rs
@@ -99,7 +99,12 @@ pub fn setup(
         }
         let c = cfg.borrow().clone();
 
-        let errors = c.validate_for_install();
+        let mut errors: Vec<String> = c
+            .validate_for_install()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        errors.extend(crate::storage::issues(&c));
         if !errors.is_empty() {
             app.global::<WizardState>()
                 .set_status_text(SharedString::from(format!("Validation: {}", errors[0])));

--- a/slint-ui/src/controllers/lists.rs
+++ b/slint-ui/src/controllers/lists.rs
@@ -5,6 +5,10 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use slint::{ComponentHandle, Model, SharedString};
 
@@ -66,17 +70,20 @@ fn setup_users(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &EditingMo
     let cfg = config.clone();
     let model = models.users.clone();
     app.on_user_added(move |username, password, sudo| {
-        let Some(app) = weak.upgrade() else { return };
+        let Some(app) = weak.upgrade() else { return false };
+        app.global::<EditingState>().set_user_error(SharedString::default());
         let username = username.to_string();
         if !archinstall_zfs_core::config::validation::is_valid_username(&username) {
-            return;
+            app.global::<EditingState>().set_user_error("Use up to 32 lowercase letters, digits, underscores or hyphens. Start with a letter or underscore.".into());
+            return false;
         }
         let mut c = cfg.borrow_mut();
         if c.users
             .as_ref()
             .is_some_and(|users| users.iter().any(|u| u.username == username))
         {
-            return;
+            app.global::<EditingState>().set_user_error("This username is already in the account list.".into());
+            return false;
         }
         let password = if password.is_empty() {
             None
@@ -98,6 +105,7 @@ fn setup_users(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &EditingMo
             has_sudo: sudo,
         });
         refresh_items(&app, &c);
+        true
     });
 
     let weak = app.as_weak();
@@ -175,28 +183,39 @@ fn setup_extra_services(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &
 }
 
 fn setup_packages(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &EditingModels) {
+    // Repository and AUR requests share an epoch so old results cannot replace a new query.
+    let search_epoch = Arc::new(AtomicU64::new(0));
+    let epoch = search_epoch.clone();
     // Repo search (alpm — runs blocking inside a tokio task)
     let weak = app.as_weak();
     let search_model = models.package_search.clone();
     app.on_pkg_search_changed(move |text| {
+        let request = epoch.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
         let Some(app) = weak.upgrade() else { return };
         let editing = app.global::<EditingState>();
+        editing.set_package_searching_aur(false);
+        search_model.set_vec(Vec::new());
+        editing.set_package_status_text(SharedString::default());
         if text.is_empty() {
-            search_model.set_vec(Vec::<PackageSearchResult>::new());
-            editing.set_package_status_text(SharedString::default());
             return;
         }
-        editing.set_package_searching_aur(false);
         if crate::preview::enabled() {
             search_model.set_vec(crate::preview::packages(&text, false));
             return;
         }
+        editing.set_package_status_text("Searching repositories…".into());
         let query = text.to_string();
         let weak2 = app.as_weak();
+        let epoch = epoch.clone();
         tokio::spawn(async move {
-            let results = archinstall_zfs_core::packages::search_repo(&query, 20)
-                .await
-                .unwrap_or_default();
+            let results = archinstall_zfs_core::packages::search_repo(&query, 20).await;
+            let (results, status) = match results {
+                Ok(results) => (results, SharedString::default()),
+                Err(error) => (
+                    Vec::new(),
+                    format!("Repository search failed: {error}").into(),
+                ),
+            };
             let items: Vec<PackageSearchResult> = results
                 .into_iter()
                 .map(|p| PackageSearchResult {
@@ -206,9 +225,11 @@ fn setup_packages(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &Editin
                 })
                 .collect();
             let _ = weak2.upgrade_in_event_loop(move |app| {
+                if epoch.load(Ordering::Relaxed) != request {
+                    return;
+                }
                 set_search_results(&app, items);
-                app.global::<EditingState>()
-                    .set_package_status_text(SharedString::default());
+                app.global::<EditingState>().set_package_status_text(status);
             });
         });
     });
@@ -216,18 +237,21 @@ fn setup_packages(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &Editin
     // AUR search
     let weak = app.as_weak();
     app.on_pkg_search_aur(move |text| {
+        let request = search_epoch.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
         let Some(app) = weak.upgrade() else { return };
         if text.is_empty() {
             return;
         }
         let editing = app.global::<EditingState>();
         editing.set_package_searching_aur(true);
+        set_search_results(&app, Vec::new());
         if crate::preview::enabled() {
             set_search_results(&app, crate::preview::packages(&text, true));
             editing.set_package_searching_aur(false);
             return;
         }
         editing.set_package_status_text(SharedString::from("Searching AUR..."));
+        let epoch = search_epoch.clone();
         let query = text.to_string();
         let weak2 = app.as_weak();
         tokio::spawn(async move {
@@ -242,6 +266,11 @@ fn setup_packages(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &Editin
                         })
                         .collect();
                     let _ = weak2.upgrade_in_event_loop(move |app| {
+                        if epoch.load(Ordering::Relaxed) != request {
+                            return;
+                        }
+                        app.global::<EditingState>()
+                            .set_package_searching_aur(false);
                         set_search_results(&app, items);
                         app.global::<EditingState>()
                             .set_package_status_text(SharedString::default());
@@ -250,6 +279,11 @@ fn setup_packages(app: &App, config: &Rc<RefCell<GlobalConfig>>, models: &Editin
                 Err(e) => {
                     let msg = format!("AUR error: {e}");
                     let _ = weak2.upgrade_in_event_loop(move |app| {
+                        if epoch.load(Ordering::Relaxed) != request {
+                            return;
+                        }
+                        app.global::<EditingState>()
+                            .set_package_searching_aur(false);
                         app.global::<EditingState>()
                             .set_package_status_text(SharedString::from(&msg));
                     });

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -26,6 +26,18 @@ use crate::ui::{
 };
 
 pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_scan: &KernelScan) {
+    let cfg = config.clone();
+    let weak = app.as_weak();
+    app.on_inline_edited(move |key, value| {
+        if let Some(setting) = TextSetting::parse(&key) {
+            let mut c = cfg.borrow_mut();
+            apply_text(&mut c, setting, &value);
+            // Keep the editor and caret alive while typing; only rebuild on navigation.
+            if let Some(app) = weak.upgrade() {
+                crate::refresh::refresh_validation(&app, &c);
+            }
+        }
+    });
     setup_step_changed(app, config);
     setup_item_activated(app, config, kernel_scan);
     setup_toggle(app, config);
@@ -51,6 +63,19 @@ fn setup_item_activated(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_sc
     let kscan = kernel_scan.clone();
     app.on_item_activated(move |key| {
         let Some(app) = weak.upgrade() else { return };
+
+        if let Some(role) = key.strip_prefix("storage:") {
+            app.global::<crate::ui::StorageState>()
+                .invoke_open(role.into());
+            return;
+        }
+        if let Some(step) = key
+            .strip_prefix("edit:")
+            .and_then(|s| s.parse::<i32>().ok())
+        {
+            app.global::<WizardState>().invoke_go_to(step);
+            return;
+        }
 
         // Device rows: "device:{setting}:{path}". Split on the first colon
         // only — persistent device paths contain colons of their own, as in
@@ -79,6 +104,7 @@ fn setup_item_activated(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_sc
                     let mut c = cfg.borrow_mut();
                     apply_choice(&mut c, setting, index);
                     refresh_items(&app, &c);
+                    crate::refresh::focus_item(&app, setting.as_str());
                 }
                 None => tracing::warn!(%key, "radio row names no known setting"),
             }
@@ -253,10 +279,17 @@ fn setup_keyboard_nav(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let cfg = config.clone();
     app.on_key_nav_down(move || {
         let Some(app) = weak.upgrade() else { return };
-        let items = build_step_items(
+        let mut items = build_step_items(
             app.global::<WizardState>().get_current_step() as usize,
             &cfg.borrow(),
         );
+        if !app.global::<WizardState>().get_advanced() {
+            for item in &mut items {
+                if item.advanced {
+                    item.item_type = ItemType::Readonly;
+                }
+            }
+        }
         let current = app.global::<WizardState>().get_focused_index();
         let next = next_selectable_index(&items, current, 1);
         app.global::<WizardState>().set_focused_index(next);
@@ -266,10 +299,17 @@ fn setup_keyboard_nav(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let cfg = config.clone();
     app.on_key_nav_up(move || {
         let Some(app) = weak.upgrade() else { return };
-        let items = build_step_items(
+        let mut items = build_step_items(
             app.global::<WizardState>().get_current_step() as usize,
             &cfg.borrow(),
         );
+        if !app.global::<WizardState>().get_advanced() {
+            for item in &mut items {
+                if item.advanced {
+                    item.item_type = ItemType::Readonly;
+                }
+            }
+        }
         let current = app.global::<WizardState>().get_focused_index();
         let next = next_selectable_index(&items, current, -1);
         app.global::<WizardState>().set_focused_index(next);

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -143,16 +143,34 @@ fn setup_select_confirmed(app: &App, config: &Rc<RefCell<GlobalConfig>>, kernel_
                 let cities = archinstall_zfs_core::installer::locale::list_timezone_cities(region);
                 let city_strs: Vec<&str> = cities.iter().map(|s| s.as_str()).collect();
                 let tz_key = format!("timezone_city:{region}");
-                show_select(&app, &tz_key, &format!("{region} /"), &city_strs, 0);
+                let current = cfg
+                    .borrow()
+                    .timezone
+                    .as_deref()
+                    .and_then(|tz| tz.strip_prefix(&format!("{region}/")))
+                    .and_then(|city| cities.iter().position(|c| c == city))
+                    .map(|i| i as i32)
+                    .unwrap_or(-1);
+                show_select_with_filter(
+                    &app,
+                    &tz_key,
+                    &format!("Timezone · {region}"),
+                    &city_strs,
+                    current,
+                    true,
+                );
             }
             return;
         }
 
         if key.starts_with("timezone_city:") {
             let region = key.strip_prefix("timezone_city:").unwrap();
-            let cities = archinstall_zfs_core::installer::locale::list_timezone_cities(region);
-            if let Some(city) = cities.get(idx as usize) {
-                cfg.borrow_mut().timezone = Some(format!("{region}/{city}"));
+            if let Some(city) = app
+                .global::<PopupState>()
+                .get_select_options()
+                .row_data(idx as usize)
+            {
+                cfg.borrow_mut().timezone = Some(format!("{region}/{}", city.text));
                 refresh_items(&app, &cfg.borrow());
             }
             return;
@@ -354,6 +372,13 @@ fn setup_select_filter(app: &App) {
     app.on_select_filter_changed(move |key, filter_text| {
         let Some(app) = weak.upgrade() else { return };
         let filter = filter_text.to_lowercase();
+
+        if let Some(region) = key.strip_prefix("timezone_city:") {
+            let cities = archinstall_zfs_core::installer::locale::list_timezone_cities(region);
+            let popup = app.global::<PopupState>();
+            popup.set_select_options(ModelRc::new(VecModel::from(fuzzy_filter(&cities, &filter))));
+            popup.set_select_index(-1);
+        }
 
         if key == "locale_select" {
             let all_locales = available_locales();
@@ -579,7 +604,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
         }
         EditorSetting::Profile => {
             let profiles = archinstall_zfs_core::profile::all_profiles();
-            let mut names: Vec<String> = vec!["None".to_string()];
+            let mut names: Vec<String> = vec!["Console only".to_string()];
             names.extend(profiles.iter().map(|p| p.display_name.to_string()));
             let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
             let current = config
@@ -676,7 +701,14 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
         }
         EditorSetting::Timezone => {
             let regions = archinstall_zfs_core::installer::locale::list_timezone_regions();
-            show_select(app, "timezone_region", "Timezone region", &regions, 0);
+            let current = config
+                .timezone
+                .as_deref()
+                .and_then(|tz| tz.split_once('/'))
+                .and_then(|(region, _)| regions.iter().position(|r| *r == region))
+                .map(|i| i as i32)
+                .unwrap_or(-1);
+            show_select(app, "timezone_region", "Timezone region", &regions, current);
         }
         EditorSetting::Locale => {
             let locales = available_locales();
@@ -690,7 +722,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             show_select_with_filter(
                 app,
                 "locale_select",
-                "Locale (type to filter)",
+                "Locale",
                 &locale_strs,
                 current_idx,
                 true,
@@ -710,7 +742,7 @@ fn handle_item_activated(app: &App, key: &str, config: &GlobalConfig, kernel_sca
             show_select_with_filter(
                 app,
                 "keyboard_select",
-                "Keyboard layout (type to filter)",
+                "Keyboard layout",
                 &keymap_strs,
                 current_idx,
                 true,

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -9,6 +9,7 @@ mod format;
 mod installed_shell;
 mod preview;
 mod refresh;
+mod storage;
 mod tracing_layer;
 
 use std::cell::RefCell;
@@ -229,6 +230,7 @@ fn run_gui(
     controllers::welcome::setup(&app, &config, &kernel_scan, demo);
     controllers::lists::setup(&app, &config, &models);
     controllers::wizard::setup(&app, &config, &kernel_scan);
+    storage::setup(&app, &config);
     controllers::install::setup(&app, &config, demo, log_rx, &completion);
     controllers::wifi::setup(&app);
 

--- a/slint-ui/src/preview.rs
+++ b/slint-ui/src/preview.rs
@@ -33,6 +33,14 @@ pub fn enable() {
 pub enum Scene {
     Welcome,
     Offline,
+    NoUefi,
+    ZfsPreparing,
+    ZfsFailed,
+    WifiEmpty,
+    WifiUnavailable,
+    WifiNoInternet,
+    WifiVerifying,
+    Cancelling,
     Disk,
     NewPool,
     ExistingPool,
@@ -408,7 +416,15 @@ pub fn show(app: &App, scene: Scene, size: Size) {
     app.window()
         .set_size(slint::PhysicalSize::new(size.0, size.1));
     let step = match scene {
-        Scene::Welcome | Scene::Offline => 0,
+        Scene::Welcome
+        | Scene::Offline
+        | Scene::NoUefi
+        | Scene::ZfsPreparing
+        | Scene::ZfsFailed
+        | Scene::WifiEmpty
+        | Scene::WifiUnavailable
+        | Scene::WifiNoInternet
+        | Scene::WifiVerifying => 0,
         Scene::Disk | Scene::NewPool | Scene::ExistingPool => 1,
         Scene::Zfs => 2,
         Scene::System => 3,
@@ -424,6 +440,43 @@ pub fn show(app: &App, scene: Scene, size: Size) {
             .set_ethernet_connected(false);
     }
     match scene {
+        Scene::NoUefi => app.global::<WelcomeState>().set_uefi_ok(false),
+        Scene::ZfsPreparing | Scene::ZfsFailed => {
+            let state = app.global::<WelcomeState>();
+            state.set_zfs_ok(false);
+            let preparing = matches!(scene, Scene::ZfsPreparing);
+            state.set_zfs_installing(preparing);
+            state.set_zfs_install_pct(45);
+            state.set_zfs_install_status(if preparing {
+                "Building the ZFS module for the running kernel…".into()
+            } else {
+                "Failed: could not retrieve ZFS packages. Check your network connection and try again.".into()
+            });
+        }
+        Scene::WifiEmpty
+        | Scene::WifiUnavailable
+        | Scene::WifiNoInternet
+        | Scene::WifiVerifying => {
+            use crate::ui::{WifiPhase, WifiState};
+            let wifi = app.global::<WifiState>();
+            app.global::<crate::ui::PopupState>().set_wifi_visible(true);
+            wifi.set_visible(true);
+            app.global::<WelcomeState>().set_net_ok(false);
+            wifi.set_networks(ModelRc::new(VecModel::default()));
+            wifi.set_ethernet_connected(false);
+            wifi.set_iwd_running(!matches!(scene, Scene::WifiUnavailable));
+            wifi.set_phase(match scene {
+                Scene::WifiNoInternet => WifiPhase::NoInternet,
+                Scene::WifiVerifying => WifiPhase::Verifying,
+                _ => WifiPhase::Picking,
+            });
+            wifi.set_status_text("Checking internet access…".into());
+            if matches!(scene, Scene::WifiNoInternet) {
+                wifi.set_current_ssid("HomeNetwork".into());
+                wifi.set_error_text("Connected to HomeNetwork, but the internet check did not succeed. Check the router or choose another network.".into());
+            }
+        }
+        Scene::Cancelling => progress(app, 4),
         Scene::Install => progress(app, 1),
         Scene::Done => {
             progress(app, 2);

--- a/slint-ui/src/preview.rs
+++ b/slint-ui/src/preview.rs
@@ -110,20 +110,40 @@ fn devices() -> Vec<BlockDevice> {
         transport: Some(bus.into()),
         rotational: Some(false),
         removable,
-        usage: Default::default(),
+        usage: archinstall_zfs_core::disk::device::DeviceUsage {
+            in_use: removable,
+            ..Default::default()
+        },
     })
     .collect()
 }
 
 pub fn disks() -> Vec<DeviceChoice> {
+    if storage_fixture() == "empty" {
+        return vec![];
+    }
     devices().into_iter().map(Into::into).collect()
 }
 
+fn storage_fixture() -> String {
+    std::env::var("AZFS_PREVIEW_STORAGE").unwrap_or_default()
+}
+
 pub fn partitions() -> Vec<DeviceChoice> {
+    if storage_fixture() == "empty" {
+        return vec![];
+    }
     devices()
         .into_iter()
         .flat_map(|disk| {
-            (1..=2).map(move |number| {
+            let count = if storage_fixture() == "many" {
+                20
+            } else if disk.transport.as_deref() == Some("sata") {
+                4
+            } else {
+                2
+            };
+            (1..=count).map(move |number| {
                 BlockPartition {
                     devnode: format!(
                         "{}{}{number}",
@@ -145,13 +165,50 @@ pub fn partitions() -> Vec<DeviceChoice> {
                     size_bytes: Some(if number == 1 {
                         1024 * 1024 * 1024
                     } else {
-                        disk.size_bytes.unwrap() - 1024 * 1024 * 1024
+                        (disk.size_bytes.unwrap() - 1024 * 1024 * 1024) / (count - 1)
                     }),
                     parent_size_bytes: disk.size_bytes,
                     transport: disk.transport.clone(),
                     rotational: disk.rotational,
                     removable: disk.removable,
-                    usage: Default::default(),
+                    usage: archinstall_zfs_core::disk::device::DeviceUsage {
+                        filesystem: if storage_fixture() == "missing" {
+                            ""
+                        } else if number == 1 {
+                            "vfat"
+                        } else if number == 3 {
+                            "ntfs"
+                        } else {
+                            "ext4"
+                        }
+                        .into(),
+                        label: if storage_fixture() == "missing" {
+                            "".into()
+                        } else if number == 1 {
+                            "EFI".into()
+                        } else {
+                            format!(
+                                "{}-partition-{number}",
+                                if number == 3 {
+                                    "Windows"
+                                } else {
+                                    "Previous-Linux"
+                                }
+                            )
+                        },
+                        partition_type: if number == 1 {
+                            "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+                        } else {
+                            "0fc63daf-8483-4772-8e79-3d69d8477de4"
+                        }
+                        .into(),
+                        in_use: disk.removable,
+                        mountpoints: if disk.removable {
+                            vec!["/run/archiso/bootmnt".into()]
+                        } else {
+                            vec![]
+                        },
+                    },
                 }
                 .into()
             })
@@ -169,9 +226,9 @@ pub fn config(scene: Scene) -> GlobalConfig {
             Scene::ExistingPool => InstallationMode::ExistingPool,
             _ => InstallationMode::FullDisk,
         }),
-        disk: Some(disks()[0].path.clone()),
-        efi_partition: Some(partitions()[0].path.clone()),
-        zfs_partition: Some(partitions()[1].path.clone()),
+        disk: disks().first().map(|d| d.path.clone()),
+        efi_partition: partitions().first().map(|d| d.path.clone()),
+        zfs_partition: partitions().get(1).map(|d| d.path.clone()),
         pool_name: Some("zroot".into()),
         hostname: Some("arch-workstation".into()),
         locale: Some("en_US.UTF-8".into()),

--- a/slint-ui/src/preview.rs
+++ b/slint-ui/src/preview.rs
@@ -110,6 +110,7 @@ fn devices() -> Vec<BlockDevice> {
         transport: Some(bus.into()),
         rotational: Some(false),
         removable,
+        usage: Default::default(),
     })
     .collect()
 }
@@ -150,6 +151,7 @@ pub fn partitions() -> Vec<DeviceChoice> {
                     transport: disk.transport.clone(),
                     rotational: disk.rotational,
                     removable: disk.removable,
+                    usage: Default::default(),
                 }
                 .into()
             })

--- a/slint-ui/src/refresh.rs
+++ b/slint-ui/src/refresh.rs
@@ -6,15 +6,65 @@ use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
 
 use archinstall_zfs_core::config::types::GlobalConfig;
 
-use crate::config_items::{build_step_items, next_selectable_index};
+use crate::config_items::build_step_items;
 use crate::ui::{App, WizardState};
+use archinstall_zfs_core::config::choices::Choice;
 
 pub fn refresh_items(app: &App, config: &GlobalConfig) {
     let step = app.global::<WizardState>().get_current_step() as usize;
     let items = build_step_items(step, config);
-    let first = next_selectable_index(&items, -1, 1);
+    let first = -1;
     let wizard = app.global::<WizardState>();
     wizard.set_focused_index(first);
+    wizard.set_storage_mode(
+        config
+            .installation_mode
+            .map(|m| m.index() as i32)
+            .unwrap_or(-1),
+    );
+    refresh_validation(app, config);
     wizard.set_config_items(ModelRc::new(VecModel::from(items)));
     wizard.set_status_text(SharedString::default());
+}
+
+pub fn refresh_validation(app: &App, config: &GlobalConfig) {
+    let mut errors: Vec<String> = config
+        .validate_for_install()
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    errors.extend(crate::storage::issues(config));
+    let wizard = app.global::<WizardState>();
+    wizard.set_environment_path(
+        archinstall_zfs_core::boot_environment::BootEnvironment::new(
+            config.pool_name.as_deref().unwrap_or("?"),
+            &config.dataset_prefix,
+        )
+        .base()
+        .into(),
+    );
+    wizard.set_can_install(errors.is_empty());
+    wizard.set_validation_summary(if errors.is_empty() {
+        "".into()
+    } else {
+        format!("{} required setting(s) need attention", errors.len()).into()
+    });
+}
+
+/// Rebuilding a conditional form must not send keyboard focus back to the window.
+pub fn focus_item(app: &App, key: &str) {
+    use slint::Model;
+    let index = app
+        .global::<WizardState>()
+        .get_config_items()
+        .iter()
+        .position(|item| item.key == key);
+    if let Some(index) = index {
+        let weak = app.as_weak();
+        slint::Timer::single_shot(std::time::Duration::ZERO, move || {
+            if let Some(app) = weak.upgrade() {
+                app.global::<WizardState>().set_focused_index(index as i32);
+            }
+        });
+    }
 }

--- a/slint-ui/src/storage.rs
+++ b/slint-ui/src/storage.rs
@@ -1,0 +1,610 @@
+//! Read-only storage discovery and identity-based selection for the graphical wizard.
+use crate::{
+    refresh::refresh_items,
+    ui::{App, StorageCandidate, StorageState},
+};
+use archinstall_zfs_core::{
+    config::{
+        edit::{DeviceSetting, apply_device},
+        types::{GlobalConfig, InstallationMode, SwapMode},
+    },
+    disk::device::{self, DeviceChoice},
+};
+use slint::{ComponentHandle, ModelRc, VecModel};
+use std::{cell::RefCell, path::Path, rc::Rc};
+
+#[derive(Default)]
+struct Inventory {
+    disks: Vec<DeviceChoice>,
+    partitions: Vec<DeviceChoice>,
+    pools: Vec<StorageCandidate>,
+    datasets: Vec<String>,
+}
+thread_local! { static INVENTORY: RefCell<Inventory> = RefCell::default(); }
+
+pub fn choices(role: &str) -> Vec<DeviceChoice> {
+    if crate::preview::enabled() {
+        return if role == "disk" {
+            crate::preview::disks()
+        } else {
+            crate::preview::partitions()
+        };
+    }
+    INVENTORY.with_borrow(|i| {
+        if role == "disk" {
+            i.disks.clone()
+        } else {
+            i.partitions.clone()
+        }
+    })
+}
+fn same_device(a: &Path, b: &Path) -> bool {
+    std::fs::canonicalize(a).unwrap_or_else(|_| a.into())
+        == std::fs::canonicalize(b).unwrap_or_else(|_| b.into())
+}
+pub fn unavailable(choice: &DeviceChoice, role: &str, c: &GlobalConfig) -> String {
+    if choice.usage.in_use {
+        return if choice.usage.mountpoints.is_empty() {
+            "Device is in use".into()
+        } else {
+            format!("In use: {}", choice.usage.mountpoints.join(", "))
+        };
+    }
+    if role == "disk" {
+        return String::new();
+    }
+    for (other, selected, active) in [
+        ("efi_partition", c.efi_partition.as_ref(), true),
+        (
+            "zfs_partition",
+            c.zfs_partition.as_ref(),
+            c.installation_mode == Some(InstallationMode::NewPool),
+        ),
+        (
+            "swap_partition",
+            c.swap_partition.as_ref(),
+            matches!(
+                c.swap_mode,
+                SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+            ),
+        ),
+    ] {
+        if active && role != other && selected.is_some_and(|p| same_device(p, &choice.path)) {
+            return format!("Assigned to {}", role_label(other));
+        }
+    }
+    if role == "efi_partition"
+        && (!matches!(choice.usage.filesystem.as_str(), "vfat" | "fat32")
+            || !choice
+                .usage
+                .partition_type
+                .eq_ignore_ascii_case("c12a7328-f81f-11d2-ba4b-00a0c93ec93b"))
+    {
+        return "Requires a FAT32 EFI system partition".into();
+    }
+    String::new()
+}
+pub fn role_label(role: &str) -> &str {
+    match role {
+        "disk" => "Disk",
+        "efi_partition" => "EFI boot partition",
+        "zfs_partition" => "New ZFS pool",
+        "swap_partition" => "Swap",
+        _ => "Existing pool",
+    }
+}
+fn candidate(choice: DeviceChoice, role: &str, c: &GlobalConfig) -> StorageCandidate {
+    let unavailable = unavailable(&choice, role, c);
+    let hardware = format!(
+        "{}  {}",
+        choice.transport.to_uppercase(),
+        if choice.removable {
+            "Removable"
+        } else {
+            &choice.media
+        }
+    );
+    let details = format!(
+        "{}\nModel: {}\nSerial: {}\n{}",
+        choice.label,
+        choice.model,
+        if choice.serial.is_empty() {
+            "Unknown"
+        } else {
+            &choice.serial
+        },
+        choice.path.display()
+    );
+    StorageCandidate {
+        key: choice.path.to_string_lossy().as_ref().into(),
+        name: choice.label.clone().into(),
+        group: if choice.group_label.is_empty() {
+            "Disks".into()
+        } else {
+            format!("{}  —  {}", choice.group_model, choice.group_label).into()
+        },
+        hardware: if role == "disk" {
+            "".into()
+        } else {
+            hardware.clone().into()
+        },
+        size: choice.size.into(),
+        filesystem: if role == "disk" {
+            hardware.into()
+        } else if choice.usage.filesystem.is_empty() {
+            "Unknown".into()
+        } else {
+            choice.usage.filesystem.into()
+        },
+        label: if role == "disk" {
+            choice.model.into()
+        } else if choice.usage.label.is_empty() {
+            "—".into()
+        } else {
+            choice.usage.label.into()
+        },
+        details: details.into(),
+        unavailable: unavailable.into(),
+    }
+}
+fn current(c: &GlobalConfig, role: &str) -> String {
+    if role == "pool" {
+        return c.pool_name.clone().unwrap_or_default();
+    }
+    match role {
+        "disk" => &c.disk,
+        "efi_partition" => &c.efi_partition,
+        "zfs_partition" => &c.zfs_partition,
+        _ => &c.swap_partition,
+    }
+    .as_ref()
+    .map(|p| p.display().to_string())
+    .unwrap_or_default()
+}
+fn populate(app: &App, c: &GlobalConfig) {
+    let state = app.global::<StorageState>();
+    let role = state.get_role();
+    let filter = state.get_filter().to_lowercase();
+    let rows: Vec<_> = if role == "pool" {
+        INVENTORY.with_borrow(|i| i.pools.clone())
+    } else {
+        choices(&role)
+            .into_iter()
+            .map(|d| candidate(d, &role, c))
+            .collect()
+    };
+    let selected = state.get_selected();
+    if let Some(row) = rows
+        .iter()
+        .find(|r| r.key == selected && r.unavailable.is_empty())
+    {
+        state.set_selected_name(row.name.clone());
+        state.set_selected_details(row.details.clone());
+    } else {
+        state.set_selected("".into());
+        state.set_selected_name("".into());
+        state.set_selected_details("".into());
+    }
+    let rows: Vec<_> = rows
+        .into_iter()
+        .filter(|r| {
+            format!(
+                "{} {} {} {} {}",
+                r.name, r.group, r.filesystem, r.label, r.details
+            )
+            .to_lowercase()
+            .contains(&filter)
+        })
+        .collect();
+    if !rows.iter().any(|r| r.key == state.get_selected()) {
+        state.set_selected("".into());
+        state.set_selected_name("".into());
+        state.set_selected_details("".into());
+    }
+    state.set_candidates(ModelRc::new(VecModel::from(rows)));
+}
+pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    app.global::<StorageState>().on_open(move |role| {
+        let Some(app) = weak.upgrade() else { return };
+        let state = app.global::<StorageState>();
+        state.set_role(role.clone());
+        state.set_title(match role.as_str() {
+            "disk" => "Choose a disk",
+            "efi_partition" => "Choose an EFI partition",
+            "zfs_partition" => "Choose a ZFS partition",
+            "swap_partition" => "Choose a swap partition",
+            _ => "Choose an existing pool",
+        }.into());
+        state.set_explanation(match role.as_str() {
+            "disk" => "All partitions on this disk will be erased during installation.",
+            "efi_partition" => "Reuse an existing EFI filesystem. Bootloader files will be written here.",
+            "pool" => "Choose a pool for a new boot environment. Discovery does not import or modify pools.",
+            _ => "The selected partition's contents will be replaced during installation.",
+        }.into());
+        state.set_filter("".into());
+        state.set_selected(current(&cfg.borrow(), &role).into());
+        state.set_visible(true);
+        populate(&app, &cfg.borrow());
+        scan(&app, role == "pool");
+    });
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    app.global::<StorageState>().on_inventory_changed(move || {
+        if let Some(app) = weak.upgrade() {
+            populate(&app, &cfg.borrow());
+            refresh_items(&app, &cfg.borrow());
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<StorageState>().on_refresh(move || {
+        if let Some(app) = weak.upgrade() {
+            scan(&app, app.global::<StorageState>().get_role() == "pool");
+        }
+    });
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    app.global::<StorageState>().on_filter_changed(move || {
+        if let Some(app) = weak.upgrade() {
+            populate(&app, &cfg.borrow());
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<StorageState>().on_choose(move |key| {
+        if let Some(app) = weak.upgrade() {
+            use slint::Model;
+            let state = app.global::<StorageState>();
+            if let Some(row) = state
+                .get_candidates()
+                .iter()
+                .find(|r| r.key == key && r.unavailable.is_empty())
+            {
+                state.set_selected(key);
+                state.set_selected_name(row.name);
+                state.set_selected_details(row.details);
+            }
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<StorageState>().on_move(move |direction| {
+        if let Some(app) = weak.upgrade() {
+            use slint::Model;
+            let state = app.global::<StorageState>();
+            let rows: Vec<_> = state
+                .get_candidates()
+                .iter()
+                .filter(|r| r.unavailable.is_empty())
+                .collect();
+            if rows.is_empty() {
+                return;
+            }
+            let current = rows
+                .iter()
+                .position(|r| r.key == state.get_selected())
+                .map(|i| i as i32)
+                .unwrap_or(if direction > 0 { -1 } else { 0 });
+            let next = (current + direction).rem_euclid(rows.len() as i32) as usize;
+            state.invoke_choose(rows[next].key.clone());
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<StorageState>().on_cancel(move || {
+        if let Some(app) = weak.upgrade() {
+            let state = app.global::<StorageState>();
+            // A late scan must not rebuild the form after focus has returned.
+            state.set_generation(state.get_generation() + 1);
+            state.set_busy(false);
+            state.set_visible(false);
+            crate::refresh::focus_item(&app, &format!("storage:{}", state.get_role()));
+        }
+    });
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    app.global::<StorageState>().on_confirm(move || {
+        if let Some(app) = weak.upgrade() {
+            use slint::Model;
+            let state = app.global::<StorageState>();
+            if state.get_busy() {
+                return;
+            }
+            let Some(row) = state
+                .get_candidates()
+                .iter()
+                .find(|r| r.key == state.get_selected() && r.unavailable.is_empty())
+            else {
+                return;
+            };
+            let mut c = cfg.borrow_mut();
+            let role = state.get_role();
+            if role == "pool" {
+                c.pool_name = Some(row.key.to_string());
+            } else if let Some(setting) = DeviceSetting::parse(&role) {
+                apply_device(&mut c, setting, Path::new(row.key.as_str()));
+            }
+            refresh_items(&app, &c);
+            state.set_visible(false);
+            crate::refresh::focus_item(&app, &format!("storage:{role}"));
+        }
+    });
+    if !crate::preview::enabled() {
+        scan(app, false);
+    }
+}
+fn scan(app: &App, pools: bool) {
+    let state = app.global::<StorageState>();
+    let generation = state.get_generation() + 1;
+    state.set_generation(generation);
+    state.set_busy(true);
+    state.set_error("".into());
+    let weak = app.as_weak();
+    tokio::spawn(async move {
+        // Only plain owned Rust data crosses the worker/event-loop boundary.
+        let result = tokio::time::timeout(std::time::Duration::from_secs(20), async {
+            if pools {
+                let (pools, datasets) = pool_inventory().await?;
+                Ok::<_, String>((Vec::new(), Vec::new(), pools, datasets))
+            } else {
+                tokio::task::spawn_blocking(|| {
+                    let disks = if crate::preview::enabled() {
+                        crate::preview::disks()
+                    } else {
+                        device::disk_choices().map_err(|e| e.to_string())?
+                    };
+                    let parts = if crate::preview::enabled() {
+                        crate::preview::partitions()
+                    } else {
+                        device::partition_choices().map_err(|e| e.to_string())?
+                    };
+                    Ok((disks, parts, Vec::new(), Vec::new()))
+                })
+                .await
+                .map_err(|e| e.to_string())?
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            Err("Storage discovery timed out. Check the devices and retry.".into())
+        });
+        let _ = weak.upgrade_in_event_loop(move |app| {
+            let state = app.global::<StorageState>();
+            if state.get_generation() != generation {
+                return;
+            }
+            state.set_busy(false);
+            match result {
+                Ok((disks, parts, found, datasets)) => INVENTORY.with_borrow_mut(|i| {
+                    if pools {
+                        i.datasets = datasets;
+                        i.pools = found
+                            .into_iter()
+                            .map(|(name, status, details, blocked)| StorageCandidate {
+                                key: name.clone().into(),
+                                name: name.into(),
+                                group: "ZFS pools".into(),
+                                label: status.into(),
+                                details: details.into(),
+                                unavailable: blocked.into(),
+                                ..Default::default()
+                            })
+                            .collect();
+                    } else {
+                        i.disks = disks;
+                        i.partitions = parts;
+                    }
+                }),
+                Err(e) => {
+                    state.set_error(e.into());
+                    INVENTORY.with_borrow_mut(|i| {
+                        if pools {
+                            i.pools.clear()
+                        } else {
+                            i.disks.clear();
+                            i.partitions.clear();
+                        }
+                    });
+                }
+            }
+            state.invoke_inventory_changed();
+        });
+    });
+}
+type PoolRow = (String, String, String, String);
+async fn pool_inventory() -> Result<(Vec<PoolRow>, Vec<String>), String> {
+    if crate::preview::enabled() {
+        return Ok((vec![
+            ("zroot".into(), "ONLINE — imported".into(), "Samsung SSD 990 PRO 2TB\nAvailable: 800 GiB\nExisting environment: zroot/previous".into(), "".into()),
+            ("backup-workstation".into(), "ONLINE — available for import".into(), "Pool GUID: 12450716\nSpace and datasets cannot be inspected until import.\nImported during installation; discovery makes no changes.".into(), "".into()),
+        ],vec!["zroot/previous".into()]));
+    }
+    let zfs = zfskit::Zfs::new();
+    let imported = zfs
+        .list_pools(&Default::default())
+        .await
+        .map_err(|e| e.to_string())?;
+    let available = zfs
+        .discover_importable_pools()
+        .await
+        .map_err(|e| e.to_string())?;
+    let datasets = if imported.is_empty() {
+        Vec::new()
+    } else {
+        zfs.list_datasets(&zfskit::dataset::ListOptions {
+            recursive: true,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .map(|d| d.name)
+        .collect::<Vec<_>>()
+    };
+    let mut rows = Vec::new();
+    fn paths(v: &zfskit::models::VdevStatus, output: &mut Vec<String>) {
+        if let Some(path) = &v.path {
+            output.push(path.clone());
+        }
+        for child in v.vdevs.values() {
+            paths(child, output);
+        }
+    }
+    for p in imported {
+        let status = zfs
+            .pool(&p.name)
+            .map_err(|e| e.to_string())?
+            .status()
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut devices = Vec::new();
+        for v in status.vdevs.values() {
+            paths(v, &mut devices);
+        }
+        devices.sort();
+        let free = p
+            .properties
+            .get("free")
+            .and_then(|p| p.value.parse::<u64>().ok())
+            .map(|bytes| format!("{:.1} GiB", bytes as f64 / 1073741824.0))
+            .unwrap_or_else(|| "Unknown".into());
+        rows.push((
+            p.name.clone(),
+            format!("{} — imported", p.state),
+            format!(
+                "Pool GUID: {}\nAvailable: {}\n{}",
+                p.pool_guid,
+                free,
+                devices.join(", ")
+            ),
+            if p.state == "ONLINE" {
+                "".into()
+            } else {
+                "Pool must be ONLINE before installation".into()
+            },
+        ));
+    }
+    for p in available {
+        rows.push((
+            p.name.clone(),
+            format!("{} — available for import", p.state),
+            format!(
+                "Pool GUID: {}\n{}\nSpace and datasets cannot be inspected until import.",
+                p.id,
+                p.status
+                    .unwrap_or_else(|| "Imported during installation".into())
+            ),
+            if p.state == "ONLINE" {
+                "".into()
+            } else {
+                "Pool must be ONLINE before installation".into()
+            },
+        ));
+    }
+    let names: Vec<_> = rows.iter().map(|r| r.0.clone()).collect();
+    for row in &mut rows {
+        if names.iter().filter(|n| **n == row.0).count() > 1 {
+            row.3 = "Multiple pools have this name; resolve the ambiguity first".into();
+        }
+    }
+    Ok((rows, datasets))
+}
+
+/// Review uses the same eligibility rules as the picker, including loaded configs.
+pub fn issues(c: &GlobalConfig) -> Vec<String> {
+    let roles = if c.installation_mode == Some(InstallationMode::FullDisk) {
+        vec![("disk", c.disk.as_deref())]
+    } else {
+        let mut roles = vec![("efi_partition", c.efi_partition.as_deref())];
+        if c.installation_mode == Some(InstallationMode::NewPool) {
+            roles.push(("zfs_partition", c.zfs_partition.as_deref()));
+        }
+        if matches!(
+            c.swap_mode,
+            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+        ) {
+            roles.push(("swap_partition", c.swap_partition.as_deref()));
+        }
+        roles
+    };
+    let mut issues: Vec<String> = roles
+        .into_iter()
+        .filter_map(|(role, path)| {
+            let path = path?;
+            let choices = choices(role);
+            Some(match choices.iter().find(|d| same_device(&d.path, path)) {
+                Some(choice) => {
+                    let reason = unavailable(choice, role, c);
+                    if reason.is_empty() {
+                        return None;
+                    }
+                    format!("{}: {reason}", role_label(role))
+                }
+                None => format!(
+                    "{}: selected device is unavailable. Open the selector and refresh.",
+                    role_label(role)
+                ),
+            })
+        })
+        .collect();
+    if c.installation_mode == Some(InstallationMode::ExistingPool)
+        && let Some(name) = &c.pool_name
+    {
+        INVENTORY.with_borrow(|i| {
+            match i.pools.iter().find(|p| p.name.as_str() == name) {
+                None => issues.push("Choose or refresh the existing pool before installing".into()),
+                Some(p) if !p.unavailable.is_empty() => issues.push(p.unavailable.to_string()),
+                _ => {}
+            }
+            let be = archinstall_zfs_core::boot_environment::BootEnvironment::new(
+                name,
+                &c.dataset_prefix,
+            )
+            .base();
+            if i.datasets.contains(&be) {
+                issues.push(format!(
+                    "Boot environment {be} already exists. Choose a different name."
+                ));
+            }
+        });
+    }
+    issues
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn picker_rejects_active_devices_and_conflicting_roles() {
+        let parts = crate::preview::partitions();
+        let efi = parts.iter().find(|p| p.label == "/dev/nvme0n1p1").unwrap();
+        let data = parts.iter().find(|p| p.label == "/dev/nvme0n1p2").unwrap();
+        let c = GlobalConfig {
+            installation_mode: Some(InstallationMode::NewPool),
+            efi_partition: Some(efi.path.clone()),
+            zfs_partition: Some(data.path.clone()),
+            ..Default::default()
+        };
+        assert!(unavailable(efi, "efi_partition", &c).is_empty());
+        assert!(unavailable(efi, "zfs_partition", &c).contains("Assigned"));
+        assert!(!unavailable(data, "efi_partition", &c).is_empty());
+        assert!(unavailable(data, "zfs_partition", &c).is_empty());
+        assert!(
+            parts
+                .iter()
+                .filter(|p| p.removable)
+                .all(|p| unavailable(p, "zfs_partition", &c).starts_with("In use:"))
+        );
+        assert!(
+            crate::preview::disks()
+                .iter()
+                .filter(|p| p.removable)
+                .all(|p| !unavailable(p, "disk", &c).is_empty())
+        );
+    }
+    #[test]
+    fn missing_filesystem_information_is_not_assumed_to_be_efi() {
+        let mut part = crate::preview::partitions().remove(0);
+        part.usage = Default::default();
+        assert!(!unavailable(&part, "efi_partition", &GlobalConfig::default()).is_empty());
+        assert!(unavailable(&part, "zfs_partition", &GlobalConfig::default()).is_empty());
+    }
+}

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -89,7 +89,7 @@ export component App inherits Window {
     callback reboot-requested();
     callback shell-requested();
     callback cancel-requested();
-    callback user-added(string, string, bool); // username, password, sudo
+    callback user-added(string, string, bool) -> bool; // username, password, sudo
     callback user-removed(int);
     callback user-sudo-toggled(int);
     callback key-nav-down();
@@ -231,7 +231,7 @@ export component App inherits Window {
         popup-visible: PopupState.users-visible;
 
         user-added(username, password, sudo) => {
-            root.user-added(username, password, sudo);
+            return root.user-added(username, password, sudo);
         }
         user-removed(index) => { root.user-removed(index); }
         user-sudo-toggled(index) => { root.user-sudo-toggled(index); }

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -1,3 +1,7 @@
+import { Palette as StandardPalette } from "std-widgets.slint";
+import { StorageState, StorageCandidate } from "state/storage-state.slint";
+export { StorageState, StorageCandidate }
+import { StoragePicker } from "popups/storage-picker.slint";
 import { ListView, ScrollView } from "std-widgets.slint";
 
 import { Catppuccin, Theme } from "styling.slint";
@@ -43,10 +47,12 @@ import { InstallView } from "views/install-view.slint";
 // ── Main application ─────────────────────────────────
 
 export component App inherits Window {
+    default-font-size: 14px;
     in property <bool> preview-mode: false;
+    init => { StandardPalette.color-scheme = Catppuccin.is-dark ? ColorScheme.dark : ColorScheme.light; }
     property <bool> popup-open: PopupState.select-visible || PopupState.text-input-visible
         || PopupState.users-visible || PopupState.pkg-search-visible || PopupState.strlist-visible
-        || PopupState.multi-select-visible || PopupState.wifi-visible || DemoState.popup-visible;
+        || PopupState.multi-select-visible || PopupState.wifi-visible || DemoState.popup-visible || StorageState.visible;
     changed popup-open => {
         if !root.popup-open && InstallState.state == 0 { main-focus-scope.focus(); }
     }
@@ -72,6 +78,7 @@ export component App inherits Window {
 
     // Callbacks to Rust
     callback item-activated(string);
+    callback inline-edited(string,string);
     callback select-confirmed(string, int);
     callback select-filter-changed(string, string); // (select-key, filter-text)
     callback text-confirmed(string, string);
@@ -94,14 +101,6 @@ export component App inherits Window {
                 if text == "j" || text == Key.DownArrow { key-nav-down(); return true; }
                 if text == "k" || text == Key.UpArrow { key-nav-up(); return true; }
                 if text == Key.Return { key-nav-activate(); return true; }
-            }
-            if text == Key.Tab {
-                WizardState.next();
-                return true;
-            }
-            if text == Key.Backtab {
-                WizardState.back();
-                return true;
             }
             if text == "q" {
                 quit-requested();
@@ -130,7 +129,7 @@ export component App inherits Window {
             && !PopupState.pkg-search-visible
             && !PopupState.strlist-visible
             && !PopupState.multi-select-visible
-            && !PopupState.wifi-visible;
+            && !PopupState.wifi-visible && !StorageState.visible;
         key-pressed(e) => {
             if root.handle-global-key(e.text) { return accept; }
             return reject;
@@ -162,6 +161,7 @@ export component App inherits Window {
         y: DemoState.enabled || root.preview-mode ? 32px : 0px;
         height: root.height - self.y;
         item-activated(key) => { item-activated(key); }
+        inline-edited(key,value) => { inline-edited(key,value); }
         toggle-activated(key) => { toggle-activated(key); }
         install-requested() => { install-requested(); }
         quit-requested() => { quit-requested(); }
@@ -305,4 +305,5 @@ export component App inherits Window {
             vertical-alignment: center;
         }
     }
+    if StorageState.visible: StoragePicker { }
 }

--- a/slint-ui/ui/components/check-box.slint
+++ b/slint-ui/ui/components/check-box.slint
@@ -14,6 +14,7 @@ export component CheckBox inherits Rectangle {
     in-out property <bool> checked;
     in property <bool> enabled: true;
 
+    out property <bool> has-focus: touch-area.has-focus;
     callback toggled();
 
     height: 24px;
@@ -22,7 +23,7 @@ export component CheckBox inherits Rectangle {
     accessible-role: checkbox;
     accessible-checkable: true;
     accessible-checked <=> root.checked;
-    accessible-label <=> root.label;
+    accessible-label: root.label;
     accessible-enabled <=> root.enabled;
     accessible-action-default => { touch-area.clicked(); }
 
@@ -81,6 +82,8 @@ export component CheckBox inherits Rectangle {
     }
 
     states [
-        disabled when !root.enabled: { root.opacity: 0.5; }
+        disabled when !root.enabled: {
+            root.opacity: 0.5;
+        }
     ]
 }

--- a/slint-ui/ui/components/config-item.slint
+++ b/slint-ui/ui/components/config-item.slint
@@ -1,3 +1,4 @@
+import { StyledButton } from "styled-button.slint";
 // Renders one row of the wizard's config-items list. The visual appearance
 // depends on the row's ItemType. Field types (text/select/password/toggle/
 // radio-option/readonly) are rendered as connected section cards: every
@@ -89,7 +90,7 @@ export component ConfigItemRow inherits Rectangle {
 
     height: is-separator ? 8px
           : is-warning ? max(32px, warning-text.preferred-height + 16px)
-          : is-section-header ? 36px
+          : is-section-header ? (item.key != "" ? 52px : 36px)
           : is-radio-subheader ? (has-secondary-text ? 48px : 40px)
           : is-grouped-radio-option ? (has-secondary-text ? 62px : 44px)
           : is-radio-option ? (has-choice-details ? 86px : has-secondary-text ? 62px : 44px)
@@ -138,17 +139,22 @@ export component ConfigItemRow inherits Rectangle {
     // ── Section header (small uppercase label above the connected card) ──
     if is-section-header: HorizontalLayout {
         padding-left: 4px;
-        padding-top: 14px;
+        padding-top: 8px;
         padding-bottom: 6px;
-        alignment: start;
+        spacing: 12px;
 
         Text {
-            text: item.label.to-uppercase();
-            color: Theme.c.overlay0;
-            font-size: 11px;
+            text: item.label;
+            color: Theme.c.subtext1;
+            font-size: 14px;
             font-weight: FontWeight.semi-bold;
-            letter-spacing: 0.6px;
-            vertical-alignment: bottom;
+            vertical-alignment: center;
+            horizontal-stretch: 1;
+        }
+        if item.key != "": StyledButton {
+            label: "Edit"; accessible-label: "Edit " + item.label;
+            height: 36px; outlined: true;
+            clicked => { root.activated(item.key); }
         }
     }
 
@@ -387,18 +393,9 @@ export component ConfigItemRow inherits Rectangle {
         }
     }
     if is-readonly && !has-device-secondary-text: HorizontalLayout {
-        padding-left: 14px;
-        padding-right: 14px;
-        spacing: 12px;
-        Text {
-            text: item.label; color: Theme.c.subtext0; font-size: 13px;
-            vertical-alignment: center; horizontal-stretch: 0;
-        }
-        Text {
-            text: item.value; color: item.is-empty ? Theme.c.overlay0 : Theme.c.text;
-            font-size: 13px; vertical-alignment: center;
-            horizontal-alignment: right; horizontal-stretch: 1; overflow: elide;
-        }
+        padding-left: 12px; padding-right: 12px; spacing: 16px;
+        Text { text: item.label; color: Theme.c.subtext1; font-size: 14px; vertical-alignment: center; width: 180px; wrap: word-wrap; }
+        Text { text: item.value; color: Theme.c.text; font-size: 14px; vertical-alignment: center; horizontal-stretch: 1; overflow: elide; }
     }
 
     // ── Normal config items (text, select, password, toggle) ──
@@ -463,6 +460,7 @@ export component ConfigItemRow inherits Rectangle {
         accessible-action-default => { root.activate(); }
     }
     row-ta := TouchArea {
+        enabled: !is-non-interactive;
         mouse-cursor: is-non-interactive ? default : pointer;
         clicked => { root.activate(); }
     }

--- a/slint-ui/ui/components/config-item.slint
+++ b/slint-ui/ui/components/config-item.slint
@@ -1,3 +1,4 @@
+import { CheckBox } from "check-box.slint";
 import { StyledButton } from "styled-button.slint";
 // Renders one row of the wizard's config-items list. The visual appearance
 // depends on the row's ItemType. Field types (text/select/password/toggle/
@@ -73,6 +74,7 @@ export component ConfigItemRow inherits Rectangle {
     property <bool> is-radio-option: item.item-type == ItemType.radio-option;
     property <bool> is-grouped-radio-option: is-radio-option && item.group-label != "";
     property <bool> is-readonly: item.item-type == ItemType.readonly;
+    property <bool> is-editor: item.item-type == ItemType.text || item.item-type == ItemType.select || item.item-type == ItemType.password || is-toggle;
     property <bool> is-toggle: item.item-type == ItemType.toggle;
     property <bool> has-choice-details: item.icon != "" || is-grouped-radio-option;
     property <bool> has-device-secondary-text: item.detail-model != ""
@@ -89,15 +91,16 @@ export component ConfigItemRow inherits Rectangle {
         || is-radio-subheader;
 
     height: is-separator ? 8px
-          : is-warning ? max(32px, warning-text.preferred-height + 16px)
-          : is-section-header ? (item.key != "" ? 52px : 36px)
-          : is-radio-subheader ? (has-secondary-text ? 48px : 40px)
-          : is-grouped-radio-option ? (has-secondary-text ? 62px : 44px)
-          : is-radio-option ? (has-choice-details ? 86px : has-secondary-text ? 62px : 44px)
-          : is-action ? 40px
-          : is-readonly && has-device-secondary-text ? 92px
-          : is-readonly && has-secondary-text ? 52px
-          : 44px;
+        : is-warning ? max(32px, warning-text.preferred-height + 16px)
+        : is-section-header ? (item.key != "" ? 52px : 36px)
+        : is-radio-subheader ? (has-secondary-text ? 48px : 40px)
+        : is-grouped-radio-option ? (has-secondary-text ? 62px : 44px)
+        : is-radio-option ? (has-choice-details ? 86px : has-secondary-text ? 62px : 44px)
+        : is-action ? 40px
+        : is-editor ? max(56px, editor-content.min-height)
+        : is-readonly && has-device-secondary-text ? 92px
+        : is-readonly && has-secondary-text ? 52px
+        : 44px;
 
     // Section card background — only field rows draw it. Corner radius is
     // applied conditionally per-corner so adjacent rows in the same section
@@ -151,9 +154,12 @@ export component ConfigItemRow inherits Rectangle {
             vertical-alignment: center;
             horizontal-stretch: 1;
         }
+
         if item.key != "": StyledButton {
-            label: "Edit"; accessible-label: "Edit " + item.label;
-            height: 36px; outlined: true;
+            label: "Edit";
+            accessible-label: "Edit " + item.label;
+            height: 36px;
+            outlined: true;
             clicked => { root.activated(item.key); }
         }
     }
@@ -173,6 +179,7 @@ export component ConfigItemRow inherits Rectangle {
             font-size: 14px;
             vertical-alignment: center;
         }
+
         warning-text := Text {
             text: item.value;
             color: Theme.c.yellow;
@@ -303,6 +310,7 @@ export component ConfigItemRow inherits Rectangle {
                     horizontal-stretch: 1;
                     overflow: elide;
                 }
+
                 if item.detail-size != "": Text {
                     text: item.detail-size;
                     color: Theme.c.text;
@@ -322,6 +330,7 @@ export component ConfigItemRow inherits Rectangle {
                     horizontal-stretch: 1;
                     overflow: elide;
                 }
+
                 Text {
                     text: item.detail-transport.to-uppercase() + (item.is-removable ? " · Removable" : " · " + item.detail-media);
                     color: item.is-removable ? Theme.c.yellow : Theme.c.subtext0;
@@ -373,78 +382,119 @@ export component ConfigItemRow inherits Rectangle {
         spacing: 5px;
         HorizontalLayout {
             spacing: 12px;
-            Text { text: item.label; color: Theme.c.subtext0; font-size: 13px; }
+            Text {
+                text: item.label;
+                color: Theme.c.subtext0;
+                font-size: 13px;
+            }
+
             Text {
                 text: item.detail-model != "" ? item.detail-model : item.value;
-                color: Theme.c.text; font-size: 13px; font-weight: FontWeight.semi-bold;
-                horizontal-stretch: 1; horizontal-alignment: right; overflow: elide;
+                color: Theme.c.text;
+                font-size: 13px;
+                font-weight: FontWeight.semi-bold;
+                horizontal-stretch: 1;
+                horizontal-alignment: right;
+                overflow: elide;
             }
-            Text { text: item.detail-size; color: Theme.c.text; font-size: 13px; }
+
+            Text {
+                text: item.detail-size;
+                color: Theme.c.text;
+                font-size: 13px;
+            }
         }
+
         Text {
             text: item.value + (item.detail-serial != "" ? " · SN " + item.detail-serial : "")
                 + (item.is-removable ? " · Removable" : "");
             color: item.is-removable ? Theme.c.yellow : Theme.c.subtext0;
-            font-size: 12px; overflow: elide;
+            font-size: 12px;
+            overflow: elide;
         }
+
         Text {
             text: item.persistent-path;
-            color: Theme.c.overlay0; font-size: 11px; overflow: elide;
+            color: Theme.c.overlay0;
+            font-size: 11px;
+            overflow: elide;
         }
     }
     if is-readonly && !has-device-secondary-text: HorizontalLayout {
-        padding-left: 12px; padding-right: 12px; spacing: 16px;
-        Text { text: item.label; color: Theme.c.subtext1; font-size: 14px; vertical-alignment: center; width: 180px; wrap: word-wrap; }
-        Text { text: item.value; color: Theme.c.text; font-size: 14px; vertical-alignment: center; horizontal-stretch: 1; overflow: elide; }
-    }
-
-    // ── Normal config items (text, select, password, toggle) ──
-    //
-    // Layout: label on the left at its natural width, value column on the
-    // right with stretch + elide. When the value is long ("one, two, three,
-    // ...") it truncates with `…` instead of overflowing the row past the
-    // right padding.
-    if item.item-type == ItemType.text || item.item-type == ItemType.select
-        || item.item-type == ItemType.password || is-toggle: HorizontalLayout {
-        padding-left: 14px;
-        padding-right: 14px;
-        spacing: 12px;
-
+        padding-left: 12px;
+        padding-right: 12px;
+        spacing: 16px;
         Text {
             text: item.label;
             color: Theme.c.subtext1;
             font-size: 14px;
             vertical-alignment: center;
-            horizontal-stretch: 0;
+            width: 180px;
+            wrap: word-wrap;
         }
 
-        HorizontalLayout {
-            spacing: 6px;
+        Text {
+            text: item.value;
+            color: Theme.c.text;
+            font-size: 14px;
+            vertical-alignment: center;
             horizontal-stretch: 1;
+            overflow: elide;
+        }
+    }
 
-
-
+    // Keep values beside their labels; explicit controls expose the action.
+    editor-content := VerticalLayout {
+        visible: is-editor;
+        padding-left: 12px;
+        padding-right: 12px;
+        padding-top: 8px;
+        padding-bottom: 8px;
+        spacing: 6px;
+        HorizontalLayout {
+            spacing: 16px;
             Text {
-                text: item.value;
-                color: item.is-empty ? Theme.c.overlay0 : Theme.c.green;
-                font-size: 14px;
+                text: item.label;
+                color: Theme.c.text;
+                font-size: 15px;
+                font-weight: 600;
+                width: 180px;
                 vertical-alignment: center;
-                horizontal-alignment: right;
+                wrap: word-wrap;
+            }
+
+            if !is-toggle: Text {
+                text: item.value;
+                color: Theme.c.text;
+                font-size: 15px;
+                vertical-alignment: center;
                 horizontal-stretch: 1;
                 overflow: elide;
             }
-            if is-toggle: RadioDot {
-                width: 14px;
-                dot-size: 10px;
-                filled: item.value == "Enabled";
-                dot-color: item.value == "Enabled" ? Theme.c.green : Theme.c.overlay0;
-                horizontal-stretch: 0;
+            if is-toggle: CheckBox {
+                height: 40px;
+                horizontal-stretch: 1;
+                label: item.value;
+                accessible-label: item.label;
+                checked: item.value == "Enabled";
+                changed has-focus => { if self.has-focus { root.focus-requested(index); root.ensure-visible(root.y, root.height); } }
+                toggled => { root.activate(); }
             }
-            if !is-toggle: Text {
-                text: "›"; color: Theme.c.overlay0; font-size: 18px;
-                width: 14px; vertical-alignment: center;
+            if !is-toggle: StyledButton {
+                label: item.key == "users" || item.key == "packages" || item.key == "extra_services" || item.key == "optional_packages" ? "Manage" : "Change";
+                accessible-label: item.label;
+                height: 40px;
+                outlined: true;
+                changed has-focus => { if self.has-focus { root.focus-requested(index); root.ensure-visible(root.y, root.height); } }
+                clicked => { root.activate(); }
             }
+        }
 
+        if item.description != "": Text {
+            text: item.description;
+            color: Theme.c.subtext1;
+            font-size: 13px;
+            wrap: word-wrap;
         }
     }
 
@@ -454,13 +504,13 @@ export component ConfigItemRow inherits Rectangle {
         else if is-toggle { root.toggled(item.key); }
         else if !is-non-interactive { root.activated(item.key); }
     }
-    if !is-non-interactive: Rectangle {
+    if !is-non-interactive && !is-editor: Rectangle {
         accessible-role: button;
         accessible-label: item.label + (has-choice-details ? " " + item.detail-model + " " + item.persistent-path : "");
         accessible-action-default => { root.activate(); }
     }
     row-ta := TouchArea {
-        enabled: !is-non-interactive;
+        enabled: !is-non-interactive && !is-editor;
         mouse-cursor: is-non-interactive ? default : pointer;
         clicked => { root.activate(); }
     }

--- a/slint-ui/ui/components/setup-row.slint
+++ b/slint-ui/ui/components/setup-row.slint
@@ -1,0 +1,102 @@
+import { WizardState } from "../state/wizard-state.slint";
+import { ComboBox } from "std-widgets.slint";
+import { Theme } from "../styling.slint";
+import { ConfigItem, ItemType } from "../types.slint";
+import { StyledButton } from "styled-button.slint";
+import { StyledTextInput } from "styled-text-input.slint";
+
+export component SetupRow inherits Rectangle {
+    in property <ConfigItem> item;
+    in property <int> row-index;
+    callback ensure-visible(length);
+    callback activated(string);
+    callback edited(string, string);
+    background: Theme.c.surface0.with-alpha(0.55);
+    border-radius: 8px;
+    height: max(item.item-type == ItemType.storage ? 104px : 64px, contents.min-height);
+    vertical-stretch: 0;
+    contents := VerticalLayout {
+        padding: 12px;
+        spacing: 6px;
+        HorizontalLayout {
+            spacing: 16px;
+            Text {
+                text: item.label;
+                color: Theme.c.text;
+                font-size: 15px;
+                font-weight: 600;
+                width: 180px;
+                vertical-alignment: center;
+                wrap: word-wrap;
+            }
+
+            if item.item-type == ItemType.storage: Text {
+                text: item.value;
+                font-size: 15px;
+                color: item.is-empty ? Theme.c.subtext1 : Theme.c.text;
+                font-weight: 600;
+                horizontal-stretch: 1;
+                overflow: elide;
+                vertical-alignment: center;
+            }
+            if item.item-type == ItemType.storage && item.detail-size != "": Text {
+                text: item.detail-size;
+                color: Theme.c.text;
+                vertical-alignment: center;
+                horizontal-alignment: right;
+                width: 90px;
+            }
+            if item.item-type == ItemType.storage && item.key != "": StyledButton {
+                label: item.is-empty ? "Choose" : "Change";
+                height: 40px;
+                outlined: true;
+                accessible-label: self.label + " " + item.label;
+                changed has-focus => { if self.has-focus { root.ensure-visible(root.y + root.height); } }
+                property <int> row-focus: WizardState.focused-index;
+                init => { if self.row-focus == root.row-index { self.focus-button(); } }
+                changed row-focus => { if self.row-focus == root.row-index { self.focus-button(); } }
+                clicked => { root.activated(item.key); }
+            }
+            if item.item-type == ItemType.inline-text || item.item-type == ItemType.inline-password: StyledTextInput {
+                height: 40px;
+                horizontal-stretch: 1;
+                font-size: 15px;
+                is-password: item.item-type == ItemType.inline-password;
+                placeholder: self.is-password ? item.value : item.label;
+                text: self.is-password ? "" : item.value;
+                accessible-label: item.label;
+                changed has-focus => { if self.has-focus { root.ensure-visible(root.y + root.height); } }
+                property <int> row-focus: WizardState.focused-index;
+                init => { if self.row-focus == root.row-index { self.focus-input(); } }
+                changed row-focus => { if self.row-focus == root.row-index { self.focus-input(); } }
+                edited(value) => { root.edited(item.key,value); }
+                accepted(value) => { root.edited(item.key,value); }
+            }
+            if item.item-type == ItemType.compact-choice: ComboBox {
+                height: 40px;
+                horizontal-stretch: 1;
+                model: item.choices;
+                current-index: item.choice-index;
+                accessible-label: item.label;
+                changed has-focus => { if self.has-focus { root.ensure-visible(root.y + root.height); } }
+                property <int> row-focus: WizardState.focused-index;
+                init => { if self.row-focus == root.row-index { self.focus(); } }
+                changed row-focus => { if self.row-focus == root.row-index { self.focus(); } }
+                selected(value) => { root.activated("radio:" + item.key + ":" + self.current-index); }
+            }
+        }
+
+        if item.detail-model != "": Text {
+            text: item.detail-model;
+            color: Theme.c.subtext1;
+            font-size: 13px;
+            overflow: elide;
+        }
+        if item.description != "": Text {
+            text: item.key == "dataset_prefix" ? "Create " + WizardState.environment-path : item.description;
+            font-size: 13px;
+            wrap: word-wrap;
+            color: item.item-type == ItemType.storage && !item.is-empty && item.destructive ? Theme.c.yellow : Theme.c.subtext1;
+        }
+    }
+}

--- a/slint-ui/ui/components/storage-mode.slint
+++ b/slint-ui/ui/components/storage-mode.slint
@@ -1,0 +1,48 @@
+import { Theme } from "../styling.slint";
+import { WizardState } from "../state/wizard-state.slint";
+import { FocusTouchArea } from "internal/state-layer.slint";
+export component StorageMode inherits Rectangle {
+    callback activated(string);
+    height: 106px;
+    HorizontalLayout {
+        spacing: 12px;
+        padding-top: 8px;
+        padding-bottom: 14px;
+        for label[index] in ["Erase a disk", "Use existing partitions", "Use an existing pool"]: Rectangle {
+            horizontal-stretch: 1;
+            background: WizardState.storage-mode == index ? Theme.c.blue.with-alpha(0.16) : Theme.c.surface0.with-alpha(0.55);
+            border-radius: 8px;
+            border-width: touch.has-focus ? 2px : 1px;
+            border-color: touch.has-focus || WizardState.storage-mode == index ? Theme.c.blue : Theme.c.surface1;
+            VerticalLayout {
+                padding: 12px;
+                spacing: 5px;
+                alignment: center;
+                Text {
+                    text: (WizardState.storage-mode == index ? "●  " : "○  ") + label;
+                    color: Theme.c.text;
+                    font-size: 15px;
+                    font-weight: 600;
+                    wrap: word-wrap;
+                }
+
+                Text {
+                    text: index == 0 ? "Create a new partition layout" : index == 1 ? "Create a new ZFS pool" : "Create a new boot environment";
+                    color: Theme.c.subtext1;
+                    font-size: 12px;
+                    wrap: word-wrap;
+                }
+            }
+
+            touch := FocusTouchArea {
+                width: 100%;
+                height: 100%;
+                accessible-role: radio-button;
+                accessible-label: label;
+                accessible-checked: WizardState.storage-mode == index;
+                accessible-action-default => { root.activated("radio:installation_mode:" + index); }
+                clicked => { root.activated("radio:installation_mode:" + index); }
+            }
+        }
+    }
+}

--- a/slint-ui/ui/components/styled-button.slint
+++ b/slint-ui/ui/components/styled-button.slint
@@ -1,9 +1,11 @@
 import { Theme, ButtonStyle } from "../styling.slint";
 import { AnimationSettings } from "../styling.slint";
 import { StateLayer, FocusTouchArea } from "internal/state-layer.slint";
+import { Icon } from "icon.slint";
 
 export component StyledButton {
     in property <string> label;
+    in property <image> icon-source;
     in property <ButtonStyle> style: Theme.button-default;
     in property <bool> enabled: true;
     in property <bool> outlined: false;
@@ -42,6 +44,18 @@ export component StyledButton {
     content-layout := HorizontalLayout {
         padding-left: Theme.spacing-md;
         padding-right: Theme.spacing-md;
+        spacing: 8px;
+        alignment: center;
+
+        if root.icon-source.width > 0: VerticalLayout {
+            horizontal-stretch: 0;
+            alignment: center;
+            Icon {
+                source: root.icon-source;
+                size: 18px;
+                tint: root.style.foreground;
+            }
+        }
 
         Text {
             text: root.label;

--- a/slint-ui/ui/components/styled-button.slint
+++ b/slint-ui/ui/components/styled-button.slint
@@ -8,7 +8,7 @@ export component StyledButton {
     in property <bool> enabled: true;
     in property <bool> outlined: false;
     in property <length> corner-radius: Theme.radius-sm;
-    in property <length> label-size: Theme.font-md;
+    in property <length> label-size: Theme.font-base;
 
     out property <bool> has-focus: touch-area.has-focus;
     public function focus-button() { touch-area.focus(); }

--- a/slint-ui/ui/components/styled-button.slint
+++ b/slint-ui/ui/components/styled-button.slint
@@ -10,6 +10,8 @@ export component StyledButton {
     in property <length> corner-radius: Theme.radius-sm;
     in property <length> label-size: Theme.font-md;
 
+    out property <bool> has-focus: touch-area.has-focus;
+    public function focus-button() { touch-area.focus(); }
     callback clicked <=> touch-area.clicked;
 
     min-width: max(80px, content-layout.min-width);
@@ -18,7 +20,7 @@ export component StyledButton {
     accessible-role: button;
     accessible-label: root.label;
     accessible-enabled: root.enabled;
-    accessible-action-default => { touch-area.clicked(); }
+    accessible-action-default => { if root.enabled { touch-area.clicked(); } }
 
     background-rect := Rectangle {
         background: root.style.background;

--- a/slint-ui/ui/popups/multi-select-popup.slint
+++ b/slint-ui/ui/popups/multi-select-popup.slint
@@ -12,6 +12,7 @@
 import { ScrollView } from "std-widgets.slint";
 import { Theme } from "../styling.slint";
 import { MultiSelectOption } from "../types.slint";
+import { FocusTouchArea } from "../components/internal/state-layer.slint";
 import { StyledButton } from "../components/styled-button.slint";
 
 export component MultiSelectPopup inherits Rectangle {
@@ -24,116 +25,136 @@ export component MultiSelectPopup inherits Rectangle {
 
     if popup-visible: Rectangle {
         background: #00000080;
-        width: 100%; height: 100%;
+        width: 100%;
+        height: 100%;
 
         TouchArea {
             clicked => { closed(); }
             scroll-event(e) => { return accept; }
         }
 
-        Rectangle {
-            x: (parent.width - self.width) / 2;
-            y: (parent.height - self.height) / 2;
-            width: min(540px, parent.width - 40px);
-            height: min(self.preferred-height, parent.height - 80px);
-            background: Theme.c.mantle;
-            border-radius: Theme.radius-md;
-            border-color: Theme.c.surface1;
-            border-width: 1px;
-            clip: true;
-            accessible-role: groupbox;
-            accessible-label: root.title;
+        FocusScope {
+            width: 100%;
+            height: 100%;
+            key-pressed(e) => { if e.text == Key.Escape { root.closed(); return accept; } return reject; }
+            Rectangle {
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+                width: min(640px, parent.width - 40px);
+                height: min(self.preferred-height, parent.height - 80px);
+                background: Theme.c.mantle;
+                border-radius: Theme.radius-md;
+                border-color: Theme.c.surface1;
+                border-width: 1px;
+                clip: true;
+                accessible-role: groupbox;
+                accessible-label: root.title;
 
-            VerticalLayout {
-                padding: Theme.spacing-lg;
-                spacing: Theme.spacing-sm;
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: 12px;
 
-                Text {
-                    text: root.title;
-                    color: Theme.c.blue;
-                    font-size: Theme.font-lg;
-                    font-weight: FontWeight.semi-bold;
-                    height: Theme.spacing-xl;
-                }
+                    Text {
+                        text: root.title;
+                        color: Theme.c.text;
+                        font-size: 24px;
+                        font-weight: FontWeight.semi-bold;
+                        wrap: word-wrap;
+                    }
 
-                // ScrollView pattern: preferred-height override exposes
+                    // ScrollView pattern: preferred-height override exposes
                 // content height to the parent layout, vertical-stretch
                 // (std default) absorbs the deficit when capped.
                 ScrollView {
-                    preferred-height: items-vbox.preferred-height;
-                    vertical-stretch: 1;
+                        preferred-height: items-vbox.preferred-height;
+                        vertical-stretch: 1;
 
-                    items-vbox := VerticalLayout {
-                        spacing: Theme.spacing-xs;
+                        items-vbox := VerticalLayout {
+                            spacing: Theme.spacing-xs;
 
-                        for option[index] in root.options: Rectangle {
-                            height: Theme.control-height;
-                            background: row-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
-                            border-radius: Theme.radius-sm;
+                            for option[index] in root.options: Rectangle {
+                                height: max(68px, row-content.min-height);
+                                accessible-role: checkbox;
+                                accessible-label: option.text;
+                                accessible-checked: option.checked;
+                                accessible-checkable: true;
+                                accessible-action-default => { root.toggled(index); }
+                                background: row-ta.has-hover || row-ta.has-focus ? Theme.c.surface1 : Theme.c.surface0;
+                                border-radius: Theme.radius-sm;
 
-                            row-ta := TouchArea {
-                                clicked => { root.toggled(index); }
-                            }
+                                row-ta := FocusTouchArea {
+                                    width: 100%;
+                                    height: 100%;
+                                    clicked => { root.toggled(index); }
+                                }
 
-                            HorizontalLayout {
-                                padding-left: Theme.spacing-md;
-                                padding-right: Theme.spacing-md;
-                                spacing: Theme.spacing-sm;
+                                row-content := HorizontalLayout {
+                                    padding-top: 10px;
+                                    padding-bottom: 10px;
+                                    padding-left: Theme.spacing-md;
+                                    padding-right: Theme.spacing-md;
+                                    spacing: 12px;
 
-                                // Inline checkbox visual. Click is owned
+                                    // Inline checkbox visual. Click is owned
                                 // by the row's TouchArea above so we don't
                                 // need an interactive CheckBox here.
                                 VerticalLayout {
-                                    alignment: center;
-                                    horizontal-stretch: 0;
+                                        alignment: center;
+                                        horizontal-stretch: 0;
 
-                                    Rectangle {
-                                        width: 16px;
-                                        height: 16px;
-                                        background: option.checked ? Theme.c.blue : transparent;
-                                        border-color: option.checked ? Theme.c.blue : Theme.c.overlay0;
-                                        border-width: 1.5px;
-                                        border-radius: 3px;
+                                        Rectangle {
+                                            width: 16px;
+                                            height: 16px;
+                                            background: option.checked ? Theme.c.blue : transparent;
+                                            border-color: option.checked ? Theme.c.blue : Theme.c.overlay0;
+                                            border-width: 1.5px;
+                                            border-radius: 3px;
 
-                                        if option.checked: Text {
-                                            text: "\u{2713}";
-                                            color: Theme.c.base;
-                                            font-size: 12px;
-                                            font-weight: FontWeight.bold;
-                                            horizontal-alignment: center;
-                                            vertical-alignment: center;
+                                            if option.checked: Text {
+                                                text: "\u{2713}";
+                                                color: Theme.c.base;
+                                                font-size: 12px;
+                                                font-weight: FontWeight.bold;
+                                                horizontal-alignment: center;
+                                                vertical-alignment: center;
+                                            }
                                         }
                                     }
-                                }
 
-                                Text {
-                                    text: option.text;
-                                    color: Theme.c.text;
-                                    font-size: Theme.font-base;
-                                    vertical-alignment: center;
-                                }
+                                    VerticalLayout {
+                                        horizontal-stretch: 1;
+                                        spacing: 4px;
+                                        alignment: center;
+                                        Text {
+                                            text: option.text;
+                                            color: Theme.c.text;
+                                            font-size: 15px;
+                                            font-weight: 600;
+                                            overflow: elide;
+                                        }
 
-                                if option.description != "": Text {
-                                    text: option.description;
-                                    color: Theme.c.overlay0;
-                                    font-size: Theme.font-sm;
-                                    vertical-alignment: center;
-                                    overflow: elide;
-                                    horizontal-stretch: 1;
+                                        if option.description != "": Text {
+                                            text: option.description;
+                                            color: Theme.c.subtext1;
+                                            font-size: 13px;
+                                            wrap: word-wrap;
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                HorizontalLayout {
-                    alignment: end;
+                    HorizontalLayout {
+                        alignment: end;
 
-                    StyledButton {
-                        label: "Done";
-                        min-width: 80px;
-                        style: Theme.button-primary;
-                        clicked => { root.closed(); }
+                        StyledButton {
+                            label: "Done";
+                            height: 40px;
+                            min-width: 80px;
+                            style: Theme.button-primary;
+                            clicked => { root.closed(); }
+                        }
                     }
                 }
             }

--- a/slint-ui/ui/popups/package-search-popup.slint
+++ b/slint-ui/ui/popups/package-search-popup.slint
@@ -3,7 +3,6 @@ import { Theme } from "../styling.slint";
 import { PackageSearchResult, PackageEntry } from "../types.slint";
 import { StyledButton } from "../components/styled-button.slint";
 import { StyledTextInput } from "../components/styled-text-input.slint";
-import { Badge } from "../components/badge.slint";
 
 export component PackageSearchPopup inherits Rectangle {
     in property <[PackageSearchResult]> search-results;
@@ -11,7 +10,6 @@ export component PackageSearchPopup inherits Rectangle {
     in property <bool> popup-visible;
     in property <bool> searching-aur: false;
     in property <string> status-text;
-
     callback search-changed(string);
     callback search-aur(string);
     callback package-added(int);
@@ -20,192 +18,191 @@ export component PackageSearchPopup inherits Rectangle {
 
     if popup-visible: Rectangle {
         background: #00000080;
-        width: 100%; height: 100%;
-
+        width: 100%;
+        height: 100%;
         TouchArea {
             clicked => { closed(); }
             scroll-event(e) => { return accept; }
         }
 
-        Rectangle {
-            x: (parent.width - self.width) / 2;
-            y: (parent.height - self.height) / 2;
-            width: min(600px, parent.width - 40px);
-            height: min(parent.height - 60px, 520px);
-            background: Theme.c.mantle;
-            border-radius: Theme.radius-md;
-            border-color: Theme.c.surface1;
-            border-width: 1px;
-            clip: true;
-            accessible-role: groupbox;
-            accessible-label: "Package search";
-
-            VerticalLayout {
-                padding: Theme.spacing-lg;
-                spacing: Theme.spacing-sm;
-
-                Text {
-                    text: root.searching-aur ? "AUR search" : "Package search";
-                    color: Theme.c.blue;
-                    font-size: Theme.font-lg;
-                    font-weight: FontWeight.semi-bold;
-                }
-
-                HorizontalLayout {
-                    spacing: Theme.spacing-sm;
-
-                    pkg-search-input := StyledTextInput {
-                        horizontal-stretch: 1;
-                        font-size: Theme.font-base;
-                        placeholder: "type to search packages...";
-                        height: Theme.control-height;
-                        edited(text) => { root.search-changed(text); }
+        FocusScope {
+            width: 100%;
+            height: 100%;
+            key-pressed(e) => { if e.text == Key.Escape { root.closed(); return accept; } return reject; }
+            Rectangle {
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+                width: min(760px, parent.width - 40px);
+                height: min(700px, parent.height - 40px);
+                background: Theme.c.mantle;
+                border-radius: 12px;
+                border-color: Theme.c.surface1;
+                border-width: 1px;
+                clip: true;
+                accessible-role: groupbox;
+                accessible-label: "Package search";
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: 12px;
+                    Text {
+                        text: "Extra packages";
+                        color: Theme.c.text;
+                        font-size: 24px;
+                        font-weight: 600;
                     }
-
-                    init => { pkg-search-input.focus-input(); }
-
-                    // AUR search button
-                    Rectangle {
-                        width: 60px;
-                        height: Theme.control-height;
-                        background: aur-btn-ta.has-hover ? Theme.c.mauve : Theme.c.surface0;
-                        border-radius: Theme.radius-sm;
-                        border-color: root.searching-aur ? Theme.c.mauve : Theme.c.surface1;
-                        border-width: 1px;
-
-                        aur-btn-ta := TouchArea {
-                            clicked => { root.search-aur(pkg-search-input.text); }
-                        }
-
-                        Text {
-                            text: "AUR";
-                            color: aur-btn-ta.has-hover ? Theme.c.base : (root.searching-aur ? Theme.c.mauve : Theme.c.subtext0);
-                            font-size: Theme.font-md;
-                            font-weight: FontWeight.semi-bold;
-                            horizontal-alignment: center;
-                            vertical-alignment: center;
-                        }
-                    }
-                }
-
-                if root.status-text != "": Text {
-                    text: root.status-text;
-                    color: Theme.c.overlay0;
-                    font-size: Theme.font-sm;
-                    height: Theme.spacing-lg;
-                }
-
-                ListView {
-                    vertical-stretch: 1;
-
-                    for result[index] in root.search-results: Rectangle {
-                        height: Theme.control-height;
-                        background: result-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
-                        border-radius: Theme.radius-sm;
-
-                        result-ta := TouchArea {
-                            clicked => {
-                                root.package-added(index);
-                                pkg-search-input.text = "";
-                                pkg-search-input.focus-input();
-                            }
-                        }
-
-                        HorizontalLayout {
-                            padding-left: Theme.spacing-md;
-                            padding-right: Theme.spacing-md;
-                            spacing: Theme.spacing-sm;
-
-                            Text {
-                                text: result.name;
-                                color: Theme.c.text;
-                                font-size: Theme.font-md;
-                                vertical-alignment: center;
-                            }
-
-                            VerticalLayout {
-                                alignment: center;
-                                Badge {
-                                    label: result.repo;
-                                    bg: result.repo == "aur" ? Theme.c.mauve : Theme.c.blue;
-                                }
-                            }
-
-                            Text {
-                                text: result.description;
-                                color: Theme.c.overlay0;
-                                font-size: Theme.font-sm;
-                                vertical-alignment: center;
-                                overflow: elide;
-                                horizontal-stretch: 1;
-                            }
-                        }
-                    }
-                }
-
-                if root.selected-packages.length > 0: Rectangle {
-                    height: 1px;
-                    background: Theme.c.surface1;
-                }
-
-                if root.selected-packages.length > 0: VerticalLayout {
-                    spacing: Theme.spacing-xs;
 
                     Text {
-                        text: "Selected";
-                        color: Theme.c.subtext0;
-                        font-size: Theme.font-sm;
-                        font-weight: FontWeight.semi-bold;
-                        height: Theme.spacing-lg;
+                        text: "Search repositories as you type, or search the AUR for community packages.";
+                        color: Theme.c.subtext1;
+                        font-size: 14px;
+                        wrap: word-wrap;
                     }
 
-                    // Wrapping chip cloud — FlexboxLayout flows chips onto
-                    // multiple lines instead of a single overflowing row.
-                    chips-flow := FlexboxLayout {
-                        flex-direction: row;
-                        flex-wrap: wrap;
-                        spacing: Theme.spacing-xs + 2px;
+                    HorizontalLayout {
+                        spacing: 12px;
+                        search := StyledTextInput {
+                            horizontal-stretch: 1;
+                            height: 40px;
+                            placeholder: "Search package names";
+                            accessible-label: "Search packages";
+                            edited(text) => { root.search-changed(text); }
+                            init => { self.focus-input(); root.search-changed(""); }
+                        }
 
-                        for pkg[index] in root.selected-packages: Rectangle {
-                            width: pkg-chip-layout.preferred-width;
-                            height: Theme.control-height-sm - 4px;
-                            background: pkg-del-ta.has-hover ? Theme.c.red : Theme.c.surface0;
-                            border-radius: Theme.radius-sm;
+                        StyledButton {
+                            label: root.searching-aur ? "Searching…" : "Search AUR";
+                            height: 40px;
+                            outlined: true;
+                            enabled: search.text != "" && !root.searching-aur;
+                            clicked => { root.search-aur(search.text); }
+                        }
+                    }
 
-                            pkg-del-ta := TouchArea {
-                                clicked => { root.package-removed(index); }
-                            }
+                    if root.status-text != "": Text {
+                        text: root.status-text;
+                        color: Theme.c.subtext1;
+                        font-size: 14px;
+                        wrap: word-wrap;
+                    }
+                    if root.search-results.length == 0 && root.status-text == "": Text {
+                        text: search.text == "" ? "Type a name to find packages to add." : "No matching packages. Try another name or search the AUR.";
+                        color: Theme.c.subtext1;
+                        font-size: 14px;
+                        wrap: word-wrap;
+                    }
+                    ListView {
+                        vertical-stretch: 1;
+                        for result[index] in root.search-results: Rectangle {
+                            height: max(76px, row.min-height);
+                            background: Theme.c.surface0;
+                            border-radius: 8px;
+                            row := HorizontalLayout {
+                                padding: 12px;
+                                spacing: 12px;
+                                VerticalLayout {
+                                    horizontal-stretch: 1;
+                                    spacing: 4px;
+                                    alignment: center;
+                                    HorizontalLayout {
+                                        spacing: 12px;
+                                        Text {
+                                            text: result.name;
+                                            color: Theme.c.text;
+                                            font-size: 15px;
+                                            font-weight: 600;
+                                            overflow: elide;
+                                            horizontal-stretch: 1;
+                                        }
 
-                            pkg-chip-layout := HorizontalLayout {
-                                padding-left: Theme.spacing-sm;
-                                padding-right: Theme.spacing-sm;
-                                spacing: Theme.spacing-xs;
+                                        Text {
+                                            text: result.repo;
+                                            color: Theme.c.subtext1;
+                                            font-size: 13px;
+                                        }
+                                    }
 
-                                Text {
-                                    text: pkg.name;
-                                    color: pkg-del-ta.has-hover ? Theme.c.base : Theme.c.text;
-                                    font-size: Theme.font-sm;
-                                    vertical-alignment: center;
+                                    Text {
+                                        text: result.description;
+                                        color: Theme.c.subtext1;
+                                        font-size: 13px;
+                                        wrap: word-wrap;
+                                    }
                                 }
 
-                                Text {
-                                    text: pkg.repo == "aur" ? "[aur]" : "[repo]";
-                                    color: pkg-del-ta.has-hover ? Theme.c.base : Theme.c.overlay0;
-                                    font-size: 10px;
-                                    vertical-alignment: center;
+                                VerticalLayout {
+                                    alignment: center;
+                                    StyledButton {
+                                        label: "Add";
+                                        height: 40px;
+                                        outlined: true;
+                                        accessible-label: "Add package " + result.name;
+                                        clicked => { root.package-added(index); search.text = ""; root.search-changed(""); search.focus-input(); }
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                HorizontalLayout {
-                    alignment: end;
+                    Rectangle {
+                        height: 1px;
+                        background: Theme.c.surface1;
+                    }
 
-                    StyledButton {
-                        label: "Done";
-                        style: Theme.button-primary;
-                        clicked => { root.closed(); }
+                    Text {
+                        text: "Selected packages · " + root.selected-packages.length;
+                        color: Theme.c.text;
+                        font-size: 15px;
+                        font-weight: 600;
+                    }
+
+                    if root.selected-packages.length == 0: Text {
+                        text: "No extra packages selected. Your profile already includes its base packages.";
+                        color: Theme.c.subtext1;
+                        font-size: 13px;
+                        wrap: word-wrap;
+                    }
+                    if root.selected-packages.length > 0: ListView {
+                        height: min(144px, root.selected-packages.length * 48px);
+                        for pkg[index] in root.selected-packages: Rectangle {
+                            height: 48px;
+                            background: Theme.c.surface0;
+                            HorizontalLayout {
+                                padding: 6px;
+                                spacing: 12px;
+                                Text {
+                                    text: pkg.name;
+                                    color: Theme.c.text;
+                                    font-size: 14px;
+                                    vertical-alignment: center;
+                                    horizontal-stretch: 1;
+                                    overflow: elide;
+                                }
+
+                                Text {
+                                    text: pkg.repo == "aur" ? "AUR" : "Repository";
+                                    color: Theme.c.subtext1;
+                                    font-size: 13px;
+                                    vertical-alignment: center;
+                                }
+
+                                StyledButton {
+                                    label: "Remove";
+                                    height: 36px;
+                                    outlined: true;
+                                    accessible-label: "Remove package " + pkg.name;
+                                    clicked => { root.package-removed(index); }
+                                }
+                            }
+                        }
+                    }
+                    HorizontalLayout {
+                        alignment: end;
+                        StyledButton {
+                            label: "Done";
+                            height: 40px;
+                            style: Theme.button-primary;
+                            clicked => { root.closed(); }
+                        }
                     }
                 }
             }

--- a/slint-ui/ui/popups/select-popup.slint
+++ b/slint-ui/ui/popups/select-popup.slint
@@ -1,6 +1,7 @@
 import { ListView } from "std-widgets.slint";
 import { Theme } from "../styling.slint";
 import { SelectOption } from "../types.slint";
+import { StyledButton } from "../components/styled-button.slint";
 import { StyledTextInput } from "../components/styled-text-input.slint";
 
 export component SelectPopup inherits Rectangle {
@@ -22,7 +23,8 @@ export component SelectPopup inherits Rectangle {
 
     if popup-visible: Rectangle {
         background: #00000080;
-        width: 100%; height: 100%;
+        width: 100%;
+        height: 100%;
 
         TouchArea {
             clicked => { closed(); }
@@ -34,6 +36,8 @@ export component SelectPopup inherits Rectangle {
         // visible the input itself owns text-typing keys, so we only
         // intercept the navigation set.
         focus-scope := FocusScope {
+            width: 100%;
+            height: 100%;
             key-pressed(ev) => {
                 if ev.text == Key.Escape {
                     root.closed();
@@ -50,7 +54,7 @@ export component SelectPopup inherits Rectangle {
                     if root.options.length > 0 {
                         root.selected-index = min(
                             root.options.length - 1,
-                            max(0, root.selected-index) + 1);
+                            root.selected-index + 1);
                     }
                     return accept;
                 }
@@ -62,78 +66,102 @@ export component SelectPopup inherits Rectangle {
                 }
                 return reject;
             }
-        }
 
-        Rectangle {
-            x: (parent.width - self.width) / 2;
-            y: (parent.height - self.height) / 2;
-            width: min(500px, parent.width - 40px);
-            height: min(parent.height - 80px, 500px);
-            background: Theme.c.mantle;
-            border-radius: Theme.radius-md;
-            border-color: Theme.c.surface1;
-            border-width: 1px;
-            clip: true;
-            accessible-role: groupbox;
-            accessible-label: root.title;
+            Rectangle {
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+                width: min(600px, parent.width - 40px);
+                height: min(parent.height - 40px, root.show-filter ? 500px : min(600px, max(240px, root.options.length * 44px + 172px)));
+                background: Theme.c.mantle;
+                border-radius: Theme.radius-md;
+                border-color: Theme.c.surface1;
+                border-width: 1px;
+                clip: true;
+                accessible-role: groupbox;
+                accessible-label: root.title;
 
-            VerticalLayout {
-                padding: Theme.spacing-lg;
-                spacing: Theme.spacing-sm;
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: 12px;
 
-                Text {
-                    text: root.title;
-                    color: Theme.c.blue;
-                    font-size: Theme.font-lg;
-                    font-weight: FontWeight.semi-bold;
-                    height: Theme.spacing-xl;
-                }
+                    Text {
+                        text: root.title;
+                        color: Theme.c.text;
+                        font-size: 24px;
+                        font-weight: FontWeight.semi-bold;
+                        wrap: word-wrap;
+                    }
 
-                // Focus the filter input on open if present so the user
+                    // Focus the filter input on open if present so the user
                 // can type straight away. The `init` lives on the input
                 // itself because ids inside `if`-conditional elements
                 // aren't reachable from outer-scope handlers.
                 if root.show-filter: filter-input := StyledTextInput {
-                    height: Theme.control-height-sm;
-                    border-color: Theme.c.blue;
-                    edited(text) => { root.filter-changed(text); }
-                    init => { filter-input.focus-input(); }
-                }
+                        height: 40px;
+                        placeholder: "Type to filter choices";
+                        accessible-label: "Filter choices";
+                        border-color: Theme.c.blue;
+                        edited(text) => { root.filter-changed(text); }
+                        init => { filter-input.focus-input(); }
+                    }
 
-                // No filter → grab the FocusScope so arrow / Enter
+                    // No filter → grab the FocusScope so arrow / Enter
                 // navigation is live without an extra click.
                 if !root.show-filter: Rectangle {
-                    height: 0px;
-                    init => { focus-scope.focus(); }
-                }
+                        height: 0px;
+                        init => { focus-scope.focus(); }
+                    }
 
-                ListView {
-                    for option[index] in root.options: Rectangle {
-                        height: Theme.control-height-sm;
-                        background: item-ta.has-hover ? Theme.c.surface1
-                                  : index == root.selected-index ? Theme.c.surface0
-                                  : transparent;
-                        border-radius: Theme.radius-sm;
-                        accessible-role: list-item;
-                        accessible-label: option.text;
-                        accessible-item-selected: index == root.selected-index;
-                        accessible-item-index: index;
-                        accessible-item-count: root.options.length;
-
-                        item-ta := TouchArea {
-                            clicked => { root.accepted(index); }
+                    if root.options.length == 0: Text {
+                        text: "No matching choices. Try a different search.";
+                        color: Theme.c.subtext1;
+                        font-size: 14px;
+                        wrap: word-wrap;
+                    }
+                    choices := ListView {
+                        property <int> cursor: root.selected-index;
+                        changed cursor => {
+                            if self.cursor * 44px + self.content-y < 0px { self.content-y = -self.cursor * 44px; }
+                            else if (self.cursor + 1) * 44px + self.content-y > self.height { self.content-y = self.height - (self.cursor + 1) * 44px; }
                         }
+                        for option[index] in root.options: Rectangle {
+                            height: 44px;
+                            background: item-ta.has-hover ? Theme.c.surface1
+                                : index == root.selected-index ? Theme.c.surface0
+                                : transparent;
+                            border-radius: Theme.radius-sm;
+                            accessible-role: list-item;
+                            accessible-label: option.text;
+                            accessible-item-selected: index == root.selected-index;
+                            accessible-item-index: index;
+                            accessible-item-count: root.options.length;
+                            accessible-action-default => { root.accepted(index); }
 
-                        HorizontalLayout {
-                            padding-left: Theme.spacing-md;
-                            alignment: start;
-
-                            Text {
-                                text: index == root.selected-index ? "> " + option.text : "  " + option.text;
-                                color: index == root.selected-index ? Theme.c.green : Theme.c.text;
-                                font-size: Theme.font-base;
-                                vertical-alignment: center;
+                            item-ta := TouchArea {
+                                clicked => { root.accepted(index); }
                             }
+
+                            HorizontalLayout {
+                                padding-left: Theme.spacing-md;
+                                alignment: start;
+
+                                Text {
+                                    text: option.text;
+                                    color: index == root.selected-index ? Theme.c.blue : Theme.c.text;
+                                    font-size: 15px;
+                                    vertical-alignment: center;
+                                }
+                            }
+                        }
+                    }
+
+                    HorizontalLayout {
+                        alignment: end;
+                        StyledButton {
+                            label: "Cancel";
+                            height: 40px;
+                            outlined: true;
+                            clicked => { root.closed(); }
                         }
                     }
                 }

--- a/slint-ui/ui/popups/storage-picker.slint
+++ b/slint-ui/ui/popups/storage-picker.slint
@@ -1,0 +1,303 @@
+import { ListView, ScrollView } from "std-widgets.slint";
+import { Theme } from "../styling.slint";
+import { StorageState } from "../state/storage-state.slint";
+import { StyledButton } from "../components/styled-button.slint";
+import { StyledTextInput } from "../components/styled-text-input.slint";
+import { FocusTouchArea } from "../components/internal/state-layer.slint";
+
+export component StoragePicker inherits Rectangle {
+    property <bool> show-details;
+    background: #00000090;
+    // The surface owns keyboard events, including events rejected by search.
+    FocusScope {
+        width: 100%;
+        height: 100%;
+        key-pressed(e) => {
+            if e.text == Key.Escape { StorageState.cancel(); return accept; }
+            if e.text == Key.DownArrow { StorageState.move(1); return accept; }
+            if e.text == Key.UpArrow { StorageState.move(-1); return accept; }
+            if e.text == Key.Return && selection-focus.has-focus {
+                if confirm.enabled { StorageState.confirm(); }
+                return accept;
+            }
+            // Keep Tab inside the dialog; arrows navigate its selectable rows.
+            if e.text == Key.Tab {
+                if search.has-focus && refresh.enabled { refresh.focus-button(); }
+                else if search.has-focus || refresh.has-focus { selection-focus.focus(); }
+                else if cancel.has-focus && confirm.enabled { confirm.focus-button(); }
+                else if cancel.has-focus || confirm.has-focus { search.focus-input(); }
+                else if details.has-focus { cancel.focus-button(); }
+                else if details.enabled { details.focus-button(); }
+                else { cancel.focus-button(); }
+                return accept;
+            }
+            if e.text == Key.Backtab {
+                if search.has-focus && confirm.enabled { confirm.focus-button(); }
+                else if search.has-focus { cancel.focus-button(); }
+                else if confirm.has-focus { cancel.focus-button(); }
+                else if cancel.has-focus && details.enabled { details.focus-button(); }
+                else if cancel.has-focus || details.has-focus { selection-focus.focus(); }
+                else if refresh.has-focus || !refresh.enabled { search.focus-input(); }
+                else { refresh.focus-button(); }
+                return accept;
+            }
+            return reject;
+        }
+        selection-focus := FocusScope {
+            width: 0px;
+            height: 0px;
+        }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: min(980px, parent.width - 32px);
+            height: min(700px, parent.height - 32px);
+            background: Theme.c.base;
+            border-radius: 12px;
+            border-width: 1px;
+            border-color: Theme.c.surface1;
+            VerticalLayout {
+                padding: 20px;
+                spacing: 12px;
+                Text {
+                    wrap: word-wrap;
+                    text: StorageState.title;
+                    color: Theme.c.text;
+                    font-size: 24px;
+                    font-weight: 600;
+                }
+
+                Text {
+                    text: StorageState.explanation;
+                    color: Theme.c.subtext1;
+                    font-size: 14px;
+                    wrap: word-wrap;
+                }
+
+                HorizontalLayout {
+                    spacing: 12px;
+                    search := StyledTextInput {
+                        accessible-label: "Search storage";
+                        horizontal-stretch: 1;
+                        height: 40px;
+                        placeholder: StorageState.role == "pool" ? "Search pool name or GUID" : "Search device, filesystem or label";
+                        text <=> StorageState.filter;
+                        edited(_) => { StorageState.filter-changed(); }
+                        init => { self.focus-input(); }
+                    }
+
+                    refresh := StyledButton {
+                        label: "Refresh";
+                        height: 40px;
+                        enabled: !StorageState.busy;
+                        clicked => { StorageState.refresh(); }
+                    }
+                }
+
+                if StorageState.busy: Text {
+                    text: "Scanning storage…";
+                    color: Theme.c.subtext1;
+                }
+                if StorageState.error != "": Text {
+                    text: StorageState.error;
+                    color: Theme.c.red;
+                    wrap: word-wrap;
+                }
+                if !StorageState.busy && StorageState.error == "" && StorageState.candidates.length == 0: Text {
+                    text: StorageState.filter == "" ? (StorageState.role == "pool" ? "No pools found. Check the devices, then refresh." : "No devices found. Connect a device, then refresh.") : "No matches. Try a device name or clear the search.";
+                    color: Theme.c.subtext1;
+                    wrap: word-wrap;
+                }
+                if StorageState.role != "pool": HorizontalLayout {
+                    padding-left: 32px;
+                    padding-right: 16px;
+                    spacing: 12px;
+                    Text {
+                        text: "Device";
+                        color: Theme.c.subtext1;
+                        horizontal-stretch: 1;
+                    }
+
+                    Text {
+                        text: "Size";
+                        color: Theme.c.subtext1;
+                        width: 84px;
+                        horizontal-alignment: right;
+                    }
+
+                    Text {
+                        text: StorageState.role == "disk" ? "Type" : "Filesystem";
+                        color: Theme.c.subtext1;
+                        width: 130px;
+                    }
+
+                    Text {
+                        text: StorageState.role == "disk" ? "Model / availability" : "Label / availability";
+                        color: Theme.c.subtext1;
+                        width: 220px;
+                    }
+                }
+                list := ListView {
+                    vertical-stretch: 1;
+                    for candidate[index] in StorageState.candidates: Rectangle {
+                        property <bool> first: index == 0 || StorageState.candidates[index - 1].group != candidate.group;
+                        property <bool> selected: StorageState.selected == candidate.key;
+                        property <length> heading: first ? 44px : 0px;
+                        height: heading + (candidate.unavailable != "" ? 76px : 56px);
+                        changed selected => {
+                            if self.selected {
+                                if self.y + list.content-y < 0px { list.content-y = -self.y; }
+                                else if self.y + self.height + list.content-y > list.height { list.content-y = list.height - self.y - self.height; }
+                            }
+                        }
+                        VerticalLayout {
+                            spacing: 0px;
+                            if first: Rectangle {
+                                height: 44px;
+                                background: Theme.c.surface0;
+                                HorizontalLayout {
+                                    padding-left: 12px;
+                                    padding-right: 12px;
+                                    spacing: 12px;
+                                    Text {
+                                        text: candidate.group;
+                                        color: Theme.c.text;
+                                        font-weight: 600;
+                                        overflow: elide;
+                                        vertical-alignment: center;
+                                        horizontal-stretch: 1;
+                                    }
+
+                                    Text {
+                                        text: candidate.hardware;
+                                        color: Theme.c.subtext1;
+                                        vertical-alignment: center;
+                                    }
+                                }
+                            }
+                            Rectangle {
+                                background: selected ? Theme.c.blue.with-alpha(0.16) : touch.has-hover ? Theme.c.surface0 : transparent;
+                                border-color: touch.has-focus ? Theme.c.blue : transparent;
+                                border-width: 2px;
+                                VerticalLayout {
+                                    padding-left: 12px;
+                                    padding-right: 16px;
+                                    padding-top: 10px;
+                                    padding-bottom: 10px;
+                                    spacing: 5px;
+                                    HorizontalLayout {
+                                        spacing: 12px;
+                                        Text {
+                                            text: candidate.unavailable != "" ? "−" : selected ? "●" : "○";
+                                            color: selected ? Theme.c.blue : Theme.c.subtext1;
+                                            width: 16px;
+                                        }
+
+                                        Text {
+                                            text: candidate.name;
+                                            color: Theme.c.text;
+                                            font-size: 15px;
+                                            font-weight: 600;
+                                            overflow: elide;
+                                            horizontal-stretch: 1;
+                                        }
+
+                                        if StorageState.role != "pool": Text {
+                                            text: candidate.size;
+                                            color: Theme.c.text;
+                                            width: 84px;
+                                            horizontal-alignment: right;
+                                        }
+                                        if StorageState.role != "pool": Text {
+                                            text: candidate.filesystem;
+                                            color: Theme.c.subtext1;
+                                            width: 130px;
+                                            overflow: elide;
+                                        }
+                                        Text {
+                                            text: candidate.label;
+                                            color: Theme.c.subtext1;
+                                            width: StorageState.role == "pool" ? 300px : 220px;
+                                            overflow: elide;
+                                        }
+                                    }
+
+                                    if candidate.unavailable != "": Text {
+                                        text: candidate.unavailable;
+                                        color: Theme.c.yellow;
+                                        font-size: 13px;
+                                        overflow: elide;
+                                    }
+                                }
+
+                                touch := FocusTouchArea {
+                                    width: 100%;
+                                    height: 100%;
+                                    enabled: candidate.unavailable == "" && !StorageState.busy;
+                                    accessible-enabled: self.enabled;
+                                    accessible-role: list-item;
+                                    accessible-label: candidate.name + " " + candidate.label + " " + candidate.unavailable;
+                                    accessible-action-default => { if self.enabled { StorageState.choose(candidate.key); } }
+                                    clicked => { StorageState.choose(candidate.key); }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    height: 1px;
+                    background: Theme.c.surface1;
+                }
+
+                HorizontalLayout {
+                    spacing: 12px;
+                    Text {
+                        text: StorageState.selected-name == "" ? (StorageState.role == "pool" ? "Select a pool to continue" : "Select a device to continue") : "Selected: " + StorageState.selected-name;
+                        color: Theme.c.text;
+                        font-size: 15px;
+                        horizontal-stretch: 1;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+
+                    details := StyledButton {
+                        label: root.show-details ? "Hide details" : "Details";
+                        height: 36px;
+                        enabled: StorageState.selected != "";
+                        clicked => { root.show-details = !root.show-details; }
+                    }
+                }
+
+                if root.show-details && StorageState.selected-details != "": ScrollView {
+                    height: 80px;
+                    Text {
+                        text: StorageState.selected-details;
+                        color: Theme.c.subtext1;
+                        font-size: 13px;
+                        wrap: word-wrap;
+                    }
+                }
+                HorizontalLayout {
+                    alignment: end;
+                    spacing: 12px;
+                    cancel := StyledButton {
+                        label: "Cancel";
+                        height: 40px;
+                        outlined: true;
+                        clicked => { StorageState.cancel(); }
+                    }
+
+                    confirm := StyledButton {
+                        label: StorageState.role == "pool" ? "Use this pool" : "Use this device";
+                        style: Theme.button-primary;
+                        height: 40px;
+                        enabled: StorageState.selected != "" && !StorageState.busy && StorageState.error == "";
+                        clicked => { StorageState.confirm(); }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/slint-ui/ui/popups/string-list-popup.slint
+++ b/slint-ui/ui/popups/string-list-popup.slint
@@ -36,116 +36,154 @@ export component StringListPopup inherits Rectangle {
 
     if popup-visible: Rectangle {
         background: #00000080;
-        width: 100%; height: 100%;
+        width: 100%;
+        height: 100%;
 
         TouchArea {
             clicked => { closed(); }
             scroll-event(e) => { return accept; }
         }
 
-        Rectangle {
-            x: (parent.width - self.width) / 2;
-            y: (parent.height - self.height) / 2;
-            width: min(540px, parent.width - 40px);
-            height: min(self.preferred-height, parent.height - 80px);
-            background: Theme.c.mantle;
-            border-radius: Theme.radius-md;
-            border-color: Theme.c.surface1;
-            border-width: 1px;
-            clip: true;
-            accessible-role: groupbox;
-            accessible-label: root.title;
+        FocusScope {
+            width: 100%;
+            height: 100%;
+            key-pressed(e) => { if e.text == Key.Escape { root.closed(); return accept; } return reject; }
+            Rectangle {
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+                width: min(600px, parent.width - 40px);
+                height: min(self.preferred-height, parent.height - 80px);
+                background: Theme.c.mantle;
+                border-radius: Theme.radius-md;
+                border-color: Theme.c.surface1;
+                border-width: 1px;
+                clip: true;
+                accessible-role: groupbox;
+                accessible-label: root.title;
 
-            VerticalLayout {
-                padding: Theme.spacing-lg;
-                spacing: Theme.spacing-sm;
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: 12px;
 
-                Text {
-                    text: root.title;
-                    color: Theme.c.blue;
-                    font-size: Theme.font-lg;
-                    font-weight: FontWeight.semi-bold;
-                    height: Theme.spacing-xl;
-                }
+                    Text {
+                        text: root.title;
+                        color: Theme.c.text;
+                        font-size: 24px;
+                        font-weight: FontWeight.semi-bold;
+                        wrap: word-wrap;
+                    }
 
+                    Text {
+                        text: "Enable these services at boot. Add their packages under Extra packages if needed.";
+                        color: Theme.c.subtext1;
+                        font-size: 14px;
+                        wrap: word-wrap;
+                    }
+
+                    if root.items.length == 0: Text {
+                        text: "No extra services selected.";
+                        color: Theme.c.subtext1;
+                        font-size: 14px;
+                    }
                 // Items list. ScrollView grows with content (preferred-height
                 // override) up to the popup's window-bounds cap, then scrolls
                 // overflow. See file header for the full rationale.
                 ScrollView {
-                    preferred-height: items-vbox.preferred-height;
-                    vertical-stretch: 1;
+                        preferred-height: items-vbox.preferred-height;
+                        vertical-stretch: 1;
 
-                    items-vbox := VerticalLayout {
-                        spacing: Theme.spacing-xs;
+                        items-vbox := VerticalLayout {
+                            spacing: Theme.spacing-xs;
 
-                        for item[index] in root.items: Rectangle {
-                            height: Theme.control-height;
-                            background: Theme.c.surface0;
-                            border-radius: Theme.radius-sm;
+                            for item[index] in root.items: Rectangle {
+                                height: 48px;
+                                background: Theme.c.surface0;
+                                border-radius: Theme.radius-sm;
 
-                            HorizontalLayout {
-                                padding-left: Theme.spacing-md;
-                                padding-right: Theme.spacing-sm;
-                                alignment: space-between;
+                                HorizontalLayout {
+                                    padding-left: Theme.spacing-md;
+                                    padding-right: Theme.spacing-sm;
+                                    alignment: space-between;
 
-                                Text {
-                                    text: item.text;
-                                    color: Theme.c.text;
-                                    font-size: Theme.font-base;
-                                    vertical-alignment: center;
-                                    horizontal-stretch: 1;
-                                }
+                                    Text {
+                                        text: item.text;
+                                        color: Theme.c.text;
+                                        font-size: 15px;
+                                        overflow: elide;
+                                        vertical-alignment: center;
+                                        horizontal-stretch: 1;
+                                    }
 
-                                VerticalLayout {
-                                    alignment: center;
-                                    DeleteButton {
-                                        clicked => { root.item-removed(index); }
+                                    VerticalLayout {
+                                        alignment: center;
+                                        StyledButton {
+                                            label: "Remove";
+                                            outlined: true;
+                                            height: 36px;
+                                            accessible-label: "Remove service " + item.text;
+                                            clicked => { root.item-removed(index); }
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
 
-                HorizontalLayout {
-                    spacing: Theme.spacing-sm;
+                    Text {
+                        text: "Service name";
+                        color: Theme.c.subtext1;
+                        font-size: 14px;
+                    }
 
-                    add-input := StyledTextInput {
-                        horizontal-stretch: 1;
-                        placeholder: "add new entry...";
-                        accepted(val) => {
-                            if val != "" {
-                                root.item-added(val);
-                                add-input.text = "";
+                    HorizontalLayout {
+                        spacing: 12px;
+
+                        add-input := StyledTextInput {
+                            horizontal-stretch: 1;
+                            placeholder: "e.g. sshd or cups";
+                            height: 40px;
+                            accessible-label: "Service name";
+                            accepted(val) => {
+                                if val != "" {
+                                    root.item-added(val);
+                                    add-input.text = "";
+                                }
+                            }
+                        }
+
+                        StyledButton {
+                            label: "Add";
+                            height: 40px;
+                            enabled: add-input.text != "";
+                            min-width: 60px;
+                            outlined: true;
+                            clicked => {
+                                if add-input.text != "" {
+                                    root.item-added(add-input.text);
+                                    add-input.text = "";
+                                    add-input.focus-input();
+                                }
                             }
                         }
                     }
 
-                    StyledButton {
-                        label: "Add";
-                        min-width: 60px;
-                        style: Theme.button-primary;
-                        clicked => {
-                            if add-input.text != "" {
-                                root.item-added(add-input.text);
-                                add-input.text = "";
-                                add-input.focus-input();
-                            }
+                    HorizontalLayout {
+                        alignment: end;
+                        StyledButton {
+                            label: "Done";
+                            height: 40px;
+                            style: Theme.button-primary;
+                            min-width: 60px;
+                            clicked => { root.closed(); }
                         }
                     }
-
-                    StyledButton {
-                        label: "Done";
-                        min-width: 60px;
-                        clicked => { root.closed(); }
-                    }
                 }
-            }
 
-            // Focus the input on first show. Placed at the popup-card level
+                // Focus the input on first show. Placed at the popup-card level
             // so it runs once when the `if popup-visible:` subtree is
             // instantiated, not on every layout init pass.
             init => { add-input.focus-input(); }
+            }
         }
     }
 }

--- a/slint-ui/ui/popups/text-input-popup.slint
+++ b/slint-ui/ui/popups/text-input-popup.slint
@@ -19,91 +19,101 @@ export component TextInputPopup inherits Rectangle {
 
     if popup-visible: Rectangle {
         background: #00000080;
-        width: 100%; height: 100%;
+        width: 100%;
+        height: 100%;
 
         TouchArea {
             clicked => { closed(); }
             scroll-event(e) => { return accept; }
         }
 
-        Rectangle {
-            x: (parent.width - self.width) / 2;
-            y: (parent.height - self.height) / 2;
-            width: min(500px, parent.width - 40px);
-            height: self.preferred-height;
-            background: Theme.c.mantle;
-            border-radius: Theme.radius-md;
-            border-color: Theme.c.surface1;
-            border-width: 1px;
-            accessible-role: groupbox;
-            accessible-label: root.title;
+        FocusScope {
+            width: 100%;
+            height: 100%;
+            key-pressed(e) => { if e.text == Key.Escape { root.closed(); return accept; } return reject; }
+            Rectangle {
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+                width: min(560px, parent.width - 40px);
+                height: self.preferred-height;
+                background: Theme.c.mantle;
+                border-radius: Theme.radius-md;
+                border-color: Theme.c.surface1;
+                border-width: 1px;
+                accessible-role: groupbox;
+                accessible-label: root.title;
 
-            VerticalLayout {
-                padding: Theme.spacing-lg;
-                spacing: Theme.spacing-md;
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: Theme.spacing-md;
 
-                Text {
-                    text: root.title;
-                    color: Theme.c.blue;
-                    font-size: Theme.font-lg;
-                    font-weight: FontWeight.semi-bold;
-                }
+                    Text {
+                        text: root.title;
+                        color: Theme.c.text;
+                        font-size: 24px;
+                        font-weight: FontWeight.semi-bold;
+                    }
 
-                input := StyledTextInput {
-                    is-password: root.is-password;
-                    font-size: Theme.font-base;
-                    text: root.input-text;
-                    border-color: Theme.c.blue;
-                    height: Theme.control-height;
+                    input := StyledTextInput {
+                        is-password: root.is-password;
+                        font-size: Theme.font-base;
+                        text: root.input-text;
+                        border-color: Theme.c.text;
+                        height: 40px;
+                        accessible-label: root.title;
 
-                    edited(val) => { root.text-edited(val); }
-                    accepted(val) => { root.confirmed(val); }
-                }
+                        edited(val) => { root.text-edited(val); }
+                        accepted(val) => { root.confirmed(val); }
+                    }
 
-                init => { input.focus-input(); root.text-edited(root.input-text); }
+                    init => { input.focus-input(); root.text-edited(root.input-text); }
 
                 // Password strength bar
                 if root.is-password && root.strength-score >= 0: VerticalLayout {
-                    spacing: Theme.spacing-xs;
+                        spacing: Theme.spacing-xs;
 
-                    ProgressBar {
-                        value: root.strength-score + 1;
-                        max: 5;
-                        fill-color: root.strength-color;
+                        ProgressBar {
+                            value: root.strength-score + 1;
+                            max: 5;
+                            fill-color: root.strength-color;
+                        }
+
+                        VerticalLayout {
+                            spacing: Theme.spacing-md;
+
+                            Text {
+                                text: root.strength-label;
+                                color: root.strength-color;
+                                font-size: Theme.font-sm;
+                                font-weight: FontWeight.semi-bold;
+                            }
+
+                            if root.strength-hint != "": Text {
+                                text: root.strength-hint;
+                                color: Theme.c.subtext1;
+                                font-size: 13px;
+                                wrap: word-wrap;
+                            }
+                        }
                     }
 
                     HorizontalLayout {
-                        alignment: center;
-                        spacing: Theme.spacing-md;
+                        spacing: Theme.spacing-sm;
+                        alignment: end;
 
-                        Text {
-                            text: root.strength-label;
-                            color: root.strength-color;
-                            font-size: Theme.font-sm;
-                            font-weight: FontWeight.semi-bold;
+                        StyledButton {
+                            label: "Cancel";
+                            height: 40px;
+                            outlined: true;
+                            clicked => { root.closed(); }
                         }
 
-                        if root.strength-hint != "": Text {
-                            text: root.strength-hint;
-                            color: Theme.c.overlay0;
-                            font-size: Theme.font-sm;
+                        StyledButton {
+                            label: "Save";
+                            height: 40px;
+                            style: Theme.button-primary;
+                            clicked => { root.confirmed(input.text); }
                         }
-                    }
-                }
-
-                HorizontalLayout {
-                    spacing: Theme.spacing-sm;
-                    alignment: end;
-
-                    StyledButton {
-                        label: "Cancel";
-                        clicked => { root.closed(); }
-                    }
-
-                    StyledButton {
-                        label: "OK";
-                        style: Theme.button-primary;
-                        clicked => { root.confirmed(input.text); }
                     }
                 }
             }

--- a/slint-ui/ui/popups/user-manage-popup.slint
+++ b/slint-ui/ui/popups/user-manage-popup.slint
@@ -1,221 +1,240 @@
 import { ScrollView } from "std-widgets.slint";
-import { Theme, Palette } from "../styling.slint";
+import { Theme } from "../styling.slint";
 import { UserEntry } from "../types.slint";
 import { StyledButton } from "../components/styled-button.slint";
 import { StyledTextInput } from "../components/styled-text-input.slint";
-import { Badge } from "../components/badge.slint";
-import { DeleteButton } from "../components/delete-button.slint";
 import { CheckBox } from "../components/check-box.slint";
 import { ProgressBar } from "../components/progress-bar.slint";
 import { PopupState } from "../state/popup-state.slint";
+import { EditingState } from "../state/editing-state.slint";
 
 export component UserManagePopup inherits Rectangle {
     in property <[UserEntry]> users;
     in property <bool> popup-visible;
-
-    callback user-added(string, string, bool);
+    callback user-added(string, string, bool) -> bool;
     callback user-removed(int);
     callback user-sudo-toggled(int);
-    // Forwarded to Rust on every keystroke in the password field. Rust runs
-    // it through zxcvbn (same handler as TextInputPopup) and writes the
-    // strength values back into PopupState.
     callback password-edited(string);
     callback closed();
 
     if popup-visible: Rectangle {
         background: #00000080;
-        width: 100%; height: 100%;
-
+        width: 100%;
+        height: 100%;
         TouchArea {
             clicked => { closed(); }
             scroll-event(e) => { return accept; }
         }
 
-        Rectangle {
-            x: (parent.width - self.width) / 2;
-            y: (parent.height - self.height) / 2;
-            width: min(520px, parent.width - 40px);
-            // Grow with content up to the window-bounds clamp. ScrollView's
-            // preferred-height override exposes the inner content height to
-            // this layout (same trick as StringListPopup).
-            height: min(self.preferred-height, parent.height - 80px);
-            background: Theme.c.mantle;
-            border-radius: Theme.radius-md;
-            border-color: Theme.c.surface1;
-            border-width: 1px;
-            clip: true;
-            accessible-role: groupbox;
-            accessible-label: "User accounts";
+        FocusScope {
+            width: 100%;
+            height: 100%;
+            key-pressed(e) => {
+                if e.text == Key.Escape { root.closed(); return accept; }
+                return reject;
+            }
+            Rectangle {
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+                width: min(640px, parent.width - 40px);
+                height: min(self.preferred-height, parent.height - 40px);
+                background: Theme.c.mantle;
+                border-radius: 12px;
+                border-color: Theme.c.surface1;
+                border-width: 1px;
+                clip: true;
+                accessible-role: groupbox;
+                accessible-label: "User accounts";
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: 16px;
+                    Text {
+                        text: "User accounts";
+                        color: Theme.c.text;
+                        font-size: 24px;
+                        font-weight: 600;
+                    }
 
-            VerticalLayout {
-                padding: Theme.spacing-lg;
-                spacing: Theme.spacing-md;
-
-                // ── Title ──
-                Text {
-                    text: "User accounts";
-                    color: Theme.c.blue;
-                    font-size: Theme.font-lg;
-                    font-weight: FontWeight.semi-bold;
-                    height: Theme.spacing-xl;
-                }
-
-                // ── Existing users list ──
-                // Grows naturally with the model up to the popup's
-                // window-bounds cap; ScrollView's preferred-height override
-                // exposes content height to the parent layout. See
-                // StringListPopup file header for the full rationale.
-                if root.users.length > 0: ScrollView {
-                    preferred-height: users-vbox.preferred-height;
-                    vertical-stretch: 1;
-
-                    users-vbox := VerticalLayout {
-                        spacing: Theme.spacing-xs;
-
-                        for user[index] in root.users: Rectangle {
-                            height: Theme.control-height-lg - 4px;
-                            background: user-row-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
-                            border-radius: Theme.radius-sm;
-
-                            user-row-ta := TouchArea {
-                                clicked => { root.user-sudo-toggled(index); }
+                    form-scroll := ScrollView {
+                        function reveal(y: length, h: length) {
+                            if y + self.content-y < 0px { self.content-y = -y; }
+                            else if y + h + self.content-y > self.height { self.content-y = self.height - y - h; }
+                        }
+                        preferred-height: body.preferred-height;
+                        body := VerticalLayout {
+                            spacing: 12px;
+                            Text {
+                                text: "Administrators can run commands with sudo. Use a regular account for everyday work.";
+                                color: Theme.c.subtext1;
+                                font-size: 14px;
+                                wrap: word-wrap;
                             }
 
-                            HorizontalLayout {
-                                padding-left: Theme.spacing-md;
-                                padding-right: Theme.spacing-sm;
-                                spacing: Theme.spacing-sm;
-                                alignment: space-between;
-
+                            if root.users.length == 0: Text {
+                                text: "No user accounts yet. Add your first account below.";
+                                color: Theme.c.subtext1;
+                                font-size: 14px;
+                                wrap: word-wrap;
+                            }
+                            for user[index] in root.users: user-row := Rectangle {
+                                height: 56px;
+                                background: Theme.c.surface0;
+                                border-radius: 8px;
                                 HorizontalLayout {
-                                    spacing: Theme.spacing-sm;
-                                    alignment: start;
-
+                                    padding: 8px;
+                                    spacing: 12px;
                                     Text {
                                         text: user.username;
                                         color: Theme.c.text;
-                                        font-size: Theme.font-base;
+                                        font-size: 15px;
+                                        font-weight: 600;
                                         vertical-alignment: center;
+                                        horizontal-stretch: 1;
+                                        overflow: elide;
                                     }
 
-                                    // Wrap in a centering VerticalLayout —
-                                    // HorizontalLayout doesn't center
-                                    // fixed-size children on the cross axis
-                                    // by default, they get top-aligned.
-                                    if user.has-sudo: VerticalLayout {
-                                        alignment: center;
-                                        Badge { label: "sudo"; }
+                                    CheckBox {
+                                        label: "Administrator";
+                                        height: 40px;
+                                        width: 156px;
+                                        accessible-label: "Administrator " + user.username;
+                                        checked: user.has-sudo;
+                                        changed has-focus => { if self.has-focus { form-scroll.reveal(user-row.y, user-row.height); } }
+                                        toggled => { root.user-sudo-toggled(index); }
                                     }
 
-                                    if !user.has-sudo: Text {
-                                        text: "(click to toggle sudo)";
-                                        color: Theme.c.overlay0;
-                                        font-size: Theme.font-sm;
-                                        vertical-alignment: center;
-                                    }
-                                }
-
-                                VerticalLayout {
-                                    alignment: center;
-                                    DeleteButton {
+                                    StyledButton {
+                                        label: "Remove";
+                                        height: 40px;
+                                        outlined: true;
+                                        accessible-label: "Remove user " + user.username;
+                                        changed has-focus => { if self.has-focus { form-scroll.reveal(user-row.y, user-row.height); } }
                                         clicked => { root.user-removed(index); }
                                     }
                                 }
                             }
-                        }
-                    }
-                }
+                            Rectangle {
+                                height: 1px;
+                                background: Theme.c.surface1;
+                            }
 
-                if root.users.length > 0: Rectangle {
-                    height: 1px;
-                    background: Theme.c.surface1;
-                }
+                            Text {
+                                text: "New account";
+                                color: Theme.c.text;
+                                font-size: 16px;
+                                font-weight: 600;
+                            }
 
-                // ── Add user form ──
-                Text {
-                    text: "Add user";
-                    color: Theme.c.subtext0;
-                    font-size: Theme.font-md;
-                    font-weight: FontWeight.semi-bold;
-                    height: Theme.spacing-xl - Theme.spacing-xs;
-                }
+                            Text {
+                                text: "Username";
+                                color: Theme.c.subtext1;
+                                font-size: 14px;
+                            }
 
-                username-input := StyledTextInput {
-                    placeholder: "username";
-                }
-                init => { username-input.focus-input(); root.password-edited(""); }
+                            username-input := StyledTextInput {
+                                height: 40px;
+                                placeholder: "e.g. alex";
+                                accessible-label: "Username";
+                                edited(_) => { EditingState.user-error = ""; }
+                                changed has-focus => { if self.has-focus { form-scroll.reveal(self.y, self.height); } }
+                            }
 
-                password-input := StyledTextInput {
-                    placeholder: "password (optional)";
-                    is-password: true;
-                    edited(val) => { root.password-edited(val); }
-                }
+                            Text {
+                                text: "Password";
+                                color: Theme.c.subtext1;
+                                font-size: 14px;
+                            }
 
-                // Strength bar — only visible when there's a password and
-                // Rust has reported a strength score (>= 0).
-                if password-input.text != "" && PopupState.password-strength-score >= 0: VerticalLayout {
-                    spacing: Theme.spacing-xs;
+                            password-input := StyledTextInput {
+                                height: 40px;
+                                placeholder: "Set a sign-in password";
+                                accessible-label: "Account password";
+                                is-password: true;
+                                changed has-focus => { if self.has-focus { form-scroll.reveal(self.y, self.height); } }
+                                edited(val) => { root.password-edited(val); }
+                            }
 
-                    ProgressBar {
-                        value: PopupState.password-strength-score + 1;
-                        max: 5;
-                        fill-color: PopupState.password-strength-color;
-                    }
+                            if password-input.text == "": Text {
+                                text: "Without a password, password login is unavailable. Configure another sign-in method before using this account.";
+                                color: Theme.c.subtext1;
+                                font-size: 13px;
+                                wrap: word-wrap;
+                            }
+                            if password-input.text != "" && PopupState.password-strength-score >= 0: VerticalLayout {
+                                spacing: 6px;
+                                ProgressBar {
+                                    value: PopupState.password-strength-score + 1;
+                                    max: 5;
+                                    fill-color: PopupState.password-strength-color;
+                                }
 
-                    HorizontalLayout {
-                        alignment: center;
-                        spacing: Theme.spacing-md;
+                                Text {
+                                    text: PopupState.password-strength-label;
+                                    color: PopupState.password-strength-color;
+                                    font-size: 13px;
+                                    font-weight: 600;
+                                }
 
-                        Text {
-                            text: PopupState.password-strength-label;
-                            color: PopupState.password-strength-color;
-                            font-size: Theme.font-sm;
-                            font-weight: FontWeight.semi-bold;
-                        }
-
-                        if PopupState.password-strength-hint != "": Text {
-                            text: PopupState.password-strength-hint;
-                            color: Theme.c.overlay0;
-                            font-size: Theme.font-sm;
-                        }
-                    }
-                }
-
-                // ── Sudo opt-in + action buttons ──
-                sudo-check := CheckBox {
-                    label: "Grant sudo privileges";
-                    checked: true;
-                }
-
-                HorizontalLayout {
-                    spacing: Theme.spacing-sm;
-
-                    StyledButton {
-                        label: "Add user";
-                        style: Theme.button-primary;
-                        min-width: 100px;
-                        clicked => {
-                            if username-input.text != "" {
-                                root.user-added(username-input.text, password-input.text, sudo-check.checked);
-                                sudo-check.checked = true;
-                                username-input.text = "";
-                                password-input.text = "";
-                                username-input.focus-input();
-                                // Reset strength feedback for the next user.
-                                root.password-edited("");
+                                if PopupState.password-strength-hint != "": Text {
+                                    text: PopupState.password-strength-hint;
+                                    color: Theme.c.subtext1;
+                                    font-size: 13px;
+                                    wrap: word-wrap;
+                                }
+                            }
+                            sudo-check := CheckBox {
+                                label: "Administrator (sudo)";
+                                height: 40px;
+                                checked: true;
+                                changed has-focus => { if self.has-focus { form-scroll.reveal(self.y, self.height); } }
                             }
                         }
                     }
 
-                    // Spacer
-                    Rectangle { horizontal-stretch: 1; }
+                    if EditingState.user-error != "": Text {
+                        text: EditingState.user-error;
+                        color: Theme.c.red;
+                        font-size: 14px;
+                        wrap: word-wrap;
+                    }
+                    HorizontalLayout {
+                        spacing: 12px;
+                        StyledButton {
+                            label: "Add user";
+                            height: 40px;
+                            style: username-input.text != "" ? Theme.button-primary : Theme.button-default;
+                            outlined: username-input.text == "";
+                            enabled: username-input.text != "";
+                            clicked => {
+                                if root.user-added(username-input.text, password-input.text, sudo-check.checked) {
+                                    username-input.text = "";
+                                    password-input.text = "";
+                                    sudo-check.checked = true;
+                                    root.password-edited("");
+                                    username-input.focus-input();
+                                }
+                            }
+                        }
 
-                    StyledButton {
-                        label: "Done";
-                        min-width: 80px;
-                        clicked => { root.closed(); }
+                        Rectangle {
+                            horizontal-stretch: 1;
+                        }
+
+                        StyledButton {
+                            label: "Done";
+                            height: 40px;
+                            style: username-input.text == "" ? Theme.button-primary : Theme.button-default;
+                            outlined: username-input.text != "";
+                            clicked => {
+                                if username-input.text != "" || password-input.text != "" {
+                                    EditingState.user-error = "Click Add user to save this account, or clear the form to finish.";
+                                } else { root.closed(); }
+                            }
+                        }
                     }
                 }
+
+                init => { username-input.focus-input(); root.password-edited(""); EditingState.user-error = ""; }
             }
         }
     }

--- a/slint-ui/ui/popups/wifi-popup.slint
+++ b/slint-ui/ui/popups/wifi-popup.slint
@@ -69,612 +69,628 @@ export component WifiPopup inherits Rectangle {
     // The whole subtree is gated by `if popup-visible:` above, so this
     // scope only exists while the popup is open — no enabled gate needed.
     focus-scope := FocusScope {
-        key-pressed(ev) => {
-            if ev.text == Key.Escape {
-                if WifiState.phase == WifiPhase.auth {
-                    WifiState.cancel-pick();
-                } else {
-                    WifiState.close();
+            key-pressed(ev) => {
+                if ev.text == Key.Escape {
+                    if WifiState.phase == WifiPhase.auth {
+                        WifiState.cancel-pick();
+                    } else {
+                        WifiState.close();
+                    }
+                    return accept;
                 }
-                return accept;
-            }
-
-            if ev.text == Key.Return && WifiState.phase == WifiPhase.connected {
-                WifiState.close();
-                return accept;
-            }
+                if ev.text == Key.Return && WifiState.phase == WifiPhase.connected {
+                    WifiState.close();
+                    return accept;
+                }
 
             // Below here: only relevant in the picking phase (list
             // navigation). Auth phase delegates Enter to the text
             // input itself so show-password toggles and normal text
             // editing keep working.
             if WifiState.phase != WifiPhase.picking {
+                    return reject;
+                }
+                if ev.text == Key.DownArrow || ev.text == "j" {
+                    if WifiState.networks.length > 0 {
+                        WifiState.selected-index =
+                            min(WifiState.networks.length - 1, WifiState.selected-index + 1);
+                        if WifiState.selected-index < 0 {
+                            WifiState.selected-index = 0;
+                        }
+                    }
+                    return accept;
+                }
+                if ev.text == Key.UpArrow || ev.text == "k" {
+                    if WifiState.selected-index > 0 {
+                        WifiState.selected-index = WifiState.selected-index - 1;
+                    }
+                    return accept;
+                }
+                if ev.text == Key.Return {
+                    if WifiState.selected-index >= 0
+                        && WifiState.selected-index < WifiState.networks.length {
+                        WifiState.pick(WifiState.selected-index);
+                    }
+                    return accept;
+                }
+                if ev.text == "r" {
+                    WifiState.rescan();
+                    return accept;
+                }
                 return reject;
             }
-
-            if ev.text == Key.DownArrow || ev.text == "j" {
-                if WifiState.networks.length > 0 {
-                    WifiState.selected-index =
-                        min(WifiState.networks.length - 1, WifiState.selected-index + 1);
-                    if WifiState.selected-index < 0 {
-                        WifiState.selected-index = 0;
-                    }
-                }
-                return accept;
-            }
-            if ev.text == Key.UpArrow || ev.text == "k" {
-                if WifiState.selected-index > 0 {
-                    WifiState.selected-index = WifiState.selected-index - 1;
-                }
-                return accept;
-            }
-            if ev.text == Key.Return {
-                if WifiState.selected-index >= 0
-                    && WifiState.selected-index < WifiState.networks.length {
-                    WifiState.pick(WifiState.selected-index);
-                }
-                return accept;
-            }
-            if ev.text == "r" {
-                WifiState.rescan();
-                return accept;
-            }
-            return reject;
         }
-    }
 
-    // Centered card
+        // Centered card
     Rectangle {
-        width: min(560px, parent.width - 64px);
-        height: min(WifiState.phase == WifiPhase.connected ? 340px
-            : WifiState.phase == WifiPhase.picking || WifiState.phase == WifiPhase.scanning ? 520px
-            : 400px, parent.height - 48px);
-        background: Theme.c.base;
-        border-radius: Theme.radius-lg;
-        border-width: 1px;
-        border-color: Theme.c.surface0;
-        clip: true;
-        accessible-role: groupbox;
-        accessible-label: "Network management";
+            width: min(600px, parent.width - 64px);
+            height: min(WifiState.phase == WifiPhase.connected ? 340px
+                : WifiState.phase == WifiPhase.picking || WifiState.phase == WifiPhase.scanning ? 520px
+                : 400px, parent.height - 48px);
+            background: Theme.c.base;
+            border-radius: Theme.radius-lg;
+            border-width: 1px;
+            border-color: Theme.c.surface0;
+            clip: true;
+            accessible-role: groupbox;
+            accessible-label: "Network management";
 
-        // Swallow clicks so the backdrop TouchArea does not see them.
+            // Swallow clicks so the backdrop TouchArea does not see them.
         TouchArea { }
 
-        VerticalLayout {
-            padding: Theme.spacing-lg;
-            spacing: Theme.spacing-md;
+            VerticalLayout {
+                padding: Theme.spacing-lg;
+                spacing: Theme.spacing-md;
 
-            // ───────────────── HEADER ─────────────────
+                // ───────────────── HEADER ─────────────────
             HorizontalLayout {
-                height: 40px;
-                spacing: Theme.spacing-sm;
-
-                Icon {
-                    source: @image-url("../../assets/icons/wifi.svg");
-                    size: 22px;
-                    tint: WifiState.current-ssid != "" ? Theme.c.green : Theme.c.blue;
-                }
-
-                Text {
-                    text: "Network";
-                    color: Theme.c.text;
-                    font-size: Theme.font-xl;
-                    font-weight: 600;
-                    vertical-alignment: center;
-                    horizontal-stretch: 1;
-                }
-
-                StyledButton {
-                    label: "Close";
-                    width: 88px;
                     height: 40px;
-                    style: Theme.button-default;
-                    clicked => { WifiState.close(); }
-                }
-            }
+                    spacing: Theme.spacing-sm;
 
-            // ───────────────── ETHERNET ROW ─────────────────
+                    Icon {
+                        source: @image-url("../../assets/icons/wifi.svg");
+                        size: 22px;
+                        tint: WifiState.current-ssid != "" ? Theme.c.green : Theme.c.blue;
+                    }
+
+                    Text {
+                        text: "Network";
+                        color: Theme.c.text;
+                        font-size: 24px;
+                        font-weight: 600;
+                        vertical-alignment: center;
+                        horizontal-stretch: 1;
+                    }
+
+                    StyledButton {
+                        label: "Close";
+                        outlined: true;
+                        width: 88px;
+                        height: 40px;
+                        style: Theme.button-default;
+                        clicked => { WifiState.close(); }
+                    }
+                }
+
+                // ───────────────── ETHERNET ROW ─────────────────
             // Always shown — a quick-read status for wired connectivity
             // so the user never has to wonder whether their ethernet is
             // up. Read-only: we don't configure static IPs.
             Rectangle {
-                height: Theme.control-height-lg;
-                background: Theme.c.surface0;
-                border-radius: Theme.radius-md;
-
-                HorizontalLayout {
-                    padding-left: Theme.spacing-md;
-                    padding-right: Theme.spacing-md;
-                    spacing: Theme.spacing-md;
-
-                    Icon {
-                        source: @image-url("../../assets/icons/ethernet-port.svg");
-                        size: 18px;
-                        tint: WifiState.ethernet-connected
-                            ? Theme.c.green : Theme.c.overlay0;
-                    }
-
-                    Text {
-                        text: "Ethernet";
-                        color: Theme.c.text;
-                        font-size: Theme.font-base;
-                        vertical-alignment: center;
-                        horizontal-stretch: 0;
-                        width: 80px;
-                    }
-
-                    Text {
-                        text: WifiState.ethernet-connected
-                            ? (WifiState.ethernet-ipv4 != ""
-                                ? WifiState.ethernet-ipv4
-                                : "Connected")
-                            : "Not connected";
-                        color: WifiState.ethernet-connected
-                            ? Theme.c.green : Theme.c.overlay0;
-                        font-size: Theme.font-sm;
-                        vertical-alignment: center;
-                        horizontal-stretch: 1;
-                    }
-                }
-            }
-
-            // ───────────────── BODY (phase-driven) ─────────────────
-            Rectangle {
-                horizontal-stretch: 1;
-                vertical-stretch: 1;
-                background: transparent;
-                clip: true;
-
-                // — scanning / idle — centered spinner —
-                if WifiState.phase == WifiPhase.scanning
-                    || WifiState.phase == WifiPhase.idle: VerticalLayout {
-                    alignment: center;
-                    spacing: Theme.spacing-md;
+                    height: Theme.control-height-lg;
+                    background: Theme.c.surface0;
+                    border-radius: Theme.radius-md;
 
                     HorizontalLayout {
-                        height: 28px;
-                        alignment: center;
+                        padding-left: Theme.spacing-md;
+                        padding-right: Theme.spacing-md;
+                        spacing: Theme.spacing-md;
 
                         Icon {
-                            source: @image-url("../../assets/icons/refresh-cw.svg");
-                            size: 28px;
-                            tint: Theme.c.blue;
+                            source: @image-url("../../assets/icons/ethernet-port.svg");
+                            size: 18px;
+                            tint: WifiState.ethernet-connected
+                                ? Theme.c.green : Theme.c.overlay0;
+                        }
+
+                        Text {
+                            text: "Ethernet";
+                            color: Theme.c.text;
+                            font-size: Theme.font-base;
+                            vertical-alignment: center;
+                            horizontal-stretch: 0;
+                            width: 80px;
+                        }
+
+                        Text {
+                            text: WifiState.ethernet-connected
+                                ? (WifiState.ethernet-ipv4 != ""
+                                ? WifiState.ethernet-ipv4
+                                : "Connected")
+                                : "Not connected";
+                            color: WifiState.ethernet-connected
+                                ? Theme.c.green : Theme.c.overlay0;
+                            font-size: 14px;
+                            vertical-alignment: center;
+                            horizontal-stretch: 1;
+                        }
+                    }
+                }
+
+                // ───────────────── BODY (phase-driven) ─────────────────
+            Rectangle {
+                    horizontal-stretch: 1;
+                    vertical-stretch: 1;
+                    background: transparent;
+                    clip: true;
+
+                    // — scanning / idle — centered spinner —
+                if WifiState.phase == WifiPhase.scanning
+                        || WifiState.phase == WifiPhase.idle: VerticalLayout {
+                        alignment: center;
+                        spacing: Theme.spacing-md;
+
+                        HorizontalLayout {
+                            height: 28px;
+                            alignment: center;
+
+                            Icon {
+                                source: @image-url("../../assets/icons/refresh-cw.svg");
+                                size: 28px;
+                                tint: Theme.c.blue;
                             // Drives the rotation off `animation-tick()` so the
                             // icon spins continuously while this branch is live.
                             transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
-                        }
-                    }
-
-                    Text {
-                        text: WifiState.status-text != ""
-                            ? WifiState.status-text
-                            : "Scanning for networks…";
-                        color: Theme.c.subtext0;
-                        font-size: Theme.font-base;
-                        horizontal-alignment: center;
-                    }
-                }
-
-                // — picking — scrollable network list —
-                if WifiState.phase == WifiPhase.picking: ScrollView {
-                    width: 100%;
-                    height: 100%;
-                    vertical-stretch: 1;
-
-                    networks-list := VerticalLayout {
-                        spacing: Theme.spacing-xs;
-
-                        if WifiState.networks.length == 0: Rectangle {
-                            height: 80px;
-                            Text {
-                                text: "No networks found. Try Rescan.";
-                                color: Theme.c.overlay0;
-                                font-size: Theme.font-sm;
-                                horizontal-alignment: center;
-                                vertical-alignment: center;
                             }
                         }
 
-                        for net[idx] in WifiState.networks: Rectangle {
-                            height: Theme.control-height-lg;
+                        Text {
+                            text: WifiState.status-text != ""
+                                ? WifiState.status-text
+                                : "Scanning for networks…";
+                            color: Theme.c.subtext0;
+                            font-size: Theme.font-base;
+                            horizontal-alignment: center;
+                        }
+                    }
+
+                    // — picking — scrollable network list —
+                if WifiState.phase == WifiPhase.picking && WifiState.networks.length == 0: VerticalLayout {
+                    alignment: center;
+                    spacing: 12px;
+                    padding: 20px;
+                    Text {
+                        text: !WifiState.has-hardware ? "No Wi-Fi adapter detected"
+                            : !WifiState.iwd-running ? "Wi-Fi is unavailable"
+                            : "No networks found";
+                        color: Theme.c.text;
+                        font-size: 20px;
+                        font-weight: 600;
+                        horizontal-alignment: center;
+                        wrap: word-wrap;
+                    }
+                    Text {
+                        text: !WifiState.has-hardware || !WifiState.iwd-running
+                            ? "Connect an Ethernet cable, or check Wi-Fi in the live system console."
+                            : "Check that your access point is on and within range, then scan again.";
+                        color: Theme.c.subtext0;
+                        font-size: 14px;
+                        horizontal-alignment: center;
+                        wrap: word-wrap;
+                    }
+                }
+
+                if WifiState.phase == WifiPhase.picking && WifiState.networks.length > 0: ScrollView {
+                        width: 100%;
+                        height: 100%;
+                        vertical-stretch: 1;
+
+                        networks-list := VerticalLayout {
+                            spacing: Theme.spacing-xs;
+
+                            for net[idx] in WifiState.networks: Rectangle {
+                                height: Theme.control-height-lg;
                             // Background priority: keyboard-focused row wins,
                             // then hover, then resting surface color.
                             background: (idx == WifiState.selected-index)
-                                ? Theme.c.surface1
-                                : row-ta.has-hover
+                                    ? Theme.c.surface1
+                                    : row-ta.has-hover
                                     ? Theme.c.surface1
                                     : Theme.c.surface0;
-                            border-radius: Theme.radius-md;
+                                border-radius: Theme.radius-md;
                             // Green outline for the currently-connected SSID,
                             // blue outline for the keyboard-focused row so
                             // users can tell which one will activate on Enter.
                             border-width: (net.ssid == WifiState.current-ssid
-                                || idx == WifiState.selected-index) ? 1px : 0px;
-                            border-color: (net.ssid == WifiState.current-ssid)
-                                ? Theme.c.green
-                                : Theme.c.blue;
+                                    || idx == WifiState.selected-index) ? 1px : 0px;
+                                border-color: (net.ssid == WifiState.current-ssid)
+                                    ? Theme.c.green
+                                    : Theme.c.blue;
 
-                            accessible-role: list-item;
-                            accessible-label: net.ssid + ", "
-                                + net.signal-percent + " percent signal, "
-                                + (net.security == WifiSecurity.open
+                                accessible-role: list-item;
+                                accessible-label: net.ssid + ", "
+                                    + net.signal-percent + " percent signal, "
+                                    + (net.security == WifiSecurity.open
                                     ? "open"
                                     : net.security == WifiSecurity.enterprise
-                                        ? "enterprise"
-                                        : "secured")
-                                + (net.known ? ", known" : "");
+                                    ? "enterprise"
+                                    : "secured")
+                                    + (net.known ? ", known" : "");
 
-                            row-ta := TouchArea {
-                                clicked => {
-                                    WifiState.selected-index = idx;
-                                    WifiState.pick(idx);
+                                row-ta := TouchArea {
+                                    clicked => {
+                                        WifiState.selected-index = idx;
+                                        WifiState.pick(idx);
+                                    }
+                                    mouse-cursor: pointer;
                                 }
-                                mouse-cursor: pointer;
+
+                                HorizontalLayout {
+                                    padding-left: Theme.spacing-md;
+                                    padding-right: Theme.spacing-sm;
+                                    spacing: Theme.spacing-md;
+
+                                    // Signal strength bars
+                                VerticalLayout {
+                                        alignment: center;
+                                        width: 28px;
+
+                                        SignalBars {
+                                            percent: net.signal-percent;
+                                            lit: (net.ssid == WifiState.current-ssid)
+                                                ? Theme.c.green
+                                                : Theme.c.subtext0;
+                                        }
+                                    }
+
+                                    // SSID
+                                Text {
+                                        text: net.ssid;
+                                        color: Theme.c.text;
+                                        font-size: Theme.font-base;
+                                        vertical-alignment: center;
+                                        horizontal-stretch: 1;
+                                        overflow: elide;
+                                    }
+
+                                    // "Known" badge
+                                if net.known: Rectangle {
+                                        width: 52px;
+                                        height: 20px;
+                                        background: Theme.c.surface1;
+                                        border-radius: 10px;
+                                        y: (parent.height - self.height) / 2;
+
+                                        Text {
+                                            text: "Known";
+                                            color: Theme.c.blue;
+                                            font-size: 12px;
+                                            horizontal-alignment: center;
+                                            vertical-alignment: center;
+                                        }
+                                    }
+
+                                    // Security label + lock icon
+                                HorizontalLayout {
+                                        spacing: 4px;
+                                        alignment: center;
+                                        width: 70px;
+
+                                        if net.security == WifiSecurity.psk
+                                            || net.security == WifiSecurity.wep: Icon {
+                                            source: @image-url("../../assets/icons/lock.svg");
+                                            size: 12px;
+                                            tint: Theme.c.overlay0;
+                                        }
+
+                                        Text {
+                                            text: net.security == WifiSecurity.open ? "Open"
+                                                : net.security == WifiSecurity.wep ? "WEP"
+                                                : net.security == WifiSecurity.psk ? "WPA"
+                                                : "Enterprise";
+                                            color: Theme.c.overlay0;
+                                            font-size: 12px;
+                                            vertical-alignment: center;
+                                        }
+                                    }
+
+                                    // Forget action for known networks
+                                if net.known: Rectangle {
+                                        width: 32px;
+                                        height: 32px;
+                                        accessible-role: button;
+                                        accessible-label: "Forget " + net.ssid;
+                                        accessible-action-default => { WifiState.forget(idx); }
+                                        y: (parent.height - self.height) / 2;
+                                        background: forget-ta.has-hover
+                                            ? Theme.c.red : transparent;
+                                        border-radius: Theme.radius-sm;
+
+                                        forget-ta := TouchArea {
+                                            clicked => { WifiState.forget(idx); }
+                                            mouse-cursor: pointer;
+                                        }
+
+                                        Icon {
+                                            source: @image-url("../../assets/icons/trash-2.svg");
+                                            size: 14px;
+                                            tint: forget-ta.has-hover
+                                                ? Theme.c.base : Theme.c.overlay0;
+                                        }
+                                    }
+                                }
                             }
+                        }
+                    }
+
+                    // — auth — password entry for the selected network —
+                if WifiState.phase == WifiPhase.auth: VerticalLayout {
+                        spacing: Theme.spacing-md;
+                        padding-top: Theme.spacing-sm;
+                        alignment: start;
+
+                        // Selected-network summary card
+                    Rectangle {
+                            height: Theme.control-height-lg;
+                            background: Theme.c.surface0;
+                            border-radius: Theme.radius-md;
 
                             HorizontalLayout {
                                 padding-left: Theme.spacing-md;
-                                padding-right: Theme.spacing-sm;
+                                padding-right: Theme.spacing-md;
                                 spacing: Theme.spacing-md;
 
-                                // Signal strength bars
-                                VerticalLayout {
-                                    alignment: center;
-                                    width: 28px;
-
-                                    SignalBars {
-                                        percent: net.signal-percent;
-                                        lit: (net.ssid == WifiState.current-ssid)
-                                            ? Theme.c.green
-                                            : Theme.c.subtext0;
-                                    }
+                                Icon {
+                                    source: @image-url("../../assets/icons/lock.svg");
+                                    size: 16px;
+                                    tint: Theme.c.blue;
                                 }
 
-                                // SSID
                                 Text {
-                                    text: net.ssid;
+                                    text: WifiState.selected-index >= 0
+                                        && WifiState.selected-index < WifiState.networks.length
+                                        ? WifiState.networks[WifiState.selected-index].ssid
+                                        : "";
                                     color: Theme.c.text;
                                     font-size: Theme.font-base;
+                                    font-weight: 600;
                                     vertical-alignment: center;
                                     horizontal-stretch: 1;
-                                    overflow: elide;
                                 }
 
-                                // "Known" badge
-                                if net.known: Rectangle {
-                                    width: 52px;
-                                    height: 20px;
-                                    background: Theme.c.surface1;
-                                    border-radius: 10px;
-                                    y: (parent.height - self.height) / 2;
-
-                                    Text {
-                                        text: "Known";
-                                        color: Theme.c.blue;
-                                        font-size: Theme.font-xs;
-                                        horizontal-alignment: center;
-                                        vertical-alignment: center;
-                                    }
-                                }
-
-                                // Security label + lock icon
-                                HorizontalLayout {
-                                    spacing: 4px;
+                                VerticalLayout {
                                     alignment: center;
-                                    width: 70px;
-
-                                    if net.security == WifiSecurity.psk
-                                        || net.security == WifiSecurity.wep: Icon {
-                                        source: @image-url("../../assets/icons/lock.svg");
-                                        size: 12px;
-                                        tint: Theme.c.overlay0;
-                                    }
-
-                                    Text {
-                                        text: net.security == WifiSecurity.open ? "Open"
-                                            : net.security == WifiSecurity.wep ? "WEP"
-                                            : net.security == WifiSecurity.psk ? "WPA"
-                                            : "Enterprise";
-                                        color: Theme.c.overlay0;
-                                        font-size: Theme.font-xs;
-                                        vertical-alignment: center;
-                                    }
-                                }
-
-                                // Forget action for known networks
-                                if net.known: Rectangle {
-                                    width: 32px;
-                                    height: 32px;
-                                    accessible-role: button;
-                                    accessible-label: "Forget " + net.ssid;
-                                    accessible-action-default => { WifiState.forget(idx); }
-                                    y: (parent.height - self.height) / 2;
-                                    background: forget-ta.has-hover
-                                        ? Theme.c.red : transparent;
-                                    border-radius: Theme.radius-sm;
-
-                                    forget-ta := TouchArea {
-                                        clicked => { WifiState.forget(idx); }
-                                        mouse-cursor: pointer;
-                                    }
-
-                                    Icon {
-                                        source: @image-url("../../assets/icons/trash-2.svg");
-                                        size: 14px;
-                                        tint: forget-ta.has-hover
-                                            ? Theme.c.base : Theme.c.overlay0;
+                                    horizontal-stretch: 0;
+                                    SignalBars {
+                                        percent: WifiState.selected-index >= 0
+                                            && WifiState.selected-index < WifiState.networks.length
+                                            ? WifiState.networks[WifiState.selected-index].signal-percent
+                                            : 0;
+                                        lit: Theme.c.subtext0;
                                     }
                                 }
                             }
                         }
+
+                        Text {
+                            text: "Password";
+                            color: Theme.c.subtext0;
+                            font-size: 14px;
+                        }
+
+                        // Password input + show-password eye toggle
+                    HorizontalLayout {
+                            spacing: Theme.spacing-sm;
+
+                            pw-input := StyledTextInput {
+                                height: 40px;
+                                text <=> WifiState.password;
+                                is-password: !WifiState.show-password;
+                                placeholder: "Enter network passphrase";
+                                horizontal-stretch: 1;
+                                accepted(v) => { WifiState.submit-password(); }
+                            }
+
+                            Rectangle {
+                                width: 40px;
+                                height: 40px;
+                                background: eye-ta.has-hover
+                                    ? Theme.c.surface1 : Theme.c.surface0;
+                                border-radius: Theme.radius-sm;
+                                border-width: 1px;
+                                border-color: Theme.c.surface1;
+
+                                eye-ta := TouchArea {
+                                    clicked => {
+                                        WifiState.show-password = !WifiState.show-password;
+                                    }
+                                    mouse-cursor: pointer;
+                                }
+
+                                Icon {
+                                    source: WifiState.show-password
+                                        ? @image-url("../../assets/icons/eye-off.svg")
+                                        : @image-url("../../assets/icons/eye.svg");
+                                    size: 16px;
+                                    tint: Theme.c.subtext0;
+                                }
+                            }
+                        }
+
+                        if WifiState.error-text != "": Text {
+                            text: WifiState.error-text;
+                            color: Theme.c.red;
+                            font-size: 14px;
+                        }
                     }
-                }
 
-                // — auth — password entry for the selected network —
-                if WifiState.phase == WifiPhase.auth: VerticalLayout {
-                    spacing: Theme.spacing-md;
-                    padding-top: Theme.spacing-sm;
-                    alignment: start;
-
-                    // Selected-network summary card
-                    Rectangle {
-                        height: Theme.control-height-lg;
-                        background: Theme.c.surface0;
-                        border-radius: Theme.radius-md;
+                    // — connecting / verifying — spinner + status —
+                if WifiState.phase == WifiPhase.connecting
+                        || WifiState.phase == WifiPhase.verifying: VerticalLayout {
+                        alignment: center;
+                        spacing: Theme.spacing-md;
 
                         HorizontalLayout {
-                            padding-left: Theme.spacing-md;
-                            padding-right: Theme.spacing-md;
-                            spacing: Theme.spacing-md;
+                            height: 28px;
+                            alignment: center;
 
                             Icon {
-                                source: @image-url("../../assets/icons/lock.svg");
-                                size: 16px;
+                                source: @image-url("../../assets/icons/refresh-cw.svg");
+                                size: 28px;
                                 tint: Theme.c.blue;
-                            }
-
-                            Text {
-                                text: WifiState.selected-index >= 0
-                                    && WifiState.selected-index < WifiState.networks.length
-                                    ? WifiState.networks[WifiState.selected-index].ssid
-                                    : "";
-                                color: Theme.c.text;
-                                font-size: Theme.font-base;
-                                font-weight: 600;
-                                vertical-alignment: center;
-                                horizontal-stretch: 1;
-                            }
-
-                            VerticalLayout {
-                                alignment: center;
-                                horizontal-stretch: 0;
-                                SignalBars {
-                                    percent: WifiState.selected-index >= 0
-                                        && WifiState.selected-index < WifiState.networks.length
-                                        ? WifiState.networks[WifiState.selected-index].signal-percent
-                                        : 0;
-                                    lit: Theme.c.subtext0;
-                                }
+                                transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
                             }
                         }
-                    }
 
-                    Text {
-                        text: "Password";
-                        color: Theme.c.subtext0;
-                        font-size: Theme.font-sm;
-                    }
-
-                    // Password input + show-password eye toggle
-                    HorizontalLayout {
-                        spacing: Theme.spacing-sm;
-
-                        pw-input := StyledTextInput {
-                            text <=> WifiState.password;
-                            is-password: !WifiState.show-password;
-                            placeholder: "Enter network passphrase";
-                            horizontal-stretch: 1;
-                            accepted(v) => { WifiState.submit-password(); }
-                        }
-
-                        Rectangle {
-                            width: Theme.control-height;
-                            height: Theme.control-height;
-                            background: eye-ta.has-hover
-                                ? Theme.c.surface1 : Theme.c.surface0;
-                            border-radius: Theme.radius-sm;
-                            border-width: 1px;
-                            border-color: Theme.c.surface1;
-
-                            eye-ta := TouchArea {
-                                clicked => {
-                                    WifiState.show-password = !WifiState.show-password;
-                                }
-                                mouse-cursor: pointer;
-                            }
-
-                            Icon {
-                                source: WifiState.show-password
-                                    ? @image-url("../../assets/icons/eye-off.svg")
-                                    : @image-url("../../assets/icons/eye.svg");
-                                size: 16px;
-                                tint: Theme.c.subtext0;
-                            }
-                        }
-                    }
-
-                    if WifiState.error-text != "": Text {
-                        text: WifiState.error-text;
-                        color: Theme.c.red;
-                        font-size: Theme.font-sm;
-                    }
-                }
-
-                // — connecting / verifying — spinner + status —
-                if WifiState.phase == WifiPhase.connecting
-                    || WifiState.phase == WifiPhase.verifying: VerticalLayout {
-                    alignment: center;
-                    spacing: Theme.spacing-md;
-
-                    HorizontalLayout {
-                        height: 28px;
-                        alignment: center;
-
-                        Icon {
-                            source: @image-url("../../assets/icons/refresh-cw.svg");
-                            size: 28px;
-                            tint: Theme.c.blue;
-                            transform-rotation: 360deg * mod(animation-tick(), 1.2s) / 1.2s;
-                        }
-                    }
-
-                    Text {
-                        text: WifiState.status-text != ""
-                            ? WifiState.status-text
-                            : (WifiState.phase == WifiPhase.verifying
+                        Text {
+                            text: WifiState.status-text != ""
+                                ? WifiState.status-text
+                                : (WifiState.phase == WifiPhase.verifying
                                 ? "Checking internet access…"
                                 : "Connecting…");
-                        color: Theme.c.subtext0;
-                        font-size: Theme.font-base;
-                        horizontal-alignment: center;
+                            color: Theme.c.subtext0;
+                            font-size: Theme.font-base;
+                            horizontal-alignment: center;
+                        }
                     }
-                }
 
-                // — connected — success card —
+                    // — connected — success card —
                 if WifiState.phase == WifiPhase.connected: VerticalLayout {
-                    alignment: center;
-                    spacing: Theme.spacing-md;
-
-                    HorizontalLayout {
-                        height: 36px;
                         alignment: center;
+                        spacing: Theme.spacing-md;
 
-                        Icon {
-                            source: @image-url("../../assets/icons/check.svg");
-                            size: 36px;
-                            tint: Theme.c.green;
+                        HorizontalLayout {
+                            height: 36px;
+                            alignment: center;
+
+                            Icon {
+                                source: @image-url("../../assets/icons/check.svg");
+                                size: 36px;
+                                tint: Theme.c.green;
+                            }
+                        }
+
+                        Text {
+                            text: "Connected";
+                            color: Theme.c.green;
+                            font-size: Theme.font-xl;
+                            font-weight: 600;
+                            horizontal-alignment: center;
+                        }
+
+                        Text {
+                            text: WifiState.current-ssid;
+                            color: Theme.c.text;
+                            font-size: Theme.font-base;
+                            horizontal-alignment: center;
                         }
                     }
 
-                    Text {
-                        text: "Connected";
-                        color: Theme.c.green;
-                        font-size: Theme.font-xl;
-                        font-weight: 600;
-                        horizontal-alignment: center;
-                    }
-
-                    Text {
-                        text: WifiState.current-ssid;
-                        color: Theme.c.text;
-                        font-size: Theme.font-base;
-                        horizontal-alignment: center;
-                    }
-                }
-
-                // — error — failure + retry actions —
+                    // — error — failure + retry actions —
                 if WifiState.phase == WifiPhase.error
-                    || WifiState.phase == WifiPhase.no-internet: VerticalLayout {
-                    alignment: center;
-                    spacing: Theme.spacing-md;
-
-                    HorizontalLayout {
-                        height: 36px;
+                        || WifiState.phase == WifiPhase.no-internet: VerticalLayout {
                         alignment: center;
+                        spacing: Theme.spacing-md;
 
-                        Icon {
-                            source: @image-url("../../assets/icons/x.svg");
-                            size: 36px;
-                            tint: Theme.c.red;
+                        HorizontalLayout {
+                            height: 36px;
+                            alignment: center;
+
+                            Icon {
+                                source: @image-url("../../assets/icons/x.svg");
+                                size: 36px;
+                                tint: Theme.c.red;
+                            }
+                        }
+
+                        Text {
+                            text: WifiState.phase == WifiPhase.no-internet
+                                ? "Internet access not verified" : "Connection failed";
+                            color: Theme.c.red;
+                            font-size: 20px;
+                            font-weight: 600;
+                            horizontal-alignment: center;
+                        }
+
+                        if WifiState.error-text != "": Text {
+                            text: WifiState.error-text;
+                            color: Theme.c.subtext0;
+                            font-size: 14px;
+                            horizontal-alignment: center;
+                            wrap: word-wrap;
+                            width: min(400px, parent.width);
                         }
                     }
-
-                    Text {
-                        text: WifiState.phase == WifiPhase.no-internet
-                            ? "Internet access not verified" : "Connection failed";
-                        color: Theme.c.red;
-                        font-size: Theme.font-lg;
-                        font-weight: 600;
-                        horizontal-alignment: center;
-                    }
-
-                    if WifiState.error-text != "": Text {
-                        text: WifiState.error-text;
-                        color: Theme.c.subtext0;
-                        font-size: Theme.font-sm;
-                        horizontal-alignment: center;
-                        wrap: word-wrap;
-                        width: min(400px, parent.width);
-                    }
                 }
-            }
 
-            // ───────────────── FOOTER (phase-driven buttons) ─────────────────
+                // ───────────────── FOOTER (phase-driven buttons) ─────────────────
             if WifiState.phase == WifiPhase.auth
-                || WifiState.phase == WifiPhase.picking
-                || WifiState.phase == WifiPhase.error
-                || WifiState.phase == WifiPhase.no-internet
-                || WifiState.phase == WifiPhase.connected: HorizontalLayout {
+                    || WifiState.phase == WifiPhase.picking
+                    || WifiState.phase == WifiPhase.error
+                    || WifiState.phase == WifiPhase.no-internet
+                    || WifiState.phase == WifiPhase.connected: HorizontalLayout {
                     height: 40px;
                     alignment: end;
                     spacing: Theme.spacing-sm;
 
-                // Auth phase: Cancel + Connect
+                    // Auth phase: Cancel + Connect
                 if WifiState.phase == WifiPhase.auth: StyledButton {
-                    label: "Cancel";
-                    style: Theme.button-default;
-                    clicked => { WifiState.cancel-pick(); }
-                }
-                if WifiState.phase == WifiPhase.auth: StyledButton {
-                    label: "Connect";
-                    style: Theme.button-primary;
-                    enabled: WifiState.password != "";
-                    clicked => { WifiState.submit-password(); }
-                }
+                        label: "Cancel";
+                        style: Theme.button-default;
+                        clicked => { WifiState.cancel-pick(); }
+                    }
+                    if WifiState.phase == WifiPhase.auth: StyledButton {
+                        label: "Connect";
+                        style: Theme.button-primary;
+                        enabled: WifiState.password != "";
+                        clicked => { WifiState.submit-password(); }
+                    }
 
-                // Error phase: Back to the last list, or run a fresh scan.
-                if WifiState.phase == WifiPhase.error
-                    || WifiState.phase == WifiPhase.no-internet: StyledButton {
-                    label: "Back";
-                    style: Theme.button-default;
-                    clicked => { WifiState.cancel-pick(); }
-                }
-                if WifiState.phase == WifiPhase.error
-                    || WifiState.phase == WifiPhase.no-internet: StyledButton {
-                    label: "Rescan";
-                    style: Theme.button-primary;
-                    clicked => { WifiState.rescan(); }
-                }
+                    // Error phase: Back to the last list, or run a fresh scan.
+                    if WifiState.phase == WifiPhase.error
+                        || WifiState.phase == WifiPhase.no-internet: StyledButton {
+                        label: "Rescan";
+                        style: Theme.button-default;
+                        outlined: true;
+                        clicked => { WifiState.rescan(); }
+                    }
 
-                if WifiState.phase == WifiPhase.picking: StyledButton {
-                    label: "Rescan";
-                    style: Theme.button-default;
-                    clicked => { WifiState.rescan(); }
-                }
+                    if WifiState.phase == WifiPhase.picking: StyledButton {
+                        label: "Rescan";
+                        style: Theme.button-default;
+                        clicked => { WifiState.rescan(); }
+                    }
 
-                // Disconnect belongs to network management, not the success action.
+                    // Disconnect belongs to network management, not the success action.
                 if (WifiState.phase == WifiPhase.picking && WifiState.current-ssid != "")
-                    || WifiState.phase == WifiPhase.no-internet: StyledButton {
-                    label: "Disconnect";
-                    style: Theme.button-default;
-                    clicked => { WifiState.disconnect(); }
-                }
+                        || WifiState.phase == WifiPhase.no-internet: StyledButton {
+                        label: "Disconnect";
+                        style: Theme.button-default;
+                        clicked => { WifiState.disconnect(); }
+                    }
 
-                if WifiState.phase == WifiPhase.connected: StyledButton {
-                    label: "Other networks";
-                    style: Theme.button-default;
-                    clicked => { WifiState.rescan(); }
-                }
+                    if WifiState.phase == WifiPhase.connected: StyledButton {
+                        label: "Other networks";
+                        style: Theme.button-default;
+                        clicked => { WifiState.rescan(); }
+                    }
 
-                if WifiState.phase == WifiPhase.connected
-                    || WifiState.phase == WifiPhase.picking: StyledButton {
-                    label: "Done";
-                    min-width: 100px;
-                    style: Theme.button-primary;
-                    clicked => { WifiState.close(); }
+                    if WifiState.phase == WifiPhase.error
+                        || WifiState.phase == WifiPhase.no-internet: StyledButton {
+                        label: "Back to networks";
+                        style: Theme.button-primary;
+                        clicked => { WifiState.cancel-pick(); }
+                    }
+
+                    if WifiState.phase == WifiPhase.connected
+                        || WifiState.phase == WifiPhase.picking: StyledButton {
+                        label: "Done";
+                        min-width: 100px;
+                        style: Theme.button-primary;
+                        clicked => { WifiState.close(); }
+                    }
                 }
             }
         }
-    }
     }
 }

--- a/slint-ui/ui/state/editing-state.slint
+++ b/slint-ui/ui/state/editing-state.slint
@@ -9,6 +9,7 @@
 import { UserEntry, PackageEntry, PackageSearchResult, SelectOption, MultiSelectOption } from "../types.slint";
 
 export global EditingState {
+    in-out property <string> user-error;
     in property <[UserEntry]> users;
     in property <[SelectOption]> extra-services;
     in property <[PackageEntry]> packages-selected;

--- a/slint-ui/ui/state/storage-state.slint
+++ b/slint-ui/ui/state/storage-state.slint
@@ -1,0 +1,34 @@
+export struct StorageCandidate {
+    key: string,
+    name: string,
+    group: string,
+    hardware: string,
+    size: string,
+    filesystem: string,
+    label: string,
+    details: string,
+    unavailable: string,
+}
+
+export global StorageState {
+    in-out property <bool> visible;
+    in-out property <bool> busy;
+    in-out property <int> generation;
+    in-out property <string> role;
+    in-out property <string> title;
+    in-out property <string> explanation;
+    in-out property <string> error;
+    in-out property <string> filter;
+    in-out property <string> selected;
+    in-out property <string> selected-name;
+    in-out property <string> selected-details;
+    in-out property <[StorageCandidate]> candidates;
+    callback open(string);
+    callback refresh();
+    callback filter-changed();
+    callback choose(string);
+    callback move(int);
+    callback confirm();
+    callback cancel();
+    callback inventory-changed();
+}

--- a/slint-ui/ui/state/wizard-state.slint
+++ b/slint-ui/ui/state/wizard-state.slint
@@ -7,6 +7,12 @@
 import { ConfigItem } from "../types.slint";
 
 export global WizardState {
+    in property <int> storage-mode;
+    in property <string> environment-path;
+    in property <bool> can-install;
+    in property <string> validation-summary;
+    in-out property <bool> advanced;
+    in-out property <int> page-revision;
     // Per-step config items (rebuilt by Rust on step-changed).
     in property <[ConfigItem]> config-items;
 
@@ -38,6 +44,7 @@ export global WizardState {
     public function go-to(idx: int) {
         if idx >= 0 && idx < total-steps {
             current-step = idx;
+            page-revision += 1;
             if idx > max-visited {
                 max-visited = idx;
             }
@@ -54,6 +61,7 @@ export global WizardState {
     public function back() {
         if current-step > 0 {
             current-step -= 1;
+            page-revision += 1;
             step-changed(current-step);
         }
     }

--- a/slint-ui/ui/types.slint
+++ b/slint-ui/ui/types.slint
@@ -19,9 +19,17 @@ export enum ItemType {
     radio-header,
     radio-subheader,
     radio-option,
+    storage,
+    inline-text,
+    inline-password,
+    compact-choice,
 }
 
 export struct ConfigItem {
+    choices: [string],
+    choice-index: int,
+    advanced: bool,
+    destructive: bool,
     key: string,
     label: string,
     value: string,

--- a/slint-ui/ui/views/welcome-view.slint
+++ b/slint-ui/ui/views/welcome-view.slint
@@ -305,7 +305,8 @@ export component WelcomeView inherits Rectangle {
                     alignment: center;
                     spacing: 12px;
                     if WifiState.has-hardware: StyledButton {
-                        label: "Network settings";
+                        label: "Wi-Fi & network";
+                        icon-source: @image-url("../../assets/icons/wifi.svg");
                         height: 44px;
                         outlined: WelcomeState.net-ok;
                         style: WelcomeState.net-ok ? Theme.button-default : Theme.button-primary;

--- a/slint-ui/ui/views/welcome-view.slint
+++ b/slint-ui/ui/views/welcome-view.slint
@@ -8,32 +8,20 @@ import { WelcomeState } from "../state/welcome-state.slint";
 import { WizardState } from "../state/wizard-state.slint";
 import { WifiState } from "../state/wifi-state.slint";
 import { Icon } from "../components/icon.slint";
-import { SignalBars } from "../components/signal-bars.slint";
+import { StyledButton } from "../components/styled-button.slint";
 
 export component WelcomeView inherits Rectangle {
     callback quit-requested();
     background: Theme.c.base;
 
-    Rectangle {
+    StyledButton {
         x: 16px;
         y: root.height - self.height - 16px;
         width: 88px;
-        height: 36px;
-        background: quit-ta.has-hover ? Theme.c.surface1 : Theme.c.surface0;
-        border-radius: Theme.radius-sm;
-        accessible-role: button;
-        accessible-label: "Quit";
-        accessible-action-default => { root.quit-requested(); }
-        quit-ta := TouchArea {
-            clicked => { root.quit-requested(); }
-            mouse-cursor: pointer;
-        }
-        Text {
-            text: "Quit";
-            color: Theme.c.text;
-            horizontal-alignment: center;
-            vertical-alignment: center;
-        }
+        height: 40px;
+        label: "Quit";
+        outlined: true;
+        clicked => { root.quit-requested(); }
     }
 
     // ── Bottom-right connectivity widget ───────────────────────────────
@@ -78,7 +66,7 @@ export component WelcomeView inherits Rectangle {
                 size: 18px;
                 tint: WifiState.current-ssid != "" || WifiState.ethernet-connected ? Theme.c.green
                     : WifiState.iwd-running ? Theme.c.blue
-                    : Theme.c.overlay0;
+                    : Theme.c.subtext0;
             }
 
             // Label — SSID when connected, "Not connected" otherwise,
@@ -106,7 +94,7 @@ export component WelcomeView inherits Rectangle {
             alignment: center;
 
             VerticalLayout {
-                width: min(500px, root.width - 60px);
+                width: min(600px, root.width - 60px);
                 spacing: 24px;
                 alignment: center;
 
@@ -136,13 +124,13 @@ export component WelcomeView inherits Rectangle {
 
                     // Network status
                     Rectangle {
-                        height: 48px;
+                        height: 56px;
                         background: Theme.c.surface0;
                         border-radius: 10px;
 
                         HorizontalLayout {
                             padding-left: 16px;
-                            padding-right: 12px;
+                            padding-right: 16px;
                             spacing: 12px;
 
                             Text {
@@ -163,44 +151,16 @@ export component WelcomeView inherits Rectangle {
 
                             Text {
                                 text: WelcomeState.net-ok ? "Connected" : "Not connected";
-                                color: WelcomeState.net-ok ? Theme.c.green : Theme.c.overlay0;
-                                font-size: 13px;
+                                color: WelcomeState.net-ok ? Theme.c.green : Theme.c.subtext0;
+                                font-size: 14px;
                                 vertical-alignment: center;
-                            }
-
-                            if !WelcomeState.net-ok: VerticalLayout {
-                                alignment: center;
-                                horizontal-stretch: 0;
-
-                                Rectangle {
-                                    width: 90px;
-                                    height: 30px;
-                                    background: check-net-ta.has-hover ? Theme.c.surface1 : Theme.c.mantle;
-                                    border-radius: 6px;
-                                    accessible-role: button;
-                                    accessible-label: "Check again";
-                                    accessible-action-default => { WelcomeState.check-internet(); }
-
-                                    check-net-ta := TouchArea {
-                                        clicked => { WelcomeState.check-internet(); }
-                                        mouse-cursor: pointer;
-                                    }
-
-                                    Text {
-                                        text: "Check again";
-                                        color: Theme.c.blue;
-                                        font-size: 12px;
-                                        horizontal-alignment: center;
-                                        vertical-alignment: center;
-                                    }
-                                }
                             }
                         }
                     }
 
                     // UEFI status
                     Rectangle {
-                        height: 48px;
+                        height: 56px;
                         background: Theme.c.surface0;
                         border-radius: 10px;
 
@@ -228,7 +188,7 @@ export component WelcomeView inherits Rectangle {
                             Text {
                                 text: WelcomeState.uefi-ok ? "Detected" : "Not detected (required)";
                                 color: WelcomeState.uefi-ok ? Theme.c.green : Theme.c.red;
-                                font-size: 13px;
+                                font-size: 14px;
                                 vertical-alignment: center;
                             }
                         }
@@ -236,7 +196,7 @@ export component WelcomeView inherits Rectangle {
 
                     // ZFS status
                     zfs-card := Rectangle {
-                        height: 48px;
+                        height: 56px;
                         background: Theme.c.surface0;
                         border-radius: 10px;
 
@@ -245,14 +205,14 @@ export component WelcomeView inherits Rectangle {
                             spacing: 0px;
 
                             HorizontalLayout {
-                                height: 48px;
+                                height: 56px;
                                 padding-left: 16px;
                                 padding-right: 16px;
                                 spacing: 12px;
 
                                 zfs-icon := Text {
                                     text: "\u{2717}";
-                                    color: Theme.c.overlay0;
+                                    color: Theme.c.subtext0;
                                     font-size: 18px;
                                     vertical-alignment: center;
                                     width: 24px;
@@ -273,9 +233,9 @@ export component WelcomeView inherits Rectangle {
                                 }
 
                                 zfs-status := Text {
-                                    text: "Waiting for network...";
-                                    color: Theme.c.overlay0;
-                                    font-size: 13px;
+                                    text: WelcomeState.net-ok ? "Not ready" : "Waiting for network";
+                                    color: Theme.c.subtext0;
+                                    font-size: 14px;
                                     vertical-alignment: center;
                                 }
                             }
@@ -289,7 +249,8 @@ export component WelcomeView inherits Rectangle {
                                 clip: true;
 
                                 Rectangle {
-                                    x: 0; y: 0;
+                                    x: 0;
+                                    y: 0;
                                     height: parent.height;
                                     width: parent.width * WelcomeState.zfs-install-pct / 100;
                                     background: Theme.c.blue;
@@ -307,10 +268,10 @@ export component WelcomeView inherits Rectangle {
                         // both somehow match.
                         states [
                             installing when WelcomeState.zfs-installing: {
-                                zfs-card.height: 72px;
+                                zfs-card.height: 80px;
                                 zfs-icon.text: "\u{21bb}";
                                 zfs-icon.color: Theme.c.blue;
-                                zfs-status.text: WelcomeState.zfs-install-status;
+                                zfs-status.text: "Preparing…";
                                 zfs-status.color: Theme.c.blue;
                             }
                             ready when WelcomeState.zfs-ok: {
@@ -323,53 +284,52 @@ export component WelcomeView inherits Rectangle {
                     }
                 }
 
-                // Start button
+                if !WelcomeState.zfs-ok && WelcomeState.zfs-install-status != "": Text {
+                    text: WelcomeState.zfs-install-status;
+                    color: WelcomeState.zfs-installing ? Theme.c.subtext1 : Theme.c.red;
+                    font-size: 14px;
+                    wrap: word-wrap;
+                    horizontal-alignment: center;
+                }
+                if !WelcomeState.all-checks-ok: Text {
+                    text: !WelcomeState.net-ok ? "Connect to the internet to prepare ZFS and start the installation."
+                        : !WelcomeState.uefi-ok ? "Restart the installer in UEFI mode to continue."
+                        : WelcomeState.zfs-installing ? "Preparing ZFS support. This may take a few minutes."
+                        : "ZFS is not ready. Check the preparation status before continuing.";
+                    color: Theme.c.subtext1;
+                    font-size: 14px;
+                    wrap: word-wrap;
+                    horizontal-alignment: center;
+                }
                 HorizontalLayout {
                     alignment: center;
-
-                    start-button := Rectangle {
-                        accessible-role: button;
-                        accessible-label: "Get Started";
-                        accessible-enabled: WelcomeState.all-checks-ok;
-                        accessible-action-default => {
-                            if WelcomeState.all-checks-ok { WizardState.go-to(1); }
-                        }
-                        width: 160px;
+                    spacing: 12px;
+                    if WifiState.has-hardware: StyledButton {
+                        label: "Network settings";
                         height: 44px;
-                        background: Theme.c.surface1;
-                        border-radius: 10px;
-
-                        start-ta := TouchArea {
-                            enabled: WelcomeState.all-checks-ok;
-                            mouse-cursor: self.enabled ? pointer : default;
-                            clicked => { WizardState.go-to(1); }
-                        }
-
-                        start-text := Text {
-                            text: "Get Started \u{2192}";
-                            color: Theme.c.overlay0;
-                            font-size: 15px;
-                            font-weight: FontWeight.semi-bold;
-                            horizontal-alignment: center;
-                            vertical-alignment: center;
-                        }
-
-                        states [
-                            ready when WelcomeState.all-checks-ok: {
-                                start-button.background: Theme.c.blue;
-                                start-text.color: Theme.c.base;
-                            }
-                            ready-hover when WelcomeState.all-checks-ok && start-ta.has-hover: {
-                                start-button.background: Theme.c.sky;
-                                start-text.color: Theme.c.base;
-                            }
-                        ]
+                        outlined: WelcomeState.net-ok;
+                        style: WelcomeState.net-ok ? Theme.button-default : Theme.button-primary;
+                        clicked => { WifiState.open(); }
+                    }
+                    if !WelcomeState.net-ok || (!WelcomeState.zfs-ok && !WelcomeState.zfs-installing): StyledButton {
+                        label: "Check again";
+                        height: 44px;
+                        outlined: true;
+                        clicked => { WelcomeState.check-internet(); }
+                    }
+                    if WelcomeState.net-ok: StyledButton {
+                        label: "Get Started →";
+                        accessible-label: "Get Started";
+                        height: 44px;
+                        style: Theme.button-primary;
+                        enabled: WelcomeState.all-checks-ok;
+                        clicked => { if WelcomeState.all-checks-ok { WizardState.go-to(1); } }
                     }
                 }
 
                 Text {
                     text: "v" + WelcomeState.app-version;
-                    color: Theme.c.overlay0;
+                    color: Theme.c.subtext0;
                     font-size: 11px;
                     horizontal-alignment: center;
                 }

--- a/slint-ui/ui/views/wizard-view.slint
+++ b/slint-ui/ui/views/wizard-view.slint
@@ -37,9 +37,8 @@ export component WizardView inherits Rectangle {
     // list. Global shortcuts (q/1–7) live in the App root scope
     // and pick up events that this scope rejects.
     wizard-focus-scope := FocusScope {
-        x: 0;
-        width: 0px;
-        height: 0px;
+        width: 100%;
+        height: 100%;
         enabled: !PopupState.select-visible
             && !PopupState.text-input-visible
             && !PopupState.users-visible
@@ -49,6 +48,7 @@ export component WizardView inherits Rectangle {
             && !PopupState.wifi-visible
             && !DemoState.popup-visible && !StorageState.visible;
 
+        changed enabled => { if self.enabled { self.focus(); } }
         key-pressed(event) => {
             if event.text == Key.DownArrow || event.text == "j" {
                 root.key-nav-down();
@@ -65,170 +65,178 @@ export component WizardView inherits Rectangle {
             if root.global-key(event.text) { return accept; }
             return reject;
         }
-    }
 
-    init => { wizard-focus-scope.focus(); }
-    reveal-settings := Timer {
-        interval: 1ms;
-        running: false;
-        triggered => {
-            self.running = false;
-            items-scroll.content-y = min(0px, items-scroll.height - settings-content.height);
-        }
-    }
-
-    VerticalLayout {
-        width: min(root.width, 1280px);
-        x: (root.width - self.width) / 2;
-        padding: 0px;
-        spacing: 0px;
-
-        // Title bar — sits directly on the shell, no separate Rectangle
-        HorizontalLayout {
-            height: 48px;
-            padding-left: 16px;
-            padding-right: 16px;
-
-            Text {
-                text: "archinstall-zfs";
-                color: Theme.c.blue;
-                font-size: 22px;
-                font-weight: FontWeight.bold;
-                vertical-alignment: center;
-                horizontal-stretch: 1;
-            }
-
-            Text {
-                text: WizardState.current-step + " / " + (WizardState.total-steps - 1);
-                color: Theme.c.overlay0;
-                font-size: 14px;
-                vertical-alignment: center;
+        init => { wizard-focus-scope.focus(); }
+        reveal-settings := Timer {
+            interval: 1ms;
+            running: false;
+            triggered => {
+                self.running = false;
+                items-scroll.content-y = min(0px, items-scroll.height - settings-content.height);
             }
         }
 
-        // Body: sidebar + floating content card
+        VerticalLayout {
+            width: min(root.width, 1280px);
+            x: (root.width - self.width) / 2;
+            padding: 0px;
+            spacing: 0px;
+
+            // Title bar — sits directly on the shell, no separate Rectangle
         HorizontalLayout {
-            vertical-stretch: 1;
-            spacing: 8px;
-            padding-right: 16px;
-            padding-bottom: 8px;
+                height: 48px;
+                padding-left: 16px;
+                padding-right: 16px;
 
-            // Sidebar — transparent, just sits on the shell color.
-            // No background Rectangle, no vertical separator.
-            VerticalLayout {
-                width: 140px;
-                padding: 8px;
-                spacing: 2px;
-                alignment: start;
+                Text {
+                    text: "archinstall-zfs";
+                    color: Theme.c.blue;
+                    font-size: 22px;
+                    font-weight: FontWeight.bold;
+                    vertical-alignment: center;
+                    horizontal-stretch: 1;
+                }
 
-                for index in WizardState.total-steps - 1: SidebarItem {
-                    label: WizardState.step-labels[index + 1];
-                    state: WizardState.step-state-at(index + 1);
-                    step-index: index + 1;
-
-                    clicked => {
-                        if index + 1 <= WizardState.max-visited {
-                            WizardState.go-to(index + 1);
-                        }
-                    }
+                Text {
+                    text: WizardState.current-step + " / " + (WizardState.total-steps - 1);
+                    color: Theme.c.overlay0;
+                    font-size: 14px;
+                    vertical-alignment: center;
                 }
             }
 
-            // Content card — lighter than the shell, rounded corners,
+            // Body: sidebar + floating content card
+        HorizontalLayout {
+                vertical-stretch: 1;
+                spacing: 8px;
+                padding-right: 16px;
+                padding-bottom: 8px;
+
+                // Sidebar — transparent, just sits on the shell color.
+            // No background Rectangle, no vertical separator.
+            VerticalLayout {
+                    width: 140px;
+                    padding: 8px;
+                    spacing: 2px;
+                    alignment: start;
+
+                    for index in WizardState.total-steps - 1: SidebarItem {
+                        label: WizardState.step-labels[index + 1];
+                        state: WizardState.step-state-at(index + 1);
+                        step-index: index + 1;
+
+                        clicked => {
+                            if index + 1 <= WizardState.max-visited {
+                                WizardState.go-to(index + 1);
+                            }
+                        }
+                    }
+                }
+
+                // Content card — lighter than the shell, rounded corners,
             // floats inside the body padding.
             Rectangle {
-                horizontal-stretch: 1;
-                background: Theme.c.base;
-                border-radius: 12px;
-                border-width: 1px;
-                border-color: Theme.c.surface0;
-                clip: true;
+                    horizontal-stretch: 1;
+                    background: Theme.c.base;
+                    border-radius: 12px;
+                    border-width: 1px;
+                    border-color: Theme.c.surface0;
+                    clip: true;
 
-                VerticalLayout {
-                    padding: 12px;
-                    spacing: 4px;
+                    VerticalLayout {
+                        padding: 12px;
+                        spacing: 4px;
 
-                    // Step title
+                        // Step title
                     Text {
-                        text: WizardState.current-step < WizardState.step-labels.length
-                            ? WizardState.step-labels[WizardState.current-step] : "";
-                        color: Theme.c.text;
-                        font-size: 24px;
-                        font-weight: FontWeight.semi-bold;
-                        vertical-alignment: center;
-                        height: 40px;
-                    }
+                            text: WizardState.current-step < WizardState.step-labels.length
+                                ? WizardState.step-labels[WizardState.current-step] : "";
+                            color: Theme.c.text;
+                            font-size: 24px;
+                            font-weight: FontWeight.semi-bold;
+                            vertical-alignment: center;
+                            height: 40px;
+                        }
 
-                    // Config items list. Spacing is 0 so adjacent field
+                        // Config items list. Spacing is 0 so adjacent field
                     // rows in the same section touch and stitch into one
                     // connected card; section breaks come from the
                     // SectionHeader rows themselves having top padding.
                     items-scroll := ScrollView {
-                        property <int> revision: WizardState.page-revision;
-                        changed revision => { self.content-y = 0px; }
-                        settings-content := VerticalLayout {
-                            spacing: WizardState.current-step <= 2 ? 8px : 0px;
-                            alignment: start;
-                            padding-left: 4px;
-                            padding-right: 4px;
+                            property <int> revision: WizardState.page-revision;
+                            changed revision => { self.content-y = 0px; }
+                            settings-content := VerticalLayout {
+                                spacing: WizardState.current-step <= 2 ? 8px : 0px;
+                                alignment: start;
+                                padding-left: 4px;
+                                padding-right: 4px;
 
-                            if WizardState.current-step == 1: Text {
-                                text: "Choose where to install. Storage changes are applied when installation starts.";
-                                color: Theme.c.subtext1;
-                                font-size: 14px;
-                                wrap: word-wrap;
-                            }
-                            if WizardState.current-step == 1: StorageMode {
-                                activated(key) => { root.item-activated(key); }
-                            }
-                            for item[index] in WizardState.config-items: Rectangle {
-                                vertical-stretch: 0;
-                                property <length> row-position: self.y;
-                                property <bool> setup: item.item-type == ItemType.storage || item.item-type == ItemType.inline-text || item.item-type == ItemType.inline-password || item.item-type == ItemType.compact-choice;
-                                VerticalLayout {
-                                    spacing: item.advanced ? 8px : 0px;
-                                    padding: 0px;
-                                    padding-bottom: setup && WizardState.current-step == 6 ? 8px : 0px;
-                                    if item.advanced && (index == 0 || !WizardState.config-items[index - 1].advanced): StyledButton {
-                                        label: WizardState.advanced ? "Hide additional settings" : "Additional settings";
-                                        outlined: true;
-                                        height: 40px;
-                                        changed has-focus => {
-                                            if self.has-focus && row-position + self.height + items-scroll.content-y > items-scroll.height {
-                                                items-scroll.content-y = items-scroll.height - row-position - self.height;
+                                if WizardState.current-step == 1: Text {
+                                    text: "Choose where to install. Storage changes are applied when installation starts.";
+                                    color: Theme.c.subtext1;
+                                    font-size: 14px;
+                                    wrap: word-wrap;
+                                }
+                                if WizardState.current-step >= 3 && WizardState.current-step <= 5: Text {
+                                    text: WizardState.current-step == 3 ? "Configure the installed system, its language and regional settings."
+                                        : WizardState.current-step == 4 ? "Set up how you will sign in and administer the installed system."
+                                        : "Choose your working environment and the software to install with it.";
+                                    color: Theme.c.subtext1;
+                                    font-size: 14px;
+                                    wrap: word-wrap;
+                                }
+                                if WizardState.current-step == 1: StorageMode {
+                                    activated(key) => { root.item-activated(key); }
+                                }
+                                for item[index] in WizardState.config-items: Rectangle {
+                                    vertical-stretch: 0;
+                                    property <length> row-position: self.y;
+                                    property <bool> setup: item.item-type == ItemType.storage || item.item-type == ItemType.inline-text || item.item-type == ItemType.inline-password || item.item-type == ItemType.compact-choice;
+                                    VerticalLayout {
+                                        spacing: item.advanced ? 8px : 0px;
+                                        padding: 0px;
+                                        padding-bottom: setup && WizardState.current-step == 6 ? 8px : 0px;
+                                        if item.advanced && (index == 0 || !WizardState.config-items[index - 1].advanced): StyledButton {
+                                            label: WizardState.advanced ? "Hide additional settings" : "Additional settings";
+                                            outlined: true;
+                                            height: 40px;
+                                            changed has-focus => {
+                                                if self.has-focus && row-position + self.height + items-scroll.content-y > items-scroll.height {
+                                                    items-scroll.content-y = items-scroll.height - row-position - self.height;
+                                                }
                                             }
+                                            clicked => { WizardState.advanced = !WizardState.advanced; if WizardState.advanced { reveal-settings.running = true; } }
                                         }
-                                        clicked => { WizardState.advanced = !WizardState.advanced; if WizardState.advanced { reveal-settings.running = true; } }
-                                    }
-                                    if setup && (!item.advanced || WizardState.advanced): SetupRow {
-                                        item: item;
-                                        row-index: index;
-                                        ensure-visible(h) => {
-                                            if row-position + items-scroll.content-y < 0px { items-scroll.content-y = -row-position; }
-                                            else if row-position + h + items-scroll.content-y > items-scroll.height { items-scroll.content-y = items-scroll.height - row-position - h; }
+                                        if setup && (!item.advanced || WizardState.advanced): SetupRow {
+                                            item: item;
+                                            row-index: index;
+                                            ensure-visible(h) => {
+                                                if row-position + items-scroll.content-y < 0px { items-scroll.content-y = -row-position; }
+                                                else if row-position + h + items-scroll.content-y > items-scroll.height { items-scroll.content-y = items-scroll.height - row-position - h; }
+                                            }
+                                            activated(key) => { root.item-activated(key); }
+                                            edited(key, value) => { root.inline-edited(key,value); }
                                         }
-                                        activated(key) => { root.item-activated(key); }
-                                        edited(key, value) => { root.inline-edited(key,value); }
-                                    }
-                                    if !setup: ConfigItemRow {
-                                        item: item;
-                                        index: index;
-                                        focused-index: WizardState.focused-index;
+                                        if !setup: ConfigItemRow {
+                                            item: item;
+                                            index: index;
+                                            focused-index: WizardState.focused-index;
 
-                                        focus-requested(i) => { WizardState.focused-index = i; }
-                                        ensure-visible(item-y, item-height) => {
-                                            if row-position + items-scroll.content-y < 0px {
-                                                items-scroll.content-y = -row-position;
-                                            } else if row-position + item-height + items-scroll.content-y > items-scroll.height {
-                                                items-scroll.content-y = items-scroll.height - row-position - item-height;
+                                            focus-requested(i) => { WizardState.focused-index = i; }
+                                            ensure-visible(item-y, item-height) => {
+                                                if row-position + items-scroll.content-y < 0px {
+                                                    items-scroll.content-y = -row-position;
+                                                } else if row-position + item-height + items-scroll.content-y > items-scroll.height {
+                                                    items-scroll.content-y = items-scroll.height - row-position - item-height;
+                                                }
                                             }
-                                        }
-                                        activated(key) => { root.item-activated(key); }
-                                        toggled(key) => { root.toggle-activated(key); }
-                                        action-clicked(key) => {
-                                            if key == "install" { root.install-requested(); }
-                                            else if key == "quit" { root.quit-requested(); }
-                                            else { root.item-activated(key); }
+                                            activated(key) => { root.item-activated(key); }
+                                            toggled(key) => { root.toggle-activated(key); }
+                                            action-clicked(key) => {
+                                                if key == "install" { root.install-requested(); }
+                                                else if key == "quit" { root.quit-requested(); }
+                                                else { root.item-activated(key); }
+                                            }
                                         }
                                     }
                                 }
@@ -237,66 +245,66 @@ export component WizardView inherits Rectangle {
                     }
                 }
             }
-        }
 
-        // Footer — full window width, sits on the shell color
+            // Footer — full window width, sits on the shell color
         HorizontalLayout {
-            height: 64px;
-            padding-left: 16px;
-            padding-right: 16px;
-            padding-top: 12px;
-            padding-bottom: 12px;
-            spacing: 8px;
+                height: 64px;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 12px;
+                padding-bottom: 12px;
+                spacing: 8px;
 
-            // Quit button
+                // Quit button
             StyledButton {
-                label: "Quit";
-                style: Theme.button-default;
-                outlined: true;
-                clicked => { root.quit-requested(); }
-            }
-
-            if DemoState.enabled: StyledButton {
-                label: "Inspect ZFS";
-                style: Theme.button-default;
-                clicked => {
-                    DemoState.popup-visible = true;
-                    DemoState.refresh();
+                    label: "Quit";
+                    style: Theme.button-default;
+                    outlined: true;
+                    clicked => { root.quit-requested(); }
                 }
-            }
 
-            // Back button (not on first wizard step)
+                if DemoState.enabled: StyledButton {
+                    label: "Inspect ZFS";
+                    style: Theme.button-default;
+                    clicked => {
+                        DemoState.popup-visible = true;
+                        DemoState.refresh();
+                    }
+                }
+
+                // Back button (not on first wizard step)
             if WizardState.current-step > 1: StyledButton {
-                label: "\u{25c2} Back";
-                style: Theme.button-default;
-                clicked => { WizardState.back(); }
-            }
+                    label: "\u{25c2} Back";
+                    style: Theme.button-default;
+                    clicked => { WizardState.back(); }
+                }
 
-            // Status text
+                // Status text
             Text {
-                text: WizardState.validation-summary != "" && WizardState.current-step == 6 ? WizardState.validation-summary : WizardState.status-text;
-                color: Theme.c.overlay0;
-                font-size: 12px;
-                horizontal-alignment: left;
-                vertical-alignment: center;
-                horizontal-stretch: 1;
-                overflow: elide;
-            }
+                    text: WizardState.validation-summary != "" && WizardState.current-step == 6 ? WizardState.validation-summary : WizardState.status-text;
+                    color: Theme.c.overlay0;
+                    font-size: 12px;
+                    horizontal-alignment: left;
+                    vertical-alignment: center;
+                    horizontal-stretch: 1;
+                    overflow: elide;
+                }
 
-            // Next button (all steps except the final Review step)
+                // Next button (all steps except the final Review step)
             if WizardState.current-step < WizardState.total-steps - 1: StyledButton {
-                label: "Next \u{25b8}";
-                style: Theme.button-primary;
-                clicked => { WizardState.next(); }
-            }
+                    label: "Next \u{25b8}";
+                    style: Theme.button-primary;
+                    clicked => { WizardState.next(); }
+                }
 
-            // Install button (Review step only) — takes the Next slot so the
+                // Install button (Review step only) — takes the Next slot so the
             // user never needs to scroll the content card to start the install.
             if WizardState.current-step == WizardState.total-steps - 1: StyledButton {
-                label: DemoState.enabled ? "Installation disabled" : "Install \u{25b8}";
-                style: Theme.button-primary;
-                enabled: !DemoState.enabled && WizardState.can-install;
-                clicked => { root.install-requested(); }
+                    label: DemoState.enabled ? "Installation disabled" : "Install \u{25b8}";
+                    style: Theme.button-primary;
+                    enabled: !DemoState.enabled && WizardState.can-install;
+                    clicked => { root.install-requested(); }
+                }
             }
         }
     }

--- a/slint-ui/ui/views/wizard-view.slint
+++ b/slint-ui/ui/views/wizard-view.slint
@@ -1,3 +1,7 @@
+import { StorageState } from "../state/storage-state.slint";
+import { SetupRow } from "../components/setup-row.slint";
+import { StorageMode } from "../components/storage-mode.slint";
+import { ItemType } from "../types.slint";
 // Wizard config screen — title bar, sidebar with step list, content area
 // with the per-step ConfigItemRow list, and a footer with Quit / Back / Next.
 
@@ -12,6 +16,7 @@ import { StyledButton } from "../components/styled-button.slint";
 
 export component WizardView inherits Rectangle {
     callback item-activated(string);
+    callback inline-edited(string, string);
     callback toggle-activated(string);
     callback install-requested();
     callback quit-requested();
@@ -29,7 +34,7 @@ export component WizardView inherits Rectangle {
     background: Theme.c.mantle;
 
     // Wizard-local FocusScope: handles arrow / j / k / Enter for the items
-    // list. Global shortcuts (Tab/Backtab/q/1–7) live in the App root scope
+    // list. Global shortcuts (q/1–7) live in the App root scope
     // and pick up events that this scope rejects.
     wizard-focus-scope := FocusScope {
         x: 0;
@@ -42,7 +47,7 @@ export component WizardView inherits Rectangle {
             && !PopupState.pkg-search-visible
             && !PopupState.multi-select-visible
             && !PopupState.wifi-visible
-            && !DemoState.popup-visible;
+            && !DemoState.popup-visible && !StorageState.visible;
 
         key-pressed(event) => {
             if event.text == Key.DownArrow || event.text == "j" {
@@ -63,6 +68,14 @@ export component WizardView inherits Rectangle {
     }
 
     init => { wizard-focus-scope.focus(); }
+    reveal-settings := Timer {
+        interval: 1ms;
+        running: false;
+        triggered => {
+            self.running = false;
+            items-scroll.content-y = min(0px, items-scroll.height - settings-content.height);
+        }
+    }
 
     VerticalLayout {
         width: min(root.width, 1280px);
@@ -139,11 +152,11 @@ export component WizardView inherits Rectangle {
                     Text {
                         text: WizardState.current-step < WizardState.step-labels.length
                             ? WizardState.step-labels[WizardState.current-step] : "";
-                        color: Theme.c.mauve;
-                        font-size: 18px;
+                        color: Theme.c.text;
+                        font-size: 24px;
                         font-weight: FontWeight.semi-bold;
                         vertical-alignment: center;
-                        height: 32px;
+                        height: 40px;
                     }
 
                     // Config items list. Spacing is 0 so adjacent field
@@ -151,29 +164,73 @@ export component WizardView inherits Rectangle {
                     // connected card; section breaks come from the
                     // SectionHeader rows themselves having top padding.
                     items-scroll := ScrollView {
-                        VerticalLayout {
-                            spacing: 0px;
+                        property <int> revision: WizardState.page-revision;
+                        changed revision => { self.content-y = 0px; }
+                        settings-content := VerticalLayout {
+                            spacing: WizardState.current-step <= 2 ? 8px : 0px;
+                            alignment: start;
                             padding-left: 4px;
                             padding-right: 4px;
 
-                            for item[index] in WizardState.config-items: ConfigItemRow {
-                                item: item;
-                                index: index;
-                                focused-index: WizardState.focused-index;
-
-                                focus-requested(i) => { WizardState.focused-index = i; }
-                                ensure-visible(item-y, item-height) => {
-                                    if item-y + items-scroll.content-y < 0px {
-                                        items-scroll.content-y = -item-y;
-                                    } else if item-y + item-height + items-scroll.content-y > items-scroll.height {
-                                        items-scroll.content-y = items-scroll.height - item-y - item-height;
-                                    }
-                                }
+                            if WizardState.current-step == 1: Text {
+                                text: "Choose where to install. Storage changes are applied when installation starts.";
+                                color: Theme.c.subtext1;
+                                font-size: 14px;
+                                wrap: word-wrap;
+                            }
+                            if WizardState.current-step == 1: StorageMode {
                                 activated(key) => { root.item-activated(key); }
-                                toggled(key) => { root.toggle-activated(key); }
-                                action-clicked(key) => {
-                                    if key == "install" { root.install-requested(); }
-                                    if key == "quit" { root.quit-requested(); }
+                            }
+                            for item[index] in WizardState.config-items: Rectangle {
+                                vertical-stretch: 0;
+                                property <length> row-position: self.y;
+                                property <bool> setup: item.item-type == ItemType.storage || item.item-type == ItemType.inline-text || item.item-type == ItemType.inline-password || item.item-type == ItemType.compact-choice;
+                                VerticalLayout {
+                                    spacing: item.advanced ? 8px : 0px;
+                                    padding: 0px;
+                                    padding-bottom: setup && WizardState.current-step == 6 ? 8px : 0px;
+                                    if item.advanced && (index == 0 || !WizardState.config-items[index - 1].advanced): StyledButton {
+                                        label: WizardState.advanced ? "Hide additional settings" : "Additional settings";
+                                        outlined: true;
+                                        height: 40px;
+                                        changed has-focus => {
+                                            if self.has-focus && row-position + self.height + items-scroll.content-y > items-scroll.height {
+                                                items-scroll.content-y = items-scroll.height - row-position - self.height;
+                                            }
+                                        }
+                                        clicked => { WizardState.advanced = !WizardState.advanced; if WizardState.advanced { reveal-settings.running = true; } }
+                                    }
+                                    if setup && (!item.advanced || WizardState.advanced): SetupRow {
+                                        item: item;
+                                        row-index: index;
+                                        ensure-visible(h) => {
+                                            if row-position + items-scroll.content-y < 0px { items-scroll.content-y = -row-position; }
+                                            else if row-position + h + items-scroll.content-y > items-scroll.height { items-scroll.content-y = items-scroll.height - row-position - h; }
+                                        }
+                                        activated(key) => { root.item-activated(key); }
+                                        edited(key, value) => { root.inline-edited(key,value); }
+                                    }
+                                    if !setup: ConfigItemRow {
+                                        item: item;
+                                        index: index;
+                                        focused-index: WizardState.focused-index;
+
+                                        focus-requested(i) => { WizardState.focused-index = i; }
+                                        ensure-visible(item-y, item-height) => {
+                                            if row-position + items-scroll.content-y < 0px {
+                                                items-scroll.content-y = -row-position;
+                                            } else if row-position + item-height + items-scroll.content-y > items-scroll.height {
+                                                items-scroll.content-y = items-scroll.height - row-position - item-height;
+                                            }
+                                        }
+                                        activated(key) => { root.item-activated(key); }
+                                        toggled(key) => { root.toggle-activated(key); }
+                                        action-clicked(key) => {
+                                            if key == "install" { root.install-requested(); }
+                                            else if key == "quit" { root.quit-requested(); }
+                                            else { root.item-activated(key); }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -194,7 +251,8 @@ export component WizardView inherits Rectangle {
             // Quit button
             StyledButton {
                 label: "Quit";
-                style: Theme.button-ghost;
+                style: Theme.button-default;
+                outlined: true;
                 clicked => { root.quit-requested(); }
             }
 
@@ -216,7 +274,7 @@ export component WizardView inherits Rectangle {
 
             // Status text
             Text {
-                text: WizardState.status-text;
+                text: WizardState.validation-summary != "" && WizardState.current-step == 6 ? WizardState.validation-summary : WizardState.status-text;
                 color: Theme.c.overlay0;
                 font-size: 12px;
                 horizontal-alignment: left;
@@ -237,7 +295,7 @@ export component WizardView inherits Rectangle {
             if WizardState.current-step == WizardState.total-steps - 1: StyledButton {
                 label: DemoState.enabled ? "Installation disabled" : "Install \u{25b8}";
                 style: Theme.button-primary;
-                enabled: !DemoState.enabled;
+                enabled: !DemoState.enabled && WizardState.can-install;
                 clicked => { root.install-requested(); }
             }
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -113,6 +113,11 @@ enum Commands {
 
 #[derive(Parser, Clone)]
 struct TestOpts {
+    /// Testing ISO to boot. By default, use the newest *-testing-*.iso.
+    /// Custom images must allow passwordless root SSH on the ISO VM.
+    #[arg(long)]
+    iso: Option<PathBuf>,
+
     /// Path to base JSON config file (overrides layered on top)
     #[arg(long, default_value = "xtask/configs/default.json")]
     config: PathBuf,
@@ -415,8 +420,14 @@ fn seed_aur_sources(dir: &Path) {
 fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
     check_prerequisites(&opts)?;
     let timeout = Duration::from_secs(opts.timeout);
+    let iso = match &opts.iso {
+        Some(path) if path.is_file() => path.clone(),
+        Some(path) => return Err(format!("ISO not found: {}", path.display())),
+        None => qemu::find_latest_testing_iso()?,
+    };
 
     eprintln!("=== test-install: Fresh disk + install ===");
+    eprintln!("Using testing ISO: {}", iso.display());
 
     // Fresh environment
     eprintln!("[1/4] Creating fresh disk and UEFI vars");
@@ -425,7 +436,6 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
 
     // Boot ISO
     eprintln!("[2/4] Booting ISO VM on port {}", opts.iso_port);
-    let iso = qemu::find_latest_iso();
     let cache = prepare_cache(&opts)?;
     let mut vm = QemuVm::boot_iso(
         &opts.disk,

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -340,27 +340,36 @@ fn find_ovmf_vars_template() -> PathBuf {
     find_ovmf("OVMF_VARS")
 }
 
-pub fn find_latest_iso() -> PathBuf {
+pub fn find_latest_testing_iso() -> Result<PathBuf, String> {
     let out_dir = PathBuf::from("gen_iso/out");
     let mut isos: Vec<(std::time::SystemTime, PathBuf)> = std::fs::read_dir(&out_dir)
-        .unwrap_or_else(|_| panic!("gen_iso/out not found. Run 'just iso-test' first."))
+        .map_err(|e| {
+            format!(
+                "cannot read {}: {e}. Run 'just iso-test' first.",
+                out_dir.display()
+            )
+        })?
         .filter_map(|e| e.ok())
         .map(|e| e.path())
-        .filter(|p| {
-            p.extension().is_some_and(|e| e == "iso")
-                && p.file_name()
-                    .and_then(|n| n.to_str())
-                    .is_some_and(|n| n.starts_with("archzfs-"))
-        })
+        .filter(|p| is_testing_iso(p))
         .filter_map(|p| {
             let mtime = std::fs::metadata(&p).ok()?.modified().ok()?;
             Some((mtime, p))
         })
         .collect();
     isos.sort_by_key(|(mtime, _)| *mtime);
-    isos.pop()
-        .map(|(_, p)| p)
-        .expect("No ISO found in gen_iso/out. Run 'just iso-test' or 'just iso-full' first.")
+    isos.pop().map(|(_, p)| p).ok_or_else(|| {
+        "No testing ISO found in gen_iso/out. Run 'just iso-test' first, or pass --iso explicitly."
+            .to_string()
+    })
+}
+
+fn is_testing_iso(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "iso")
+        && path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("archzfs-") && name.contains("-testing-"))
 }
 
 pub fn create_fresh_disk(path: &Path) {
@@ -377,4 +386,24 @@ pub fn create_fresh_disk(path: &Path) {
 pub fn reset_uefi_vars(path: &Path) {
     let src = find_ovmf_vars_template();
     std::fs::copy(src, path).expect("failed to copy UEFI vars");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_testing_iso;
+    use std::path::Path;
+
+    #[test]
+    fn integration_harness_accepts_only_testing_isos() {
+        assert!(is_testing_iso(Path::new(
+            "archzfs-linux-lts-dkms-testing-2026.09.09-x86_64.iso"
+        )));
+        assert!(!is_testing_iso(Path::new(
+            "archzfs-linux-dkms-2026.09.09-x86_64.iso"
+        )));
+        assert!(!is_testing_iso(Path::new("other-testing-image.iso")));
+        assert!(!is_testing_iso(Path::new(
+            "archzfs-linux-lts-dkms-testing-2026.09.09-x86_64.img"
+        )));
+    }
 }


### PR DESCRIPTION
The setup UI repeats long partition lists and makes several editing and network actions difficult to discover. Replace these with compact assignments, searchable pickers and consistent editors, and allow an updated GUI binary to be loaded from Ventoy without rebuilding the base ISO for each UI iteration.

- Add filesystem/use metadata, reject conflicting partition roles, and clear stale selections when switching installation modes.
- Preserve unrelated EFI fallback files, register the selected ESP by disk, partition and PARTUUID, and replace only stale ZFSBootMenu NVRAM entries.
- Align storage metadata and introduce bounded pickers with search, selection confirmation, keyboard navigation and explanations for unavailable devices.
- Improve system, account, desktop and package editors, preserve invalid form input, and keep Wi-Fi & network settings available after connection.
- Use the combined Slint LinuxKMS integration branch and explicitly enable touchpad tapping in the installer while preserving user overrides.
- Load a trusted `/azfs-update/azfs` from the Ventoy boot medium into the live overlay before login consoles, with startup validation, atomic replacement and fallback to the embedded installer.
- Extend deterministic preview fixtures and interaction checks, and document developer workflows, Slint implementation rules, visual review and USB delivery.

## Testing

- Inspected individual Slint preview screenshots and exercised editing/network flows at 1920×1080 (100% and 200%) and 1366×768 (100%), plus storage mouse/keyboard and inventory edge cases. Coverage and limits are recorded in `slint-ui/DESIGN_REVIEW.md`.
- Booted Ventoy in QEMU with valid, absent and invalid updates; checked the installed binary hash, fallback and service ordering before getty. Also booted the prepared physical USB through a read-only backing device with a local writable overlay. This does not establish physical laptop input behavior or a complete installation.
