### PR TITLE
Add guarded alongside installation with graphical allocation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,3 +51,19 @@ jobs:
 
     - name: Audit dependencies
       run: cargo audit
+
+  zbm-publisher:
+    # Real FAT publication test for the boot image scripts. It mounts a loop
+    # image, so it runs on the VM runner rather than in the builder container.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install tools
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends dosfstools shellcheck
+
+    - name: Lint publisher scripts
+      run: shellcheck core/assets/azfs-install-zbm core/assets/azfs-update-zbm core/tests/zbm-update-fixture.sh
+
+    - name: Run publisher fixture
+      run: sudo bash core/tests/zbm-update-fixture.sh

--- a/core/assets/azfs-install-zbm
+++ b/core/assets/azfs-install-zbm
@@ -1,0 +1,91 @@
+#!/usr/bin/bash
+# Publish an already generated image. No persistent backup is stored on the ESP.
+set -euo pipefail
+umask 077
+stage=${1:-/var/lib/zfsbootmenu}
+esp=${2:-/boot/efi}
+source_file=$stage/vmlinuz.EFI
+destination=$esp/EFI/zbm/vmlinuz.EFI
+recovery=$stage/previous-installed.EFI
+temporary=
+trap 'if [[ -n $temporary ]]; then rm -f -- "$temporary"; fi' EXIT
+fail() { printf 'ZFSBootMenu update failed: %s\n' "$*" >&2; exit 1; }
+
+[[ $(findmnt -n -o FSTYPE --target "$esp") == vfat ]] || fail "ESP is not mounted as FAT at $esp"
+[[ $(stat -c %d "$stage") != "$(stat -c %d "$esp")" ]] || fail "Build and recovery files must be outside the ESP"
+exec 9>"$stage/.install.lock"
+flock -n 9 || fail "Another ZFSBootMenu update is running"
+[[ -f $source_file && ! -L $source_file ]] || fail "No generated EFI image at $source_file"
+size=$(stat -c %s "$source_file")
+[[ $size -gt 4096 && $(od -An -tx1 -N2 "$source_file" | tr -d ' \n') == 4d5a ]] || fail "Generated image is not an EFI executable"
+# Check PE32+ / x86-64 / EFI application headers before touching the old loader.
+pe_offset=$(od -An -tu4 -j60 -N4 "$source_file" | tr -d ' \n')
+[[ $pe_offset =~ ^[0-9]+$ ]] || fail "Invalid PE header offset"
+(( pe_offset >= 64 && pe_offset + 94 <= size )) || fail "Invalid PE header offset"
+[[ $(od -An -tx1 -j"$pe_offset" -N6 "$source_file" | tr -d ' \n') == 504500006486 ]] || fail "Expected an x86-64 PE executable"
+[[ $(od -An -tx1 -j"$((pe_offset + 24))" -N2 "$source_file" | tr -d ' \n') == 0b02 ]] || fail "Expected PE32+"
+[[ $(od -An -tx1 -j"$((pe_offset + 92))" -N2 "$source_file" | tr -d ' \n') == 0a00 ]] || fail "Expected an EFI application"
+mkdir -p -- "${destination%/*}"
+[[ ! -L $destination ]] || fail "Refusing a symbolic-link destination"
+
+free_bytes() {
+    local blocks unit
+    read -r blocks unit < <(stat -f -c '%a %S' "$esp")
+    printf '%s\n' "$((blocks * unit))"
+}
+
+old_size=0
+if [[ -f $destination ]]; then
+    old_size=$(stat -c %s "$destination")
+    # Do not lose the last recovery copy on a repeated no-op update.
+    if cmp -s -- "$source_file" "$destination"; then exit 0; fi
+    cp -- "$destination" "$recovery.tmp"
+    cmp -s -- "$destination" "$recovery.tmp" || fail "Recovery copy verification failed"
+    sync -f "$recovery.tmp"
+    mv -f -- "$recovery.tmp" "$recovery"
+    sync -f "$stage"
+fi
+
+available=$(free_bytes)
+fallback=$esp/EFI/BOOT/BOOTX64.EFI
+# An optional, verified copy must not make the required update impossible.
+if (( available + old_size < size + 65536 )) && [[ -f $recovery && -f $fallback ]] && cmp -s -- "$recovery" "$fallback"; then
+    rm -- "$fallback"
+    sync -f "$esp"
+    available=$(free_bytes)
+fi
+if (( available < size + 65536 )); then
+    (( old_size > 0 && available + old_size >= size + 65536 )) || fail "New image does not fit; existing loader has been preserved"
+    printf 'ESP has room for one image. Previous loader saved at %s; replacing it directly.\n' "$recovery"
+    rm -- "$destination"
+    sync -f "$esp"
+fi
+temporary=$(mktemp "${destination%/*}/.zbm-update.XXXXXXXX")
+cp -- "$source_file" "$temporary"
+cmp -s -- "$source_file" "$temporary" || fail "Written image verification failed; recovery copy: $recovery"
+sync -f "$temporary"
+mv -f -- "$temporary" "$destination"
+temporary=
+sync -f "$esp"
+
+# A fallback is useful but optional. Never overwrite another loader or fail a
+# successful main-image update merely because a duplicate does not fit.
+if [[ -e $fallback ]]; then
+    if cmp -s -- "$source_file" "$fallback"; then exit 0; fi
+    if [[ ! -f $recovery ]] || ! cmp -s -- "$recovery" "$fallback"; then
+        printf 'Preserving existing EFI fallback.\n'
+        exit 0
+    fi
+fi
+if (( $(free_bytes) < size + 65536 )); then
+    printf 'Skipping optional EFI fallback update: insufficient free space.\n'
+    exit 0
+fi
+mkdir -p -- "${fallback%/*}"
+temporary=$(mktemp "${fallback%/*}/.zbm-update.XXXXXXXX")
+cp -- "$source_file" "$temporary"
+cmp -s -- "$source_file" "$temporary" || fail "Fallback verification failed; main loader is installed"
+sync -f "$temporary"
+mv -f -- "$temporary" "$fallback"
+temporary=
+sync -f "$esp"

--- a/core/assets/azfs-install-zbm
+++ b/core/assets/azfs-install-zbm
@@ -11,6 +11,7 @@ temporary=
 trap 'if [[ -n $temporary ]]; then rm -f -- "$temporary"; fi' EXIT
 fail() { printf 'ZFSBootMenu update failed: %s\n' "$*" >&2; exit 1; }
 
+[[ -d $stage ]] || fail "Build directory $stage is missing"
 [[ $(findmnt -n -o FSTYPE --target "$esp") == vfat ]] || fail "ESP is not mounted as FAT at $esp"
 [[ $(stat -c %d "$stage") != "$(stat -c %d "$esp")" ]] || fail "Build and recovery files must be outside the ESP"
 exec 9>"$stage/.install.lock"
@@ -47,15 +48,27 @@ if [[ -f $destination ]]; then
 fi
 
 available=$(free_bytes)
+needed=$((size + 65536))
 fallback=$esp/EFI/BOOT/BOOTX64.EFI
-# An optional, verified copy must not make the required update impossible.
-if (( available + old_size < size + 65536 )) && [[ -f $recovery && -f $fallback ]] && cmp -s -- "$recovery" "$fallback"; then
+# The fallback is ours when it matches an image this script installed: the
+# current or previous main image, or the digest recorded when it was written.
+# The digest survives updates that skipped the fallback for lack of space.
+fallback_digest=$stage/fallback.sha256
+fallback_owned() {
+    [[ -f $fallback && ! -L $fallback ]] || return 1
+    if [[ -f $destination ]] && cmp -s -- "$destination" "$fallback"; then return 0; fi
+    if [[ -f $recovery ]] && cmp -s -- "$recovery" "$fallback"; then return 0; fi
+    [[ -f $fallback_digest ]] && [[ $(sha256sum < "$fallback") == "$(< "$fallback_digest")" ]]
+}
+# An optional copy must not make the required update impossible, but removing
+# it is only useful when the reclaimed space actually lets the image fit.
+if (( available + old_size < needed )) && fallback_owned && (( available + old_size + $(stat -c %s "$fallback") >= needed )); then
     rm -- "$fallback"
     sync -f "$esp"
     available=$(free_bytes)
 fi
-if (( available < size + 65536 )); then
-    (( old_size > 0 && available + old_size >= size + 65536 )) || fail "New image does not fit; existing loader has been preserved"
+if (( available < needed )); then
+    (( old_size > 0 && available + old_size >= needed )) || fail "New image does not fit; existing loader has been preserved"
     printf 'ESP has room for one image. Previous loader saved at %s; replacing it directly.\n' "$recovery"
     rm -- "$destination"
     sync -f "$esp"
@@ -72,12 +85,12 @@ sync -f "$esp"
 # successful main-image update merely because a duplicate does not fit.
 if [[ -e $fallback ]]; then
     if cmp -s -- "$source_file" "$fallback"; then exit 0; fi
-    if [[ ! -f $recovery ]] || ! cmp -s -- "$recovery" "$fallback"; then
+    if ! fallback_owned; then
         printf 'Preserving existing EFI fallback.\n'
         exit 0
     fi
 fi
-if (( $(free_bytes) < size + 65536 )); then
+if (( $(free_bytes) < needed )); then
     printf 'Skipping optional EFI fallback update: insufficient free space.\n'
     exit 0
 fi
@@ -89,3 +102,6 @@ sync -f "$temporary"
 mv -f -- "$temporary" "$fallback"
 temporary=
 sync -f "$esp"
+sha256sum < "$fallback" > "$fallback_digest.tmp"
+mv -f -- "$fallback_digest.tmp" "$fallback_digest"
+sync -f "$stage"

--- a/core/assets/azfs-update-zbm
+++ b/core/assets/azfs-update-zbm
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+# Keep generation off the ESP and propagate publication failures to pacman.
+set -euo pipefail
+[[ $# == 0 ]] || { echo "Run azfs-update-zbm without arguments; configure /etc/zfsbootmenu/config.yaml" >&2; exit 1; }
+mkdir -p /var/lib/zfsbootmenu
+exec 8>/var/lib/zfsbootmenu/.update.lock
+flock -n 8 || { echo 'Another ZFSBootMenu build is running' >&2; exit 1; }
+generate-zbm
+exec /usr/local/libexec/azfs-install-zbm

--- a/core/assets/azfs-update-zbm
+++ b/core/assets/azfs-update-zbm
@@ -2,8 +2,14 @@
 # Keep generation off the ESP and propagate publication failures to pacman.
 set -euo pipefail
 [[ $# == 0 ]] || { echo "Run azfs-update-zbm without arguments; configure /etc/zfsbootmenu/config.yaml" >&2; exit 1; }
+esp=/boot/efi
 mkdir -p /var/lib/zfsbootmenu
 exec 8>/var/lib/zfsbootmenu/.update.lock
 flock -n 8 || { echo 'Another ZFSBootMenu build is running' >&2; exit 1; }
+# generate-zbm mounts an unmounted ESP itself and unmounts it again when it
+# exits; publication needs it afterwards. Mount it here so it stays mounted.
+if ! mountpoint -q "$esp"; then
+    mount "$esp" || { echo "ZFSBootMenu update failed: cannot mount $esp" >&2; exit 1; }
+fi
 generate-zbm
 exec /usr/local/libexec/azfs-install-zbm

--- a/core/examples/alongside_fixture.rs
+++ b/core/examples/alongside_fixture.rs
@@ -122,11 +122,7 @@ fn main() -> Result<()> {
             32 * GIB
         },
     };
-    let budget = BootSpace {
-        image_bytes: 50_681_856,
-        backup: false,
-        fallback: false,
-    };
+    let budget = BootSpace::default();
     request
         .efi
         .validate_space(&inspect_efi(&RealRunner, &before, 1, &filesystems)?, budget)?;

--- a/core/examples/alongside_fixture.rs
+++ b/core/examples/alongside_fixture.rs
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
             SpaceSource::Shrink { partition: 2 }
         },
         efi: if mode == "new-esp" {
-            EfiChoice::CreateAfterInsufficientSpace {
+            EfiChoice::CreateSeparate {
                 existing_partition: 1,
             }
         } else {

--- a/core/examples/alongside_fixture.rs
+++ b/core/examples/alongside_fixture.rs
@@ -1,0 +1,177 @@
+//! Destructive integration test restricted to a loop device created here.
+//! Run the built example as root; it takes a filesystem name, never a disk path.
+use archinstall_zfs_core::{
+    disk::alongside::*,
+    system::cmd::{CommandRunner, RealRunner, check_exit},
+};
+use color_eyre::eyre::{Result, ensure};
+use std::{fs::File, path::PathBuf, process::Command};
+
+struct LoopDevice(String);
+impl Drop for LoopDevice {
+    fn drop(&mut self) {
+        let _ = Command::new("losetup").args(["--detach", &self.0]).status();
+    }
+}
+fn run(program: &str, args: &[&str]) -> Result<String> {
+    let output = RealRunner.run(program, args)?;
+    check_exit(&output, program)?;
+    Ok(output.stdout)
+}
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let fs = std::env::args().nth(1).unwrap_or_else(|| "ext4".into());
+    let mode = std::env::args().nth(2).unwrap_or_else(|| "shrink".into());
+    ensure!(
+        matches!(mode.as_str(), "shrink" | "free" | "new-esp"),
+        "Mode must be shrink, free or new-esp"
+    );
+    ensure!(
+        matches!(fs.as_str(), "ext4" | "ntfs"),
+        "Pass ext4 or ntfs, not a device path"
+    );
+    let dir = tempfile::tempdir()?;
+    let image = dir.path().join("disk.img");
+    File::create(&image)?.set_len(120 * GIB)?;
+    let loop_path = run(
+        "losetup",
+        &["--find", "--show", "--partscan", image.to_str().unwrap()],
+    )?
+    .trim()
+    .to_owned();
+    let device = LoopDevice(loop_path);
+    ensure!(device.0.starts_with("/dev/loop"), "Unexpected loop device");
+    run(
+        "sgdisk",
+        &[
+            "--clear",
+            "--new=1:0:+500M",
+            "--typecode=1:ef00",
+            "--change-name=1:Existing EFI",
+            "--new=2:0:+70G",
+            if fs == "ntfs" {
+                "--typecode=2:0700"
+            } else {
+                "--typecode=2:8300"
+            },
+            "--change-name=2:Existing OS",
+            "--new=3:0:+1G",
+            "--typecode=3:2700",
+            "--change-name=3:Recovery",
+            &device.0,
+        ],
+    )?;
+    run("udevadm", &["settle"])?;
+    let efi = format!("{}p1", device.0);
+    let data = format!("{}p2", device.0);
+    run("mkfs.fat", &["-F32", &efi])?;
+    let sentinel = dir.path().join("sentinel.txt");
+    let contents = "Retained operating system data\n".repeat(4096);
+    std::fs::write(&sentinel, &contents)?;
+    run(
+        "mcopy",
+        &["-i", &efi, sentinel.to_str().unwrap(), "::KEEP.TXT"],
+    )?;
+    if mode == "new-esp" {
+        let filler = dir.path().join("filler.bin");
+        File::create(&filler)?.set_len(430 * MIB)?;
+        run(
+            "mcopy",
+            &["-i", &efi, filler.to_str().unwrap(), "::FILLER.BIN"],
+        )?;
+    }
+    if fs == "ntfs" {
+        run("mkntfs", &["--quick", &data])?;
+        run(
+            "ntfscp",
+            &[&data, sentinel.to_str().unwrap(), "/sentinel.txt"],
+        )?;
+    } else {
+        run("mkfs.ext4", &["-q", &data])?;
+        run(
+            "debugfs",
+            &[
+                "-w",
+                "-R",
+                &format!("write {} /sentinel.txt", sentinel.display()),
+                &data,
+            ],
+        )?;
+    }
+    let (before, filesystems) = inspect(&RealRunner, &PathBuf::from(&device.0))?;
+    let minimum = minimum_size(&RealRunner, &before.partitions[1], &fs)?;
+    eprintln!("{fs}: minimum with headroom {} MiB", minimum / MIB);
+    let request = Request {
+        before: before.clone(),
+        source: if mode == "free" {
+            let (start, end) = *before.free_extents()?.last().unwrap();
+            SpaceSource::Unallocated { start, end }
+        } else {
+            SpaceSource::Shrink { partition: 2 }
+        },
+        efi: if mode == "new-esp" {
+            EfiChoice::CreateAfterInsufficientSpace {
+                existing_partition: 1,
+            }
+        } else {
+            EfiChoice::Reuse { partition: 1 }
+        },
+        allocation_bytes: if mode == "new-esp" {
+            33 * GIB
+        } else {
+            32 * GIB
+        },
+    };
+    let budget = BootSpace {
+        image_bytes: 50_681_856,
+        backup: false,
+        fallback: false,
+    };
+    request
+        .efi
+        .validate_space(&inspect_efi(&RealRunner, &before, 1, &filesystems)?, budget)?;
+    let prepared = execute(&RealRunner, &request, budget, &dir.path().join("recovery"))?;
+    ensure!(
+        (prepared.efi == std::path::Path::new(&efi)) == (mode != "new-esp"),
+        "EFI selection did not follow the explicit plan"
+    );
+    let actual = if fs == "ntfs" {
+        // ntfsresize schedules Windows' consistency check. Read the test
+        // payload despite that flag; do not clear it or force a resize.
+        ensure!(
+            mode == "free" || RealRunner.run("ntfsresize", &["--info", &data])?.exit_code != 0,
+            "NTFS check-required flag was unexpectedly cleared"
+        );
+        run("ntfscat", &["--force", &data, "/sentinel.txt"])?
+    } else {
+        run("debugfs", &["-R", "cat /sentinel.txt", &data])?
+    };
+    ensure!(actual == contents, "Retained filesystem content changed");
+    ensure!(
+        run("mtype", &["-i", &efi, "::KEEP.TXT"])? == contents,
+        "Existing ESP content changed"
+    );
+    let after = Layout::read(&RealRunner, &PathBuf::from(&device.0))?;
+    ensure!(
+        after.partitions.len() == before.partitions.len() + if mode == "new-esp" { 2 } else { 1 },
+        "Unexpected partition count"
+    );
+    if mode == "free" {
+        ensure!(
+            before.partitions[1] == after.partitions[1],
+            "Using free space changed the existing data partition"
+        );
+    }
+    ensure!(
+        before.partitions[0] == after.partitions[0] && before.partitions[2] == after.partitions[2],
+        "Existing ESP or recovery partition changed"
+    );
+    ensure!(
+        execute(&RealRunner, &request, budget, &dir.path().join("retry")).is_err(),
+        "Stale plan was accepted"
+    );
+    eprintln!(
+        "PASS: {fs} {mode}, retained payload, ESP content, recovery geometry, new ZFS partition and stale-plan rejection"
+    );
+    Ok(())
+}

--- a/core/examples/alongside_fixture.rs
+++ b/core/examples/alongside_fixture.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
     let fs = std::env::args().nth(1).unwrap_or_else(|| "ext4".into());
     let mode = std::env::args().nth(2).unwrap_or_else(|| "shrink".into());
     ensure!(
-        matches!(mode.as_str(), "shrink" | "free" | "new-esp"),
+        matches!(mode.as_str(), "shrink" | "free" | "new-esp" | "swap"),
         "Mode must be shrink, free or new-esp"
     );
     ensure!(
@@ -116,8 +116,11 @@ fn main() -> Result<()> {
         } else {
             EfiChoice::Reuse { partition: 1 }
         },
+        swap_bytes: if mode == "swap" { 8 * GIB } else { 0 },
         allocation_bytes: if mode == "new-esp" {
             33 * GIB
+        } else if mode == "swap" {
+            40 * GIB
         } else {
             32 * GIB
         },
@@ -149,9 +152,25 @@ fn main() -> Result<()> {
     );
     let after = Layout::read(&RealRunner, &PathBuf::from(&device.0))?;
     ensure!(
-        after.partitions.len() == before.partitions.len() + if mode == "new-esp" { 2 } else { 1 },
+        after.partitions.len()
+            == before.partitions.len()
+                + if matches!(mode.as_str(), "new-esp" | "swap") {
+                    2
+                } else {
+                    1
+                },
         "Unexpected partition count"
     );
+    if mode == "swap" {
+        let swap = prepared.swap.as_ref().expect("planned swap node");
+        ensure!(
+            after
+                .partitions
+                .iter()
+                .any(|p| &p.node == swap && p.size * after.sectorsize == 8 * GIB),
+            "Swap size differs from plan"
+        );
+    }
     if mode == "free" {
         ensure!(
             before.partitions[1] == after.partitions[1],

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -1,5 +1,5 @@
-use std::fs::{self, File, OpenOptions};
-use std::io::{BufReader, Read, Write};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{Context, Result};
@@ -69,7 +69,7 @@ fn write_zbm_config(target: &Path, init_system: InitSystem) -> Result<()> {
         },
         components: ZbmComponents { enabled: false },
         efi: ZbmEfi {
-            image_dir: "/boot/efi/EFI/zbm".into(),
+            image_dir: "/var/lib/zfsbootmenu".into(),
             versions: false,
             enabled: true,
         },
@@ -106,108 +106,30 @@ Target = zfs-utils
 [Action]
 Description = Regenerating ZFSBootMenu...
 When = PostTransaction
-Exec = /usr/bin/generate-zbm
+Exec = /usr/local/sbin/azfs-update-zbm
 Depends = zfsbootmenu
 "#;
 
 fn install_zbm_pacman_hook(target: &Path) -> Result<()> {
+    for (path, contents) in [
+        (
+            "usr/local/libexec/azfs-install-zbm",
+            include_str!("../assets/azfs-install-zbm"),
+        ),
+        (
+            "usr/local/sbin/azfs-update-zbm",
+            include_str!("../assets/azfs-update-zbm"),
+        ),
+    ] {
+        let path = target.join(path);
+        fs::create_dir_all(path.parent().unwrap())?;
+        fs::write(&path, contents)?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755))?;
+    }
     let hooks_dir = target.join("etc/pacman.d/hooks");
     fs::create_dir_all(&hooks_dir)?;
     fs::write(hooks_dir.join("95-zfsbootmenu.hook"), ZBM_PACMAN_HOOK)?;
     tracing::info!("installed ZBM pacman hook");
-    Ok(())
-}
-
-fn files_equal(a: &Path, b: &Path) -> Result<bool> {
-    let a_meta = fs::metadata(a)?;
-    let b_meta = fs::metadata(b)?;
-    if a_meta.len() != b_meta.len() {
-        return Ok(false);
-    }
-
-    let mut a = BufReader::new(File::open(a)?);
-    let mut b = BufReader::new(File::open(b)?);
-    let mut a_buf = [0_u8; 64 * 1024];
-    let mut b_buf = [0_u8; 64 * 1024];
-    loop {
-        let a_len = a.read(&mut a_buf)?;
-        let b_len = b.read(&mut b_buf)?;
-        if a_len != b_len || a_buf[..a_len] != b_buf[..b_len] {
-            return Ok(false);
-        }
-        if a_len == 0 {
-            return Ok(true);
-        }
-    }
-}
-
-fn copy_file_atomically(source: &Path, destination: &Path) -> Result<()> {
-    let parent = destination
-        .parent()
-        .ok_or_else(|| color_eyre::eyre::eyre!("EFI destination has no parent directory"))?;
-    let source_len = fs::metadata(source)?.len();
-    let fs_info = nix::sys::statvfs::statvfs(parent)?;
-    let available = fs_info
-        .blocks_available()
-        .saturating_mul(fs_info.fragment_size());
-    if available < source_len {
-        color_eyre::eyre::bail!(
-            "EFI system partition has {} MiB free, but the ZFSBootMenu fallback needs {} MiB",
-            available / (1024 * 1024),
-            source_len.div_ceil(1024 * 1024)
-        );
-    }
-
-    let temporary = destination.with_extension(format!("EFI.azfs-{}.tmp", std::process::id()));
-    let result = (|| -> Result<()> {
-        let mut input = File::open(source)?;
-        let mut output = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temporary)?;
-        std::io::copy(&mut input, &mut output)?;
-        output.flush()?;
-        output.sync_all()?;
-        fs::rename(&temporary, destination)?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&temporary);
-    }
-    result.wrap_err_with(|| {
-        format!(
-            "failed to atomically install EFI fallback {}",
-            destination.display()
-        )
-    })
-}
-
-fn install_fallback(target: &Path) -> Result<()> {
-    let zbm_dir = target.join("boot/efi/EFI/zbm");
-    let source = zbm_dir.join("vmlinuz.EFI");
-    if !source.is_file() {
-        color_eyre::eyre::bail!(
-            "generate-zbm did not create the configured EFI image {}",
-            source.display()
-        );
-    }
-
-    let fallback_dir = target.join("boot/efi/EFI/BOOT");
-    fs::create_dir_all(&fallback_dir)?;
-    let fallback = fallback_dir.join("BOOTX64.EFI");
-    let previous = zbm_dir.join("vmlinuz-backup.EFI");
-    let owned_previous =
-        fallback.is_file() && previous.is_file() && files_equal(&fallback, &previous)?;
-    if fallback.exists() && !files_equal(&fallback, &source)? && !owned_previous {
-        tracing::warn!(
-            path = %fallback.display(),
-            "preserving an existing EFI fallback that is not owned by ZFSBootMenu"
-        );
-        return Ok(());
-    }
-
-    copy_file_atomically(&source, &fallback)?;
-    tracing::info!("installed ZFSBootMenu as EFI/BOOT/BOOTX64.EFI fallback");
     Ok(())
 }
 
@@ -273,10 +195,8 @@ pub async fn install_and_generate_zbm(
         install_zbm_pacman_hook(&t)?;
 
         tracing::info!("running generate-zbm to build EFI bundle");
-        let output = chroot_cmd(&*r, &t, "generate-zbm", &[])?;
-        check_exit(&output, "generate-zbm")?;
-
-        install_fallback(&t)?;
+        let output = chroot_cmd(&*r, &t, "/usr/local/sbin/azfs-update-zbm", &[])?;
+        check_exit(&output, "generate and install ZFSBootMenu")?;
 
         tracing::info!("ZFSBootMenu built and installed locally");
         Ok(())
@@ -500,6 +420,7 @@ mod tests {
         assert!(config.contains("InitCPIO: false"));
         assert!(config.contains("zbm.timeout=10"));
         assert!(config.contains("Versions: false"));
+        assert!(config.contains("ImageDir: /var/lib/zfsbootmenu"));
         assert!(config.contains("Enabled: true"));
         assert!(config.contains("Prefix: vmlinuz"));
     }
@@ -540,7 +461,7 @@ mod tests {
         let hook_path = dir.path().join("etc/pacman.d/hooks/95-zfsbootmenu.hook");
         assert!(hook_path.exists());
         let content = fs::read_to_string(&hook_path).unwrap();
-        assert!(content.contains("generate-zbm"));
+        assert!(content.contains("azfs-update-zbm"));
         assert!(content.contains("zfs.ko"));
         assert!(content.contains("pkgbase"));
         // A new ZBM or zfs-utils release changes neither the kernel nor
@@ -548,40 +469,6 @@ mod tests {
         assert!(content.contains("Type = Package"));
         assert!(content.contains("Target = zfsbootmenu"));
         assert!(content.contains("Target = zfs-utils"));
-    }
-
-    #[test]
-    fn test_fallback_preserves_an_unowned_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let zbm = dir.path().join("boot/efi/EFI/zbm");
-        let boot = dir.path().join("boot/efi/EFI/BOOT");
-        fs::create_dir_all(&zbm).unwrap();
-        fs::create_dir_all(&boot).unwrap();
-        fs::write(zbm.join("vmlinuz.EFI"), b"new zbm").unwrap();
-        fs::write(boot.join("BOOTX64.EFI"), b"another bootloader").unwrap();
-
-        install_fallback(dir.path()).unwrap();
-
-        assert_eq!(
-            fs::read(boot.join("BOOTX64.EFI")).unwrap(),
-            b"another bootloader"
-        );
-    }
-
-    #[test]
-    fn test_fallback_updates_the_previous_zbm_copy() {
-        let dir = tempfile::tempdir().unwrap();
-        let zbm = dir.path().join("boot/efi/EFI/zbm");
-        let boot = dir.path().join("boot/efi/EFI/BOOT");
-        fs::create_dir_all(&zbm).unwrap();
-        fs::create_dir_all(&boot).unwrap();
-        fs::write(zbm.join("vmlinuz.EFI"), b"new zbm").unwrap();
-        fs::write(zbm.join("vmlinuz-backup.EFI"), b"old zbm").unwrap();
-        fs::write(boot.join("BOOTX64.EFI"), b"old zbm").unwrap();
-
-        install_fallback(dir.path()).unwrap();
-
-        assert_eq!(fs::read(boot.join("BOOTX64.EFI")).unwrap(), b"new zbm");
     }
 
     fn target_with_zbm(backup: bool) -> tempfile::TempDir {

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 
 use crate::boot_environment::BootEnvironment;
 use crate::config::types::InitSystem;
+use crate::installer::initramfs::mkinitcpio::set_conf_line;
 use crate::system::cmd::{CommandRunner, check_exit, chroot_cmd};
 
 pub const HOSTID_VALUE: &str = "0x00bab10c";
@@ -54,7 +55,25 @@ struct ZbmKernel {
     command_line: String,
 }
 
-/// Write /etc/zfsbootmenu/config.yaml inside the target chroot.
+/// Image size settings for the dracut build. The image must fit next to an
+/// existing operating system on a stock 100 MiB Windows ESP, so it is built
+/// for this machine's hardware. dracut's default host-only mode keeps every
+/// storage, USB and keyboard driver; only unrelated device classes are left
+/// out. `xz -9` is slower to build than the default zstd level but produces
+/// a smaller image. Measured on a stock `linux-lts` target: 36 MiB without
+/// this file, 33 MiB with it. Omitting `i18n` saves 50 KiB, but it loads the
+/// configured console keymap, so it stays.
+const ZBM_DRACUT_CONF: &str = r#"# Written by archinstall_zfs; keep ZFSBootMenu small enough for a shared ESP.
+hostonly="yes"
+hostonly_cmdline="no"
+# ZFSBootMenu never runs filesystem checks or mounts /usr.
+omit_dracutmodules+=" fs-lib usrmount "
+compress="xz -9 --check=crc32 -T0"
+"#;
+
+/// Write /etc/zfsbootmenu/config.yaml and the image size settings inside the
+/// target chroot. Both initramfs generators are configured: config.yaml
+/// selects the one in use.
 fn write_zbm_config(target: &Path, init_system: InitSystem) -> Result<()> {
     let conf_dir = target.join("etc/zfsbootmenu");
     fs::create_dir_all(&conf_dir)?;
@@ -84,6 +103,30 @@ fn write_zbm_config(target: &Path, init_system: InitSystem) -> Result<()> {
     let yaml = serde_yaml_ng::to_string(&config).wrap_err("failed to serialize ZBM config")?;
     fs::write(conf_dir.join("config.yaml"), yaml).wrap_err("failed to write ZBM config.yaml")?;
     tracing::info!("wrote /etc/zfsbootmenu/config.yaml (init_system={init_system})");
+
+    let dracut_dir = conf_dir.join("dracut.conf.d");
+    fs::create_dir_all(&dracut_dir)?;
+    fs::write(dracut_dir.join("azfs.conf"), ZBM_DRACUT_CONF)
+        .wrap_err("failed to write ZBM dracut configuration")?;
+
+    // The `autodetect` hook in the packaged file already limits modules to
+    // this machine; only the compressor needs changing.
+    let mkinitcpio_conf = conf_dir.join("mkinitcpio.conf");
+    if mkinitcpio_conf.exists() {
+        let content = fs::read_to_string(&mkinitcpio_conf)?;
+        let content = set_conf_line(&content, "COMPRESSION", "COMPRESSION=\"xz\"");
+        // mkinitcpio adds --check=crc32 itself for xz.
+        let content = set_conf_line(
+            &content,
+            "COMPRESSION_OPTIONS",
+            "COMPRESSION_OPTIONS=(-9 -T0)",
+        );
+        fs::write(&mkinitcpio_conf, content).wrap_err("failed to write ZBM mkinitcpio.conf")?;
+    } else if matches!(init_system, InitSystem::Mkinitcpio) {
+        tracing::warn!(
+            "/etc/zfsbootmenu/mkinitcpio.conf is missing; the ZBM image will use the default compression"
+        );
+    }
     Ok(())
 }
 
@@ -322,18 +365,21 @@ pub fn create_efi_entries(
         "\\EFI\\zbm\\vmlinuz.EFI",
         true,
     )?;
-    if target.join("boot/efi/EFI/zbm/vmlinuz-backup.EFI").is_file() {
-        ensure_efi_entry(
-            runner,
-            &existing.stdout,
-            &location,
-            "ZFSBootMenu (Backup)",
-            "\\EFI\\zbm\\vmlinuz-backup.EFI",
-            false,
-        )?;
+    // Earlier releases kept a second image on the ESP and registered it as
+    // "ZFSBootMenu (Backup)". The publisher no longer writes that file, so
+    // such an entry would point at a stale image; remove it from firmware.
+    for (number, label, _) in existing.stdout.lines().filter_map(boot_entry) {
+        if label != "ZFSBootMenu (Backup)" {
+            continue;
+        }
+        let output = runner.run("efibootmgr", &["-b", number, "-B"])?;
+        if !output.success() {
+            tracing::warn!(number, "failed to remove the obsolete backup EFI entry");
+        }
     }
+    let _ = target;
 
-    tracing::info!("created ZFSBootMenu EFI boot entries");
+    tracing::info!("created ZFSBootMenu EFI boot entry");
     Ok(())
 }
 
@@ -423,6 +469,38 @@ mod tests {
         assert!(config.contains("ImageDir: /var/lib/zfsbootmenu"));
         assert!(config.contains("Enabled: true"));
         assert!(config.contains("Prefix: vmlinuz"));
+
+        let dracut =
+            fs::read_to_string(dir.path().join("etc/zfsbootmenu/dracut.conf.d/azfs.conf")).unwrap();
+        assert!(dracut.contains("hostonly=\"yes\""));
+        assert!(dracut.contains("hostonly_cmdline=\"no\""));
+        assert!(dracut.contains("omit_dracutmodules+=\" fs-lib usrmount \""));
+        assert!(dracut.contains("compress=\"xz -9 --check=crc32 -T0\""));
+        assert!(!dracut.contains("i18n"));
+        assert!(!dir.path().join("etc/zfsbootmenu/mkinitcpio.conf").exists());
+    }
+
+    #[test]
+    fn test_write_zbm_config_compresses_packaged_mkinitcpio_conf() {
+        let dir = tempfile::tempdir().unwrap();
+        let conf = dir.path().join("etc/zfsbootmenu/mkinitcpio.conf");
+        fs::create_dir_all(conf.parent().unwrap()).unwrap();
+        fs::write(
+            &conf,
+            "HOOKS=(base udev autodetect modconf block filesystems keyboard zfsbootmenu)\n#COMPRESSION=\"zstd\"\n#COMPRESSION=\"xz\"\n#COMPRESSION_OPTIONS=()\n",
+        )
+        .unwrap();
+        write_zbm_config(dir.path(), InitSystem::Mkinitcpio).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&conf).unwrap(),
+            "HOOKS=(base udev autodetect modconf block filesystems keyboard zfsbootmenu)\nCOMPRESSION=\"xz\"\n#COMPRESSION=\"xz\"\nCOMPRESSION_OPTIONS=(-9 -T0)\n"
+        );
+        assert!(
+            dir.path()
+                .join("etc/zfsbootmenu/dracut.conf.d/azfs.conf")
+                .is_file()
+        );
     }
 
     #[test]
@@ -471,21 +549,18 @@ mod tests {
         assert!(content.contains("Target = zfs-utils"));
     }
 
-    fn target_with_zbm(backup: bool) -> tempfile::TempDir {
+    fn target_with_zbm() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
         let zbm = dir.path().join("boot/efi/EFI/zbm");
         fs::create_dir_all(&zbm).unwrap();
         fs::write(zbm.join("vmlinuz.EFI"), b"main").unwrap();
-        if backup {
-            fs::write(zbm.join("vmlinuz-backup.EFI"), b"backup").unwrap();
-        }
         dir
     }
 
     #[test]
     fn test_create_efi_entries_uses_the_selected_disk_and_partition() {
         // With locally-built ZBM, cmdline is embedded - no -u needed
-        let target = target_with_zbm(true);
+        let target = target_with_zbm();
         let runner = RecordingRunner::new(vec![
             CannedResponse {
                 stdout: "/dev/nvme0n1 7 AABB-CCDD\n".into(),
@@ -496,7 +571,6 @@ mod tests {
                 ..Default::default()
             },
             CannedResponse::default(), // efibootmgr -c (main)
-            CannedResponse::default(), // efibootmgr -c (backup)
         ]);
 
         create_efi_entries(
@@ -520,19 +594,15 @@ mod tests {
     }
 
     #[test]
-    fn test_matching_entries_are_kept() {
-        let target = target_with_zbm(true);
+    fn test_matching_entry_is_kept() {
+        let target = target_with_zbm();
         let runner = RecordingRunner::new(vec![
             CannedResponse {
                 stdout: "/dev/sda 1 aabb-ccdd\n".into(),
                 ..Default::default()
             },
             CannedResponse {
-                stdout: concat!(
-                    "Boot0001* ZFSBootMenu\tHD(1,GPT,AABB-CCDD,0x800,0x1000)/File(\\EFI\\zbm\\vmlinuz.EFI)\n",
-                    "Boot0002* ZFSBootMenu (Backup)\tHD(1,GPT,AABB-CCDD,0x800,0x1000)/File(\\EFI\\zbm\\vmlinuz-backup.EFI)\n"
-                )
-                .into(),
+                stdout: "Boot0001* ZFSBootMenu\tHD(1,GPT,AABB-CCDD,0x800,0x1000)/File(\\EFI\\zbm\\vmlinuz.EFI)\n".into(),
                 ..Default::default()
             },
         ]);
@@ -543,8 +613,8 @@ mod tests {
     }
 
     #[test]
-    fn test_backup_entry_does_not_hide_a_missing_main_entry() {
-        let target = target_with_zbm(true);
+    fn test_obsolete_backup_entry_is_removed_and_main_entry_created() {
+        let target = target_with_zbm();
         let runner = RecordingRunner::new(vec![
             CannedResponse {
                 stdout: "/dev/sda 1 aabb-ccdd\n".into(),
@@ -555,18 +625,20 @@ mod tests {
                 ..Default::default()
             },
             CannedResponse::default(),
+            CannedResponse::default(),
         ]);
 
         create_efi_entries(&runner, Path::new("/dev/sda1"), target.path()).unwrap();
 
         let calls = runner.calls();
-        assert_eq!(calls.len(), 3);
+        assert_eq!(calls.len(), 4);
         assert!(calls[2].args.windows(2).any(|a| a == ["-L", "ZFSBootMenu"]));
+        assert_eq!(calls[3].args, ["-b", "0002", "-B"]);
     }
 
     #[test]
     fn test_stale_same_name_entry_is_replaced() {
-        let target = target_with_zbm(false);
+        let target = target_with_zbm();
         let runner = RecordingRunner::new(vec![
             CannedResponse {
                 stdout: "/dev/sda 3 aabb-ccdd\n".into(),

--- a/core/src/config/choices.rs
+++ b/core/src/config/choices.rs
@@ -66,6 +66,7 @@ impl Choice for InstallationMode {
         (Self::FullDisk, "Full Disk"),
         (Self::NewPool, "New Pool"),
         (Self::ExistingPool, "Existing Pool"),
+        (Self::Alongside, "Alongside"),
     ];
 }
 
@@ -168,6 +169,7 @@ mod tests {
             InstallationMode::FullDisk,
             InstallationMode::NewPool,
             InstallationMode::ExistingPool,
+            InstallationMode::Alongside,
         ]);
         assert_listed(&[
             CompressionAlgo::Off,

--- a/core/src/config/edit.rs
+++ b/core/src/config/edit.rs
@@ -180,6 +180,7 @@ pub fn apply_choice(config: &mut GlobalConfig, setting: ChoiceSetting, index: us
                 {
                     config.pool_name = None;
                 }
+                config.alongside = None;
                 config.disk = None;
                 config.efi_partition = None;
                 config.zfs_partition = None;
@@ -241,7 +242,10 @@ pub fn apply_device(config: &mut GlobalConfig, setting: DeviceSetting, path: &Pa
     match setting {
         DeviceSetting::Disk => {
             // Choosing a disk is what puts the wizard in full-disk mode.
-            config.installation_mode = Some(InstallationMode::FullDisk);
+            if config.installation_mode != Some(InstallationMode::Alongside) {
+                config.installation_mode = Some(InstallationMode::FullDisk);
+            }
+            config.alongside = None;
             config.disk = Some(path);
         }
         DeviceSetting::EfiPartition => config.efi_partition = Some(path),

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -16,6 +16,7 @@ pub enum InstallationMode {
     FullDisk,
     NewPool,
     ExistingPool,
+    Alongside,
 }
 
 impl std::fmt::Display for InstallationMode {
@@ -24,6 +25,7 @@ impl std::fmt::Display for InstallationMode {
             Self::FullDisk => write!(f, "Full Disk"),
             Self::NewPool => write!(f, "New Pool"),
             Self::ExistingPool => write!(f, "Existing Pool"),
+            Self::Alongside => write!(f, "Alongside"),
         }
     }
 }
@@ -154,6 +156,8 @@ pub struct GlobalConfig {
 
     // Flow control
     pub installation_mode: Option<InstallationMode>,
+    #[serde(default)]
+    pub alongside: Option<crate::disk::alongside::Request>,
     #[serde(default, alias = "disk_by_id")]
     pub disk: Option<PathBuf>,
     #[serde(default, alias = "efi_partition_by_id")]
@@ -359,6 +363,7 @@ impl Default for GlobalConfig {
         Self {
             distribution: default_distribution(),
             installation_mode: None,
+            alongside: None,
             disk: None,
             efi_partition: None,
             zfs_partition: None,

--- a/core/src/config/validation.rs
+++ b/core/src/config/validation.rs
@@ -14,6 +14,7 @@ use super::types::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
     InstallationModeNotSelected,
+    AlongsidePlan(String),
     PoolNameMissing,
     PoolNameInvalid(String),
     DatasetPrefixInvalid(String),
@@ -66,6 +67,7 @@ pub fn is_valid_username(name: &str) -> bool {
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::AlongsidePlan(reason) => write!(f, "Alongside installation: {reason}"),
             Self::InstallationModeNotSelected => write!(f, "Installation mode not selected"),
             Self::PoolNameMissing => write!(f, "Pool name is required"),
             Self::PoolNameInvalid(name) => write!(
@@ -163,6 +165,26 @@ impl GlobalConfig {
         );
 
         match mode {
+            InstallationMode::Alongside => {
+                match &self.alongside {
+                    Some(request) => {
+                        if let Err(e) = request.plan() {
+                            errors.push(ValidationError::AlongsidePlan(e.to_string()));
+                        }
+                    }
+                    None => errors.push(ValidationError::AlongsidePlan(
+                        "Choose a disk, space allocation and EFI partition".into(),
+                    )),
+                }
+                if let Some(request) = &self.alongside
+                    && wants_swap_partition != (request.swap_bytes > 0)
+                {
+                    errors.push(ValidationError::AlongsidePlan(
+                        "Swap method differs from the disk allocation; update the storage plan"
+                            .into(),
+                    ));
+                }
+            }
             InstallationMode::FullDisk => {
                 if self.disk.is_none() {
                     errors.push(ValidationError::DiskRequired);

--- a/core/src/disk/alongside.rs
+++ b/core/src/disk/alongside.rs
@@ -1,0 +1,406 @@
+//! Planning storage changes without moving existing partition starts.
+//!
+//! Sector geometry is kept as integers; UI percentages are presentation only.
+//! A saved layout is an optimistic concurrency token, never authority to write.
+
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Result, WrapErr, bail, ensure, eyre};
+use serde::{Deserialize, Serialize};
+
+use crate::system::cmd::{CommandRunner, check_exit};
+
+mod efi;
+mod execute;
+pub use execute::execute;
+mod probe;
+pub use efi::{BootSpace, EfiChoice, EfiSpace, inspect_efi};
+pub use probe::{Filesystem, inspect, minimum_size};
+
+pub const MIB: u64 = 1024 * 1024;
+pub const GIB: u64 = 1024 * MIB;
+pub const MIN_LINUX_BYTES: u64 = 32 * GIB;
+pub const ESP_BYTES: u64 = GIB;
+pub const EFI_TYPE: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+pub const BASIC_TYPE: &str = "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7";
+pub const LINUX_TYPE: &str = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Partition {
+    pub node: PathBuf,
+    pub start: u64,
+    pub size: u64,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub uuid: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub attrs: String,
+}
+
+impl Partition {
+    pub fn end(&self) -> Result<u64> {
+        self.start
+            .checked_add(self.size)
+            .ok_or_else(|| eyre!("Partition geometry overflow"))
+    }
+
+    pub fn number(&self, disk: &Path) -> Result<u32> {
+        let node = self
+            .node
+            .to_str()
+            .ok_or_else(|| eyre!("Invalid partition path"))?;
+        let disk = disk.to_str().ok_or_else(|| eyre!("Invalid disk path"))?;
+        let suffix = node
+            .strip_prefix(disk)
+            .ok_or_else(|| eyre!("Partition belongs to another disk"))?;
+        let number: u32 = suffix.strip_prefix('p').unwrap_or(suffix).parse()?;
+        ensure!(
+            number > 0 && number <= 128,
+            "Unsupported GPT partition number"
+        );
+        Ok(number)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Layout {
+    pub label: String,
+    pub id: String,
+    pub device: PathBuf,
+    pub unit: String,
+    pub firstlba: u64,
+    pub lastlba: u64,
+    pub sectorsize: u64,
+    #[serde(default)]
+    pub partitions: Vec<Partition>,
+}
+
+impl Layout {
+    pub fn parse(json: &str) -> Result<Self> {
+        // Diagnose MBR before decoding GPT-only fields.
+        let v: serde_json::Value = serde_json::from_str(json)?;
+        let table = &v["partitiontable"];
+        ensure!(
+            table["label"] == "gpt",
+            "This disk does not use GPT. Installing alongside another system requires GPT; automatic MBR conversion is not supported. Existing data has not been changed."
+        );
+        let layout: Self = serde_json::from_value(table.clone())?;
+        layout.validate()?;
+        Ok(layout)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        ensure!(
+            self.label == "gpt" && self.unit == "sectors",
+            "A GPT sector layout is required"
+        );
+        ensure!(
+            matches!(self.sectorsize, 512 | 4096),
+            "Unsupported logical sector size"
+        );
+        ensure!(
+            !self.id.is_empty() && self.firstlba > 0 && self.lastlba >= self.firstlba,
+            "Invalid GPT identity or usable range"
+        );
+        self.lastlba
+            .checked_add(1)
+            .and_then(|n| n.checked_mul(self.sectorsize))
+            .ok_or_else(|| eyre!("Disk size overflow"))?;
+        let mut sorted: Vec<_> = self.partitions.iter().collect();
+        sorted.sort_by_key(|p| p.start);
+        let mut end = self.firstlba;
+        let mut numbers = std::collections::BTreeSet::new();
+        let mut ids = std::collections::BTreeSet::new();
+        for p in sorted {
+            ensure!(
+                p.size > 0 && p.start >= end && p.end()? <= self.lastlba + 1,
+                "Overlapping or out-of-range GPT partitions"
+            );
+            ensure!(
+                !p.uuid.is_empty()
+                    && ids.insert(p.uuid.to_uppercase())
+                    && numbers.insert(p.number(&self.device)?),
+                "Duplicate or missing GPT partition identity"
+            );
+            end = p.end()?;
+        }
+        Ok(())
+    }
+
+    pub fn read(runner: &dyn CommandRunner, disk: &Path) -> Result<Self> {
+        let disk = std::fs::canonicalize(disk)
+            .wrap_err_with(|| format!("Selected disk {} is unavailable", disk.display()))?;
+        let out = runner.run("sfdisk", &["--json", &disk.to_string_lossy()])
+            .wrap_err("Cannot inspect the partition table. Install util-linux (sfdisk) in the live system")?;
+        check_exit(&out, "Read partition table")?;
+        Self::parse(&out.stdout)
+    }
+
+    pub fn free_extents(&self) -> Result<Vec<(u64, u64)>> {
+        self.validate()?;
+        let mut sorted: Vec<_> = self.partitions.iter().collect();
+        sorted.sort_by_key(|p| p.start);
+        let mut start = self.firstlba;
+        let mut result = Vec::new();
+        for p in sorted {
+            if p.start > start {
+                result.push((start, p.start));
+            }
+            start = p.end()?;
+        }
+        if start <= self.lastlba {
+            result.push((start, self.lastlba + 1));
+        }
+        Ok(result)
+    }
+}
+
+/// An explicit region selected by the user. A partition shrink frees space at
+/// its end; existing gaps are selectable independently and are never merged
+/// across an intervening partition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SpaceSource {
+    Shrink { partition: u32 },
+    Unallocated { start: u64, end: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Request {
+    pub before: Layout,
+    pub source: SpaceSource,
+    pub efi: EfiChoice,
+    /// Includes a new ESP only when explicitly requested after a space check.
+    pub allocation_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Plan {
+    pub shrink: Option<(Partition, u64)>,
+    pub efi_number: u32,
+    pub zfs_number: u32,
+    pub efi_start: Option<u64>,
+    pub zfs_start: u64,
+    pub end: u64,
+}
+
+impl Request {
+    pub fn plan(&self) -> Result<Plan> {
+        let l = &self.before;
+        l.validate()?;
+        let additional_efi = matches!(self.efi, EfiChoice::CreateAfterInsufficientSpace { .. });
+        let efi_bytes = if additional_efi { ESP_BYTES } else { 0 };
+        ensure!(
+            self.allocation_bytes >= MIN_LINUX_BYTES + efi_bytes,
+            "Reserve at least 32 GiB for Linux, plus 1 GiB if creating an additional EFI partition"
+        );
+        let existing_efi = self.efi.existing_partition();
+        ensure!(
+            l.partitions
+                .iter()
+                .any(|p| p.number(&l.device).ok() == Some(existing_efi)
+                    && p.kind.eq_ignore_ascii_case(EFI_TYPE)),
+            "Select an existing EFI system partition on this disk"
+        );
+        ensure!(
+            self.allocation_bytes.is_multiple_of(MIB),
+            "Allocation must be aligned to MiB"
+        );
+        let alignment = MIB / l.sectorsize;
+        let allocation = self.allocation_bytes / l.sectorsize;
+        let (start, end, shrink) = match self.source {
+            SpaceSource::Shrink { partition } => {
+                ensure!(
+                    partition != existing_efi,
+                    "The existing EFI partition must not be shrunk"
+                );
+                let p = l
+                    .partitions
+                    .iter()
+                    .find(|p| p.number(&l.device).ok() == Some(partition))
+                    .ok_or_else(|| eyre!("Selected partition is missing"))?;
+                let end = p.end()? / alignment * alignment;
+                let start = end
+                    .checked_sub(allocation)
+                    .ok_or_else(|| eyre!("Not enough space"))?;
+                ensure!(
+                    start > p.start,
+                    "Allocation would erase the selected filesystem"
+                );
+                (start, end, Some((p.clone(), start - p.start)))
+            }
+            SpaceSource::Unallocated { start, end } => {
+                ensure!(
+                    l.free_extents()?.contains(&(start, end)),
+                    "Selected unallocated extent has changed"
+                );
+                let aligned = start.div_ceil(alignment) * alignment;
+                let new_end = aligned
+                    .checked_add(allocation)
+                    .ok_or_else(|| eyre!("Allocation overflow"))?;
+                ensure!(
+                    new_end <= end,
+                    "Allocation exceeds the selected free extent"
+                );
+                (aligned, new_end, None)
+            }
+        };
+        let needed = if additional_efi { 2 } else { 1 };
+        let unused: Vec<_> = (1..=128)
+            .filter(|n| {
+                !l.partitions
+                    .iter()
+                    .any(|p| p.number(&l.device).ok() == Some(*n))
+            })
+            .take(needed)
+            .collect();
+        ensure!(
+            unused.len() == needed,
+            "GPT has no room for the requested partition entries"
+        );
+        Ok(Plan {
+            shrink,
+            efi_number: if additional_efi {
+                unused[0]
+            } else {
+                existing_efi
+            },
+            zfs_number: unused[needed - 1],
+            efi_start: additional_efi.then_some(start),
+            zfs_start: start + efi_bytes / l.sectorsize,
+            end,
+        })
+    }
+}
+
+/// Does not run any filesystem tools, mount filesystems, or repair metadata.
+/// This is a capability check, not proof that a particular filesystem is safe.
+pub fn required_tools(filesystem: &str) -> Result<&'static [(&'static str, &'static str)]> {
+    match filesystem {
+        "ntfs" => Ok(&[("ntfsresize", "ntfs-3g"), ("ntfs-3g.probe", "ntfs-3g")]),
+        "ext4" => Ok(&[
+            ("resize2fs", "e2fsprogs"),
+            ("e2fsck", "e2fsprogs"),
+            ("dumpe2fs", "e2fsprogs"),
+        ]),
+        "crypto_LUKS" | "BitLocker" => bail!(
+            "Encrypted partitions cannot be resized by this installer. Shrink them from the existing system, then select unallocated space."
+        ),
+        "LVM2_member" | "linux_raid_member" => bail!(
+            "Resizing LVM or RAID containers is not supported. Use the existing system's storage tools to make unallocated space."
+        ),
+        "btrfs" => bail!(
+            "Automatic Btrfs shrinking is not supported yet. Make unallocated space first, then select it here."
+        ),
+        _ => bail!(
+            "Shrinking {filesystem} is not supported. You can use unallocated space without resizing this partition."
+        ),
+    }
+}
+
+pub fn check_tools(tools: &[(&str, &str)]) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let search = std::env::var_os("PATH").unwrap_or_default();
+    let missing: Vec<_> = tools
+        .iter()
+        .filter(|(name, _)| {
+            !std::env::split_paths(&search).any(|dir| {
+                std::fs::metadata(dir.join(name))
+                    .is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+            })
+        })
+        .map(|(name, package)| format!("{name} ({package})"))
+        .collect();
+    ensure!(
+        missing.is_empty(),
+        "This operation is unavailable: install {} in the live system, then refresh. Other installation modes remain available.",
+        missing.join(", ")
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layout(sectorsize: u64) -> Layout {
+        Layout {
+            label: "gpt".into(),
+            id: "disk-guid".into(),
+            device: "/dev/nvme0n1".into(),
+            unit: "sectors".into(),
+            firstlba: MIB / sectorsize,
+            lastlba: 128 * GIB / sectorsize - 34,
+            sectorsize,
+            partitions: vec![Partition {
+                node: "/dev/nvme0n1p3".into(),
+                start: GIB / sectorsize,
+                size: 100 * GIB / sectorsize,
+                kind: BASIC_TYPE.into(),
+                uuid: "partition-guid".into(),
+                name: "Data".into(),
+                attrs: "".into(),
+            }],
+        }
+    }
+
+    #[test]
+    fn shrink_preserves_start_and_allocates_with_both_sector_sizes() {
+        for sectorsize in [512, 4096] {
+            let mut l = layout(sectorsize);
+            l.partitions.push(Partition {
+                node: "/dev/nvme0n1p1".into(),
+                start: MIB / sectorsize,
+                size: (GIB - MIB) / sectorsize,
+                kind: EFI_TYPE.into(),
+                uuid: "efi-guid".into(),
+                name: "EFI".into(),
+                attrs: "".into(),
+            });
+            let r = Request {
+                before: l.clone(),
+                source: SpaceSource::Shrink { partition: 3 },
+                efi: EfiChoice::Reuse { partition: 1 },
+                allocation_bytes: 32 * GIB,
+            };
+            let p = r.plan().unwrap();
+            let (old, size) = p.shrink.unwrap();
+            assert_eq!(old, l.partitions[0]);
+            assert_eq!((old.start + size) * sectorsize, 69 * GIB);
+            assert_eq!((p.end - p.zfs_start) * sectorsize, 32 * GIB);
+            assert_eq!((p.efi_number, p.zfs_number), (1, 2));
+        }
+    }
+
+    #[test]
+    fn rejects_mbr_even_without_gpt_fields() {
+        assert!(
+            Layout::parse(r#"{"partitiontable":{"label":"dos"}}"#)
+                .unwrap_err()
+                .to_string()
+                .contains("MBR")
+        );
+    }
+
+    #[test]
+    fn rejects_overlap_overflow_and_allocation_through_neighbours() {
+        let mut l = layout(512);
+        l.partitions.push(l.partitions[0].clone());
+        assert!(l.validate().is_err());
+        l.partitions.pop();
+        l.partitions[0].size = u64::MAX;
+        assert!(l.validate().is_err());
+        let l = layout(512);
+        let r = Request {
+            before: l,
+            source: SpaceSource::Unallocated {
+                start: 2048,
+                end: 128 * GIB / 512,
+            },
+            efi: EfiChoice::Reuse { partition: 1 },
+            allocation_bytes: 33 * GIB,
+        };
+        assert!(r.plan().is_err());
+    }
+}

--- a/core/src/disk/alongside.rs
+++ b/core/src/disk/alongside.rs
@@ -20,7 +20,8 @@ pub use probe::{Filesystem, inspect, minimum_size};
 pub const MIB: u64 = 1024 * 1024;
 pub const GIB: u64 = 1024 * MIB;
 pub const MIN_LINUX_BYTES: u64 = 32 * GIB;
-pub const ESP_BYTES: u64 = GIB;
+/// Size of the optional separate ESP; matches the full-disk layout.
+pub const ESP_BYTES: u64 = 512 * MIB;
 pub const EFI_TYPE: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
 pub const BASIC_TYPE: &str = "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7";
 pub const LINUX_TYPE: &str = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
@@ -171,7 +172,7 @@ pub struct Request {
     pub before: Layout,
     pub source: SpaceSource,
     pub efi: EfiChoice,
-    /// Includes a new ESP only when explicitly requested after a space check.
+    /// Includes the separate ESP when one was explicitly selected.
     pub allocation_bytes: u64,
     /// Optional new swap partition, included in allocation_bytes.
     #[serde(default)]
@@ -194,7 +195,7 @@ impl Request {
     pub fn plan(&self) -> Result<Plan> {
         let l = &self.before;
         l.validate()?;
-        let additional_efi = matches!(self.efi, EfiChoice::CreateAfterInsufficientSpace { .. });
+        let additional_efi = matches!(self.efi, EfiChoice::CreateSeparate { .. });
         let efi_bytes = if additional_efi { ESP_BYTES } else { 0 };
         let minimum = MIN_LINUX_BYTES
             .checked_add(efi_bytes)
@@ -206,7 +207,7 @@ impl Request {
         );
         ensure!(
             self.allocation_bytes >= minimum,
-            "Reserve at least 32 GiB for the ZFS pool, plus the selected swap and any additional EFI partition"
+            "Reserve at least 32 GiB for the ZFS pool, plus the selected swap and the separate EFI partition if selected"
         );
         let existing_efi = self.efi.existing_partition();
         ensure!(

--- a/core/src/disk/alongside.rs
+++ b/core/src/disk/alongside.rs
@@ -173,6 +173,9 @@ pub struct Request {
     pub efi: EfiChoice,
     /// Includes a new ESP only when explicitly requested after a space check.
     pub allocation_bytes: u64,
+    /// Optional new swap partition, included in allocation_bytes.
+    #[serde(default)]
+    pub swap_bytes: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -183,6 +186,8 @@ pub struct Plan {
     pub efi_start: Option<u64>,
     pub zfs_start: u64,
     pub end: u64,
+    pub swap_number: Option<u32>,
+    pub swap_start: Option<u64>,
 }
 
 impl Request {
@@ -191,9 +196,17 @@ impl Request {
         l.validate()?;
         let additional_efi = matches!(self.efi, EfiChoice::CreateAfterInsufficientSpace { .. });
         let efi_bytes = if additional_efi { ESP_BYTES } else { 0 };
+        let minimum = MIN_LINUX_BYTES
+            .checked_add(efi_bytes)
+            .and_then(|n| n.checked_add(self.swap_bytes))
+            .ok_or_else(|| eyre!("Allocation overflow"))?;
         ensure!(
-            self.allocation_bytes >= MIN_LINUX_BYTES + efi_bytes,
-            "Reserve at least 32 GiB for Linux, plus 1 GiB if creating an additional EFI partition"
+            self.swap_bytes.is_multiple_of(MIB),
+            "Swap size must be aligned to MiB"
+        );
+        ensure!(
+            self.allocation_bytes >= minimum,
+            "Reserve at least 32 GiB for the ZFS pool, plus the selected swap and any additional EFI partition"
         );
         let existing_efi = self.efi.existing_partition();
         ensure!(
@@ -246,7 +259,7 @@ impl Request {
                 (aligned, new_end, None)
             }
         };
-        let needed = if additional_efi { 2 } else { 1 };
+        let needed = 1 + usize::from(additional_efi) + usize::from(self.swap_bytes > 0);
         let unused: Vec<_> = (1..=128)
             .filter(|n| {
                 !l.partitions
@@ -270,6 +283,8 @@ impl Request {
             efi_start: additional_efi.then_some(start),
             zfs_start: start + efi_bytes / l.sectorsize,
             end,
+            swap_number: (self.swap_bytes > 0).then(|| unused[usize::from(additional_efi)]),
+            swap_start: (self.swap_bytes > 0).then_some(end - self.swap_bytes / l.sectorsize),
         })
     }
 }
@@ -358,11 +373,12 @@ mod tests {
                 name: "EFI".into(),
                 attrs: "".into(),
             });
-            let r = Request {
+            let mut r = Request {
                 before: l.clone(),
                 source: SpaceSource::Shrink { partition: 3 },
                 efi: EfiChoice::Reuse { partition: 1 },
                 allocation_bytes: 32 * GIB,
+                swap_bytes: 0,
             };
             let p = r.plan().unwrap();
             let (old, size) = p.shrink.unwrap();
@@ -370,6 +386,19 @@ mod tests {
             assert_eq!((old.start + size) * sectorsize, 69 * GIB);
             assert_eq!((p.end - p.zfs_start) * sectorsize, 32 * GIB);
             assert_eq!((p.efi_number, p.zfs_number), (1, 2));
+            r.swap_bytes = 8 * GIB;
+            assert!(
+                r.plan().is_err(),
+                "swap cannot consume the minimum ZFS capacity"
+            );
+            r.allocation_bytes = 40 * GIB;
+            let p = r.plan().unwrap();
+            assert_eq!((p.swap_start.unwrap() - p.zfs_start) * sectorsize, 32 * GIB);
+            assert_eq!((p.end - p.swap_start.unwrap()) * sectorsize, 8 * GIB);
+            assert_ne!(p.swap_number, Some(p.zfs_number));
+            assert_ne!(p.swap_number, Some(p.efi_number));
+            r.swap_bytes = u64::MAX;
+            assert!(r.plan().is_err());
         }
     }
 
@@ -400,6 +429,7 @@ mod tests {
             },
             efi: EfiChoice::Reuse { partition: 1 },
             allocation_bytes: 33 * GIB,
+            swap_bytes: 0,
         };
         assert!(r.plan().is_err());
     }

--- a/core/src/disk/alongside/efi.rs
+++ b/core/src/disk/alongside/efi.rs
@@ -1,0 +1,220 @@
+use super::*;
+
+/// Pass the actual generated image size. Never decide to create a second ESP
+/// from a guessed bundle size. Existing files are conservatively not credited
+/// as reclaimable; the installer does not own other bootloaders' files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BootSpace {
+    pub image_bytes: u64,
+    pub backup: bool,
+    pub fallback: bool,
+}
+
+impl BootSpace {
+    pub fn required_bytes(self) -> Result<u64> {
+        ensure!(
+            self.image_bytes > 0,
+            "Build or select the ZFSBootMenu image before calculating EFI space"
+        );
+        // Main image plus one replacement, and only explicitly enabled copies.
+        // Reserve a modest allowance for cluster rounding and directory entries.
+        self.image_bytes
+            .checked_mul(2 + u64::from(self.backup) + u64::from(self.fallback))
+            .and_then(|size| size.checked_add(8 * MIB))
+            .ok_or_else(|| eyre!("EFI space calculation overflow"))
+    }
+}
+
+/// A second ESP is never a default or an error fallback. It must refer to the
+/// existing ESP whose capacity was checked; execution repeats that check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EfiChoice {
+    Reuse { partition: u32 },
+    CreateAfterInsufficientSpace { existing_partition: u32 },
+}
+
+impl EfiChoice {
+    pub fn existing_partition(&self) -> u32 {
+        match *self {
+            Self::Reuse { partition } => partition,
+            Self::CreateAfterInsufficientSpace { existing_partition } => existing_partition,
+        }
+    }
+
+    pub fn validate_space(&self, space: &EfiSpace, budget: BootSpace) -> Result<()> {
+        ensure!(
+            self.existing_partition() == space.partition,
+            "EFI capacity check belongs to another partition"
+        );
+        match self {
+            Self::Reuse { .. } => ensure!(
+                space.sufficient(budget)?,
+                "The existing EFI partition has {} MiB free; {} MiB is reserved for boot files and updates. Choose explicitly whether to create an additional EFI partition, or free space and refresh.",
+                space.free_bytes / MIB,
+                budget.required_bytes()?.div_ceil(MIB)
+            ),
+            Self::CreateAfterInsufficientSpace { .. } => ensure!(
+                !space.sufficient(BootSpace {
+                    backup: false,
+                    fallback: false,
+                    ..budget
+                })?,
+                "The existing EFI partition fits the main image and an update. Reuse it; disable optional copies if necessary. A second ESP is offered only when the minimum configuration does not fit."
+            ),
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EfiSpace {
+    pub partition: u32,
+    pub free_bytes: u64,
+}
+
+impl EfiSpace {
+    pub fn sufficient(&self, budget: BootSpace) -> Result<bool> {
+        Ok(self.free_bytes >= budget.required_bytes()?)
+    }
+}
+
+/// Inspect FAT without mounting or repairing it. A failed consistency or
+/// capacity check is not a low-space result.
+pub fn inspect_efi(
+    runner: &dyn CommandRunner,
+    layout: &Layout,
+    number: u32,
+    filesystems: &[Filesystem],
+) -> Result<EfiSpace> {
+    check_tools(&[("fsck.fat", "dosfstools"), ("mdir", "mtools")])?;
+    let p = layout
+        .partitions
+        .iter()
+        .find(|p| p.number(&layout.device).ok() == Some(number))
+        .ok_or_else(|| eyre!("EFI partition disappeared"))?;
+    ensure!(
+        p.kind.eq_ignore_ascii_case(EFI_TYPE),
+        "Selected partition is not an ESP"
+    );
+    ensure!(
+        filesystems
+            .iter()
+            .any(|f| f.path == p.node && f.fstype.as_deref() == Some("vfat")),
+        "The existing ESP must contain a FAT filesystem"
+    );
+    probe::run(runner, "fsck.fat", &["-n", &p.node.to_string_lossy()]).wrap_err("The existing EFI filesystem needs maintenance. No additional ESP is offered for a failed filesystem check")?;
+    let output = probe::run(runner, "mdir", &["-i", &p.node.to_string_lossy(), "::"])?;
+    let free_bytes = parse_free_bytes(&output)?;
+    ensure!(
+        free_bytes <= p.size * layout.sectorsize,
+        "Invalid EFI free-space result"
+    );
+    Ok(EfiSpace {
+        partition: number,
+        free_bytes,
+    })
+}
+
+fn parse_free_bytes(output: &str) -> Result<u64> {
+    let lines: Vec<_> = output
+        .lines()
+        .filter_map(|l| l.trim().strip_suffix("bytes free"))
+        .collect();
+    ensure!(
+        lines.len() == 1,
+        "Cannot determine free space on the existing ESP; refresh after checking the filesystem"
+    );
+    let digits: String = lines[0].chars().filter(|c| !c.is_whitespace()).collect();
+    Ok(digits.parse()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn measured_image_and_only_enabled_copies_contribute_to_budget() {
+        let budget = BootSpace {
+            image_bytes: 50_681_856,
+            backup: false,
+            fallback: false,
+        };
+        assert_eq!(budget.required_bytes().unwrap(), 2 * 50_681_856 + 8 * MIB);
+        assert_eq!(
+            BootSpace {
+                backup: true,
+                ..budget
+            }
+            .required_bytes()
+            .unwrap(),
+            3 * 50_681_856 + 8 * MIB
+        );
+        assert!(
+            BootSpace {
+                image_bytes: 0,
+                ..budget
+            }
+            .required_bytes()
+            .is_err()
+        );
+        assert!(
+            BootSpace {
+                image_bytes: u64::MAX,
+                ..budget
+            }
+            .required_bytes()
+            .is_err()
+        );
+    }
+    #[test]
+    fn second_esp_requires_insufficient_space_on_the_selected_esp() {
+        let budget = BootSpace {
+            image_bytes: 50 * MIB,
+            backup: false,
+            fallback: false,
+        };
+        let required = budget.required_bytes().unwrap();
+        let enough = EfiSpace {
+            partition: 1,
+            free_bytes: required,
+        };
+        let small = EfiSpace {
+            partition: 1,
+            free_bytes: required - 1,
+        };
+        let reuse = EfiChoice::Reuse { partition: 1 };
+        let create = EfiChoice::CreateAfterInsufficientSpace {
+            existing_partition: 1,
+        };
+        assert!(reuse.validate_space(&enough, budget).is_ok());
+        assert!(reuse.validate_space(&small, budget).is_err());
+        assert!(create.validate_space(&small, budget).is_ok());
+        assert!(create.validate_space(&enough, budget).is_err());
+        let with_backup = BootSpace {
+            backup: true,
+            ..budget
+        };
+        assert!(reuse.validate_space(&enough, with_backup).is_err());
+        // An optional copy must not justify repartitioning the disk.
+        assert!(create.validate_space(&enough, with_backup).is_err());
+        assert!(
+            create
+                .validate_space(
+                    &EfiSpace {
+                        partition: 2,
+                        ..small
+                    },
+                    budget
+                )
+                .is_err()
+        );
+    }
+    #[test]
+    fn unreadable_capacity_is_not_zero_space() {
+        assert_eq!(
+            parse_free_bytes("  123 456 789 bytes free\n").unwrap(),
+            123456789
+        );
+        assert!(parse_free_bytes("Device unavailable").is_err());
+        assert!(parse_free_bytes("12 bytes free\n34 bytes free").is_err());
+    }
+}

--- a/core/src/disk/alongside/efi.rs
+++ b/core/src/disk/alongside/efi.rs
@@ -1,8 +1,8 @@
 use super::*;
 
-/// Pass the actual generated image size. Never decide to create a second ESP
-/// from a guessed bundle size. Existing files are conservatively not credited
-/// as reclaimable; the installer does not own other bootloaders' files.
+/// Planning uses a 100 MiB image allowance, informed by published EFI assets.
+/// Actual installation verifies the generated file before replacing anything.
+/// Existing files are not credited as reclaimable: they may be other loaders.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BootSpace {
     pub image_bytes: u64,
@@ -10,16 +10,26 @@ pub struct BootSpace {
     pub fallback: bool,
 }
 
+impl Default for BootSpace {
+    fn default() -> Self {
+        Self {
+            image_bytes: 100 * MIB,
+            backup: false,
+            fallback: false,
+        }
+    }
+}
+
 impl BootSpace {
     pub fn required_bytes(self) -> Result<u64> {
         ensure!(
             self.image_bytes > 0,
-            "Build or select the ZFSBootMenu image before calculating EFI space"
+            "ZFSBootMenu image allowance must be nonzero"
         );
-        // Main image plus one replacement, and only explicitly enabled copies.
+        // One image, and only explicitly enabled persistent copies.
         // Reserve a modest allowance for cluster rounding and directory entries.
         self.image_bytes
-            .checked_mul(2 + u64::from(self.backup) + u64::from(self.fallback))
+            .checked_mul(1 + u64::from(self.backup) + u64::from(self.fallback))
             .and_then(|size| size.checked_add(8 * MIB))
             .ok_or_else(|| eyre!("EFI space calculation overflow"))
     }
@@ -59,7 +69,7 @@ impl EfiChoice {
                     fallback: false,
                     ..budget
                 })?,
-                "The existing EFI partition fits the main image and an update. Reuse it; disable optional copies if necessary. A second ESP is offered only when the minimum configuration does not fit."
+                "The existing EFI partition fits the main image with headroom. Reuse it; disable optional copies if necessary. A second ESP is offered only when the minimum configuration does not fit."
             ),
         }
         Ok(())
@@ -138,7 +148,7 @@ mod tests {
             backup: false,
             fallback: false,
         };
-        assert_eq!(budget.required_bytes().unwrap(), 2 * 50_681_856 + 8 * MIB);
+        assert_eq!(budget.required_bytes().unwrap(), 50_681_856 + 8 * MIB);
         assert_eq!(
             BootSpace {
                 backup: true,
@@ -146,7 +156,7 @@ mod tests {
             }
             .required_bytes()
             .unwrap(),
-            3 * 50_681_856 + 8 * MIB
+            2 * 50_681_856 + 8 * MIB
         );
         assert!(
             BootSpace {

--- a/core/src/disk/alongside/efi.rs
+++ b/core/src/disk/alongside/efi.rs
@@ -1,8 +1,11 @@
 use super::*;
 
-/// Planning uses a 100 MiB image allowance, informed by published EFI assets.
-/// Actual installation verifies the generated file before replacing anything.
-/// Existing files are not credited as reclaimable: they may be other loaders.
+/// Planning uses a 48 MiB image allowance. The image is built for this machine
+/// with `xz -9` (see `bootmenu::ZBM_DRACUT_CONF`); a stock `linux-lts` target
+/// measured 33 MiB. With the 8 MiB overhead, a 100 MiB Windows ESP holding only
+/// Microsoft's loader qualifies for reuse. Actual installation verifies the
+/// generated file before replacing anything. Existing files are not credited
+/// as reclaimable: they may be other loaders.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BootSpace {
     pub image_bytes: u64,
@@ -13,7 +16,7 @@ pub struct BootSpace {
 impl Default for BootSpace {
     fn default() -> Self {
         Self {
-            image_bytes: 100 * MIB,
+            image_bytes: 48 * MIB,
             backup: false,
             fallback: false,
         }
@@ -35,19 +38,28 @@ impl BootSpace {
     }
 }
 
-/// A second ESP is never a default or an error fallback. It must refer to the
-/// existing ESP whose capacity was checked; execution repeats that check.
+/// Reuse is the default and the recommendation. A separate ESP is only ever an
+/// explicit selection, never an automatic fallback: it costs `ESP_BYTES` of the
+/// allocation and leaves two ESPs for firmware and the other system to choose
+/// between. Both variants name the existing ESP that was inspected, so a disk
+/// without a readable FAT ESP is rejected either way; execution repeats that
+/// inspection.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EfiChoice {
-    Reuse { partition: u32 },
-    CreateAfterInsufficientSpace { existing_partition: u32 },
+    Reuse {
+        partition: u32,
+    },
+    #[serde(alias = "CreateAfterInsufficientSpace")]
+    CreateSeparate {
+        existing_partition: u32,
+    },
 }
 
 impl EfiChoice {
     pub fn existing_partition(&self) -> u32 {
         match *self {
             Self::Reuse { partition } => partition,
-            Self::CreateAfterInsufficientSpace { existing_partition } => existing_partition,
+            Self::CreateSeparate { existing_partition } => existing_partition,
         }
     }
 
@@ -56,21 +68,13 @@ impl EfiChoice {
             self.existing_partition() == space.partition,
             "EFI capacity check belongs to another partition"
         );
-        match self {
-            Self::Reuse { .. } => ensure!(
+        if let Self::Reuse { .. } = self {
+            ensure!(
                 space.sufficient(budget)?,
-                "The existing EFI partition has {} MiB free; {} MiB is reserved for boot files and updates. Choose explicitly whether to create an additional EFI partition, or free space and refresh.",
+                "The existing EFI partition has {} MiB free; {} MiB is needed for boot files and updates. Select a separate EFI partition, or free space and refresh.",
                 space.free_bytes / MIB,
                 budget.required_bytes()?.div_ceil(MIB)
-            ),
-            Self::CreateAfterInsufficientSpace { .. } => ensure!(
-                !space.sufficient(BootSpace {
-                    backup: false,
-                    fallback: false,
-                    ..budget
-                })?,
-                "The existing EFI partition fits the main image with headroom. Reuse it; disable optional copies if necessary. A second ESP is offered only when the minimum configuration does not fit."
-            ),
+            );
         }
         Ok(())
     }
@@ -176,7 +180,7 @@ mod tests {
         );
     }
     #[test]
-    fn second_esp_requires_insufficient_space_on_the_selected_esp() {
+    fn reuse_requires_space_and_a_separate_esp_is_an_explicit_choice() {
         let budget = BootSpace {
             image_bytes: 50 * MIB,
             backup: false,
@@ -192,31 +196,37 @@ mod tests {
             free_bytes: required - 1,
         };
         let reuse = EfiChoice::Reuse { partition: 1 };
-        let create = EfiChoice::CreateAfterInsufficientSpace {
+        let create = EfiChoice::CreateSeparate {
             existing_partition: 1,
         };
         assert!(reuse.validate_space(&enough, budget).is_ok());
         assert!(reuse.validate_space(&small, budget).is_err());
+        // The separate ESP is allowed whether or not the existing one fits.
         assert!(create.validate_space(&small, budget).is_ok());
-        assert!(create.validate_space(&enough, budget).is_err());
+        assert!(create.validate_space(&enough, budget).is_ok());
         let with_backup = BootSpace {
             backup: true,
             ..budget
         };
         assert!(reuse.validate_space(&enough, with_backup).is_err());
-        // An optional copy must not justify repartitioning the disk.
-        assert!(create.validate_space(&enough, with_backup).is_err());
-        assert!(
-            create
-                .validate_space(
-                    &EfiSpace {
-                        partition: 2,
-                        ..small
-                    },
-                    budget
-                )
-                .is_err()
-        );
+        // Either choice must refer to the ESP whose capacity was inspected.
+        for choice in [&reuse, &create] {
+            assert!(
+                choice
+                    .validate_space(
+                        &EfiSpace {
+                            partition: 2,
+                            ..enough
+                        },
+                        budget
+                    )
+                    .is_err()
+            );
+        }
+        let old_name: EfiChoice =
+            serde_json::from_str(r#"{"CreateAfterInsufficientSpace":{"existing_partition":1}}"#)
+                .unwrap();
+        assert_eq!(old_name, create);
     }
     #[test]
     fn unreadable_capacity_is_not_zero_space() {

--- a/core/src/disk/alongside/execute.rs
+++ b/core/src/disk/alongside/execute.rs
@@ -231,11 +231,17 @@ fn apply(
             "--new={}:{}:{}",
             plan.zfs_number,
             plan.zfs_start,
-            plan.end - 1
+            plan.swap_start.unwrap_or(plan.end) - 1
         ),
         format!("--typecode={}:bf00", plan.zfs_number),
-        dev.to_string(),
     ]);
+    if let (Some(number), Some(start)) = (plan.swap_number, plan.swap_start) {
+        args.extend([
+            format!("--new={number}:{start}:{}", plan.end - 1),
+            format!("--typecode={number}:8200"),
+        ]);
+    }
+    args.push(dev.to_string());
     probe::run(
         runner,
         "sgdisk",
@@ -256,7 +262,9 @@ fn apply(
     Ok(crate::prepare::PreparedPartitions {
         efi,
         zfs: Some(zfs),
-        swap: None,
+        swap: plan
+            .swap_number
+            .map(|n| super::super::partition::partition_path(disk, n)),
     })
 }
 
@@ -269,7 +277,7 @@ fn verify_created(before: &Layout, after: &Layout, plan: &Plan) -> Result<()> {
         .ok_or_else(|| eyre!("New ZFS partition is missing"))?;
     ensure!(
         zfs.start == plan.zfs_start
-            && zfs.end()? == plan.end
+            && zfs.end()? == plan.swap_start.unwrap_or(plan.end)
             && zfs
                 .kind
                 .eq_ignore_ascii_case("6A85CF4D-1DD2-11B2-99A6-080020736631"),
@@ -288,8 +296,24 @@ fn verify_created(before: &Layout, after: &Layout, plan: &Plan) -> Result<()> {
             "New EFI partition differs from plan"
         );
     }
+    if let (Some(number), Some(start)) = (plan.swap_number, plan.swap_start) {
+        let swap = retained
+            .partitions
+            .iter()
+            .find(|p| p.number(&before.device).ok() == Some(number))
+            .ok_or_else(|| eyre!("New swap partition is missing"))?;
+        ensure!(
+            swap.start == start
+                && swap.end()? == plan.end
+                && swap
+                    .kind
+                    .eq_ignore_ascii_case("0657FD6D-A4AB-43C4-84E5-0933C84B4F4F"),
+            "New swap partition differs from plan"
+        );
+    }
     retained.partitions.retain(|p| {
         p.number(&before.device).ok() != Some(plan.zfs_number)
+            && !(plan.swap_number.is_some() && p.number(&before.device).ok() == plan.swap_number)
             && !(plan.efi_start.is_some() && p.number(&before.device).ok() == Some(plan.efi_number))
     });
     ensure!(

--- a/core/src/disk/alongside/execute.rs
+++ b/core/src/disk/alongside/execute.rs
@@ -24,6 +24,7 @@ pub fn execute(
         ("sfdisk", "util-linux"),
         ("sgdisk", "gptfdisk"),
         ("lsblk", "util-linux"),
+        ("blockdev", "util-linux"),
     ])?;
     let disk = &request.before.device;
     let mut handle = OpenOptions::new().read(true).write(true).open(disk)?;
@@ -105,7 +106,78 @@ pub fn execute(
     backup.sync_all()?;
     File::open(recovery_dir)?.sync_all()?;
     tracing::info!(path = %recovery_dir.display(), "Saved partition table before resizing; this is not a filesystem backup");
-    apply(runner, request, &plan, filesystem.as_deref()).wrap_err_with(|| format!("Storage operation stopped. Some changes may already have completed. Do not retry or restore GPT blindly. Original partition table: {}", recovery_dir.join("partition-table.sfdisk").display()))
+    let prepared = apply(runner, request, &plan, filesystem.as_deref()).wrap_err_with(|| format!("Storage operation stopped. Some changes may already have completed. Do not retry or restore GPT blindly. Original partition table: {}", recovery_dir.join("partition-table.sfdisk").display()))?;
+    // Persistent aliases are created by udev, which may be waiting for the
+    // disk lock. Release it before waiting for them.
+    drop(handle);
+    for path in std::iter::once(&prepared.efi)
+        .chain(prepared.zfs.iter())
+        .chain(prepared.swap.iter())
+    {
+        crate::disk::partition::wait_for_path(path)?;
+    }
+    Ok(prepared)
+}
+
+/// Prefer a persistent `/dev/disk/by-id` alias for paths that are written
+/// into the installed system, as the full-disk layout does. The kernel node
+/// is only a fallback: it can change across boots.
+fn stable_disk_path(disk: &Path) -> PathBuf {
+    let Ok(canonical) = disk.canonicalize() else {
+        return disk.to_path_buf();
+    };
+    let Ok(entries) = std::fs::read_dir("/dev/disk/by-id") else {
+        return disk.to_path_buf();
+    };
+    let mut aliases: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.canonicalize().ok().as_deref() == Some(&canonical))
+        .collect();
+    aliases.sort();
+    // Model and serial names read better than WWN or EUI identifiers, but
+    // any persistent alias is preferable to the kernel node.
+    let generic = |p: &PathBuf| {
+        let name = p
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        name.starts_with("wwn-") || name.starts_with("nvme-eui.")
+    };
+    aliases
+        .iter()
+        .find(|p| !generic(p))
+        .or_else(|| aliases.first())
+        .cloned()
+        .unwrap_or_else(|| {
+            tracing::warn!(disk = %disk.display(), "No persistent alias for the disk; using the kernel node");
+            disk.to_path_buf()
+        })
+}
+
+/// The partitioning tools exit successfully even when the kernel refuses to
+/// re-read the table (`EBUSY` while another process holds a partition node).
+/// The GPT on disk is complete at that point; ask for a rescan before giving
+/// up rather than reporting a consistent disk as damaged.
+fn sync_kernel_partitions(runner: &dyn CommandRunner, disk: &Path) -> Result<()> {
+    let mut last = None;
+    for attempt in 1..=5 {
+        match inspect(runner, disk) {
+            Ok(_) => return Ok(()),
+            Err(error) => last = Some(error),
+        }
+        tracing::warn!(
+            attempt,
+            "Kernel partition table is stale; requesting a rescan"
+        );
+        let out = runner.run("blockdev", &["--rereadpt", &disk.to_string_lossy()])?;
+        if !out.success() {
+            tracing::warn!(stderr = %out.stderr, "Partition table rescan was refused");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    Err(last.expect("at least one attempt")).wrap_err(
+        "The kernel still reports the previous partition table. The GPT on disk is complete; close programs using this disk (or reboot the live system) and retry the plan after refreshing",
+    )
 }
 
 fn validate_protective_mbr(mbr: &[u8; 512]) -> Result<()> {
@@ -253,18 +325,18 @@ fn apply(
     let after = Layout::read(runner, disk)?;
     verify_created(&expected, &after, plan)?;
     // Compare kernel-reported sizes before a node is handed to mkfs or ZFS.
-    inspect(runner, disk)?;
-    let efi = super::super::partition::partition_path(disk, plan.efi_number);
-    let zfs = super::super::partition::partition_path(disk, plan.zfs_number);
+    sync_kernel_partitions(runner, disk)?;
+    use super::super::partition::partition_path;
     if plan.efi_start.is_some() {
-        crate::disk::partition::format_efi(runner, &efi)?;
+        // The kernel node exists now; persistent aliases appear only after
+        // udev runs, which must not be awaited under the disk lock.
+        crate::disk::partition::format_efi(runner, &partition_path(disk, plan.efi_number))?;
     }
+    let stable = stable_disk_path(disk);
     Ok(crate::prepare::PreparedPartitions {
-        efi,
-        zfs: Some(zfs),
-        swap: plan
-            .swap_number
-            .map(|n| super::super::partition::partition_path(disk, n)),
+        efi: partition_path(&stable, plan.efi_number),
+        zfs: Some(partition_path(&stable, plan.zfs_number)),
+        swap: plan.swap_number.map(|n| partition_path(&stable, n)),
     })
 }
 

--- a/core/src/disk/alongside/execute.rs
+++ b/core/src/disk/alongside/execute.rs
@@ -1,0 +1,314 @@
+use super::*;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::{FileTypeExt, OpenOptionsExt};
+
+/// Apply an explicitly confirmed plan. The caller must run this off the UI
+/// thread, and must not cancel it between filesystem shrink and GPT update.
+/// This operation never mounts or formats an existing partition.
+///
+/// `budget` must describe the boot image being installed. `recovery_dir` must
+/// be a new directory on the live filesystem, outside the disk being changed.
+/// A partial failure is reported, never automatically rolled back or retried.
+pub fn execute(
+    runner: &dyn CommandRunner,
+    request: &Request,
+    budget: BootSpace,
+    recovery_dir: &Path,
+) -> Result<crate::prepare::PreparedPartitions> {
+    ensure!(
+        crate::system::sysinfo::has_uefi(),
+        "Restart the installer in UEFI mode before installing"
+    );
+    check_tools(&[
+        ("sfdisk", "util-linux"),
+        ("sgdisk", "gptfdisk"),
+        ("lsblk", "util-linux"),
+    ])?;
+    let disk = &request.before.device;
+    let mut handle = OpenOptions::new().read(true).write(true).open(disk)?;
+    ensure!(
+        handle.metadata()?.file_type().is_block_device(),
+        "Installation requires a block device"
+    );
+    handle
+        .try_lock()
+        .wrap_err("Another process holds the disk lock")?;
+    let mut mbr = [0; 512];
+    handle.read_exact(&mut mbr)?;
+    validate_protective_mbr(&mbr)?;
+    let (current, filesystems) = inspect(runner, disk)?;
+    ensure!(
+        current == request.before,
+        "The disk layout changed after selection. Refresh and review a new plan; nothing has been written"
+    );
+    let plan = request.plan()?;
+    let space = inspect_efi(
+        runner,
+        &current,
+        request.efi.existing_partition(),
+        &filesystems,
+    )?;
+    request.efi.validate_space(&space, budget)?;
+    if plan.efi_start.is_some() {
+        check_tools(&[("mkfs.fat", "dosfstools")])?;
+        ensure!(
+            budget.required_bytes()? < ESP_BYTES - 8 * MIB,
+            "The boot image and selected copies do not fit the proposed additional ESP"
+        );
+    }
+    let filesystem = if let Some((part, sectors)) = &plan.shrink {
+        let fs = filesystems
+            .iter()
+            .find(|f| f.path == part.node)
+            .and_then(|f| f.fstype.clone())
+            .ok_or_else(|| eyre!("Cannot identify the filesystem to shrink"))?;
+        let bytes = sectors * current.sectorsize;
+        let minimum = minimum_size(runner, part, &fs)?;
+        ensure!(
+            bytes > MIB && bytes - MIB >= minimum,
+            "The selected size is below the current safe minimum; refresh and allocate less space to Linux"
+        );
+        if fs == "ntfs" {
+            probe::run(
+                runner,
+                "ntfsresize",
+                &[
+                    "--no-action",
+                    "--no-progress-bar",
+                    "--size",
+                    &(bytes - MIB).to_string(),
+                    &part.node.to_string_lossy(),
+                ],
+            )?;
+        }
+        Some(fs)
+    } else {
+        None
+    };
+    let validation = probe::run(runner, "sgdisk", &["--verify", &disk.to_string_lossy()])?;
+    ensure!(
+        validation.contains("No problems found."),
+        "GPT verification requires attention: {validation}"
+    );
+    // This is the last read-only gate. Keep backups outside the target and
+    // retain them even when a later command fails.
+    std::fs::create_dir(recovery_dir)
+        .wrap_err("Create a fresh recovery directory on the live filesystem")?;
+    let dump = probe::run(runner, "sfdisk", &["--dump", &disk.to_string_lossy()])?;
+    let mut backup = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(recovery_dir.join("partition-table.sfdisk"))?;
+    backup.write_all(dump.as_bytes())?;
+    backup.sync_all()?;
+    File::open(recovery_dir)?.sync_all()?;
+    tracing::info!(path = %recovery_dir.display(), "Saved partition table before resizing; this is not a filesystem backup");
+    apply(runner, request, &plan, filesystem.as_deref()).wrap_err_with(|| format!("Storage operation stopped. Some changes may already have completed. Do not retry or restore GPT blindly. Original partition table: {}", recovery_dir.join("partition-table.sfdisk").display()))
+}
+
+fn validate_protective_mbr(mbr: &[u8; 512]) -> Result<()> {
+    ensure!(
+        mbr[510..] == [0x55, 0xaa],
+        "Missing protective MBR signature"
+    );
+    let types: Vec<_> = (0..4)
+        .map(|i| mbr[446 + i * 16 + 4])
+        .filter(|t| *t != 0)
+        .collect();
+    ensure!(
+        types == [0xee],
+        "Hybrid or non-protective MBR is not supported; no disk changes were made"
+    );
+    Ok(())
+}
+
+fn apply(
+    runner: &dyn CommandRunner,
+    request: &Request,
+    plan: &Plan,
+    fs: Option<&str>,
+) -> Result<crate::prepare::PreparedPartitions> {
+    let disk = &request.before.device;
+    let dev = disk.to_string_lossy();
+    let mut expected = request.before.clone();
+    if let Some((part, sectors)) = &plan.shrink {
+        let bytes = sectors * expected.sectorsize;
+        let node = part.node.to_string_lossy();
+        tracing::info!(partition = %node, new_bytes = bytes, "Shrinking filesystem before partition boundary");
+        match fs {
+            Some("ntfs") => {
+                let out = runner.run_with_stdin(
+                    "env",
+                    &[
+                        "LC_ALL=C",
+                        "ntfsresize",
+                        "--no-progress-bar",
+                        "--size",
+                        &(bytes - MIB).to_string(),
+                        &node,
+                    ],
+                    b"y\n",
+                )?;
+                check_exit(&out, "Shrink NTFS")?;
+                // ntfsresize deliberately leaves NTFS dirty for Windows to
+                // check. Do not use --force or clear that flag to probe it.
+                let mut boot = [0; 512];
+                File::open(&part.node)?.read_exact(&mut boot)?;
+                ensure!(
+                    &boot[3..11] == b"NTFS    ",
+                    "NTFS boot sector cannot be verified after shrink"
+                );
+                let sector = u16::from_le_bytes(boot[11..13].try_into()?);
+                let count = u64::from_le_bytes(boot[40..48].try_into()?);
+                ensure!(
+                    matches!(sector, 512 | 4096)
+                        && count > 0
+                        && count
+                            .checked_add(1)
+                            .and_then(|n| n.checked_mul(u64::from(sector)))
+                            .is_some_and(|n| n <= bytes),
+                    "NTFS still exceeds the planned partition boundary"
+                );
+            }
+            Some("ext4") => {
+                // Read-only checking has already passed. Persist a clean
+                // check before resize2fs; never force the resizer itself.
+                probe::run(runner, "e2fsck", &["-f", "-p", &node])?;
+                probe::run(
+                    runner,
+                    "resize2fs",
+                    &[&node, &format!("{}K", (bytes - MIB) / 1024)],
+                )?;
+                probe::run(runner, "e2fsck", &["-f", "-n", &node])?;
+                let (block, count, _) = probe::ext_size(runner, &node)?;
+                ensure!(
+                    count.checked_mul(block).is_some_and(|n| n <= bytes),
+                    "ext4 still exceeds the planned partition boundary"
+                );
+            }
+            _ => bail!("Unsupported filesystem; partition table was not modified"),
+        }
+        let number = part.number(disk)?;
+        let out = runner.run_with_stdin(
+            "env",
+            &[
+                "LC_ALL=C",
+                "LOCK_BLOCK_DEVICE=0",
+                "sfdisk",
+                "--wipe",
+                "never",
+                "--wipe-partitions",
+                "never",
+                "-N",
+                &number.to_string(),
+                &dev,
+            ],
+            format!("size={sectors}\n").as_bytes(),
+        )?;
+        check_exit(&out, "Update the resized partition boundary")?;
+        expected
+            .partitions
+            .iter_mut()
+            .find(|p| p.node == part.node)
+            .ok_or_else(|| eyre!("Partition missing from expected layout"))?
+            .size = *sectors;
+        ensure!(
+            Layout::read(runner, disk)? == expected,
+            "GPT verification failed after shrink; no new partitions will be formatted"
+        );
+    }
+    let mut args = Vec::new();
+    if let Some(start) = plan.efi_start {
+        args.extend([
+            format!("--new={}:{}:{}", plan.efi_number, start, plan.zfs_start - 1),
+            format!("--typecode={}:ef00", plan.efi_number),
+        ]);
+    }
+    args.extend([
+        format!(
+            "--new={}:{}:{}",
+            plan.zfs_number,
+            plan.zfs_start,
+            plan.end - 1
+        ),
+        format!("--typecode={}:bf00", plan.zfs_number),
+        dev.to_string(),
+    ]);
+    probe::run(
+        runner,
+        "sgdisk",
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+    )?;
+    // Do not wait for udev while holding the whole-disk lock: its workers may
+    // be waiting for that very lock. Kernel geometry and devtmpfs nodes are
+    // verified below; udev can populate aliases after this operation returns.
+    let after = Layout::read(runner, disk)?;
+    verify_created(&expected, &after, plan)?;
+    // Compare kernel-reported sizes before a node is handed to mkfs or ZFS.
+    inspect(runner, disk)?;
+    let efi = super::super::partition::partition_path(disk, plan.efi_number);
+    let zfs = super::super::partition::partition_path(disk, plan.zfs_number);
+    if plan.efi_start.is_some() {
+        crate::disk::partition::format_efi(runner, &efi)?;
+    }
+    Ok(crate::prepare::PreparedPartitions {
+        efi,
+        zfs: Some(zfs),
+        swap: None,
+    })
+}
+
+fn verify_created(before: &Layout, after: &Layout, plan: &Plan) -> Result<()> {
+    let mut retained = after.clone();
+    let zfs = retained
+        .partitions
+        .iter()
+        .find(|p| p.number(&before.device).ok() == Some(plan.zfs_number))
+        .ok_or_else(|| eyre!("New ZFS partition is missing"))?;
+    ensure!(
+        zfs.start == plan.zfs_start
+            && zfs.end()? == plan.end
+            && zfs
+                .kind
+                .eq_ignore_ascii_case("6A85CF4D-1DD2-11B2-99A6-080020736631"),
+        "New ZFS partition differs from plan"
+    );
+    if let Some(start) = plan.efi_start {
+        let efi = retained
+            .partitions
+            .iter()
+            .find(|p| p.number(&before.device).ok() == Some(plan.efi_number))
+            .ok_or_else(|| eyre!("New EFI partition is missing"))?;
+        ensure!(
+            efi.start == start
+                && efi.end()? == plan.zfs_start
+                && efi.kind.eq_ignore_ascii_case(EFI_TYPE),
+            "New EFI partition differs from plan"
+        );
+    }
+    retained.partitions.retain(|p| {
+        p.number(&before.device).ok() != Some(plan.zfs_number)
+            && !(plan.efi_start.is_some() && p.number(&before.device).ok() == Some(plan.efi_number))
+    });
+    ensure!(
+        &retained == before,
+        "An existing partition or GPT identity changed unexpectedly; refusing to format"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn hybrid_mbr_is_not_accepted_as_gpt() {
+        let mut mbr = [0; 512];
+        mbr[510..].copy_from_slice(&[0x55, 0xaa]);
+        mbr[450] = 0xee;
+        assert!(validate_protective_mbr(&mbr).is_ok());
+        mbr[466] = 7;
+        assert!(validate_protective_mbr(&mbr).is_err());
+    }
+}

--- a/core/src/disk/alongside/probe.rs
+++ b/core/src/disk/alongside/probe.rs
@@ -9,8 +9,6 @@ pub struct Filesystem {
     pub ro: bool,
     #[serde(default)]
     pub fstype: Option<String>,
-    #[serde(default)]
-    pub label: Option<String>,
     pub mountpoints: Vec<Option<String>>,
     #[serde(default)]
     children: Vec<Filesystem>,
@@ -28,7 +26,7 @@ pub fn inspect(runner: &dyn CommandRunner, disk: &Path) -> Result<(Layout, Vec<F
             "--bytes",
             "--paths",
             "--output",
-            "PATH,TYPE,SIZE,RO,FSTYPE,LABEL,MOUNTPOINTS",
+            "PATH,TYPE,SIZE,RO,FSTYPE,MOUNTPOINTS",
             &layout.device.to_string_lossy(),
         ],
     )?;

--- a/core/src/disk/alongside/probe.rs
+++ b/core/src/disk/alongside/probe.rs
@@ -1,0 +1,174 @@
+use super::*;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Filesystem {
+    pub path: PathBuf,
+    #[serde(rename = "type")]
+    kind: String,
+    pub size: u64,
+    pub ro: bool,
+    #[serde(default)]
+    pub fstype: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    pub mountpoints: Vec<Option<String>>,
+    #[serde(default)]
+    children: Vec<Filesystem>,
+}
+
+/// Read-only inspection. Refuse active disks rather than unmounting anything
+/// the live system or another application may own.
+pub fn inspect(runner: &dyn CommandRunner, disk: &Path) -> Result<(Layout, Vec<Filesystem>)> {
+    let layout = Layout::read(runner, disk)?;
+    let out = runner.run(
+        "lsblk",
+        &[
+            "--json",
+            "--tree",
+            "--bytes",
+            "--paths",
+            "--output",
+            "PATH,TYPE,SIZE,RO,FSTYPE,LABEL,MOUNTPOINTS",
+            &layout.device.to_string_lossy(),
+        ],
+    )?;
+    check_exit(&out, "Inspect disk usage")?;
+    #[derive(Deserialize)]
+    struct Devices {
+        blockdevices: Vec<Filesystem>,
+    }
+    let mut devices: Devices = serde_json::from_str(&out.stdout)?;
+    ensure!(devices.blockdevices.len() == 1, "Expected one whole disk");
+    let d = devices.blockdevices.remove(0);
+    ensure!(
+        d.path == layout.device && matches!(d.kind.as_str(), "disk" | "loop"),
+        "Select a whole disk, not a mapped device"
+    );
+    ensure!(
+        (layout.lastlba + 1) * layout.sectorsize <= d.size,
+        "GPT exceeds the device capacity"
+    );
+    for node in std::iter::once(&d).chain(d.children.iter()) {
+        ensure!(
+            !node.ro
+                && node
+                    .mountpoints
+                    .iter()
+                    .all(|p| p.as_deref().is_none_or(str::is_empty)),
+            "{} is read-only or in use. Unmount its filesystems and disable its swap before proceeding.",
+            node.path.display()
+        );
+        if node.path != d.path {
+            ensure!(
+                node.kind == "part" && node.children.is_empty(),
+                "{} has active mappings; close them in the existing system first",
+                node.path.display()
+            );
+            ensure!(
+                node.fstype.as_deref() != Some("zfs_member"),
+                "A disk containing ZFS members cannot be repartitioned by this workflow"
+            );
+        }
+    }
+    ensure!(
+        d.children.len() == layout.partitions.len(),
+        "Kernel partition list does not match GPT; refresh the device before proceeding"
+    );
+    for p in &layout.partitions {
+        ensure!(
+            d.children
+                .iter()
+                .any(|c| c.path == p.node && c.size == p.size * layout.sectorsize),
+            "Kernel partition size differs from GPT for {}",
+            p.node.display()
+        );
+    }
+    Ok((layout, d.children))
+}
+
+pub(super) fn run(runner: &dyn CommandRunner, program: &str, args: &[&str]) -> Result<String> {
+    let mut argv = vec!["LC_ALL=C", program];
+    argv.extend_from_slice(args);
+    let out = runner.run("env", &argv)?;
+    check_exit(&out, program)?;
+    Ok(out.stdout)
+}
+
+fn number_after(text: &str, key: &str) -> Result<u64> {
+    let value = text
+        .lines()
+        .find_map(|line| line.trim().strip_prefix(key))
+        .and_then(|s| s.split_whitespace().next())
+        .ok_or_else(|| eyre!("Cannot interpret filesystem tool output: missing {key}"))?;
+    Ok(value.parse()?)
+}
+
+pub(super) fn ext_size(runner: &dyn CommandRunner, device: &str) -> Result<(u64, u64, u64)> {
+    let header = run(runner, "dumpe2fs", &["-h", device])?;
+    let block = number_after(&header, "Block size:")?;
+    let count = number_after(&header, "Block count:")?;
+    let free = number_after(&header, "Free blocks:")?;
+    ensure!(
+        matches!(block, 1024 | 2048 | 4096) && free <= count,
+        "Unsupported ext4 block size or invalid accounting"
+    );
+    Ok((block, count, free))
+}
+
+/// Returns a conservative lower bound. Passing this check does not bypass the
+/// resizer's own checks. Failed or unparseable probes never enable shrinking.
+pub fn minimum_size(runner: &dyn CommandRunner, part: &Partition, fs: &str) -> Result<u64> {
+    check_tools(required_tools(fs)?)?;
+    ensure!(
+        part.attrs.is_empty(),
+        "Partition attributes require manual review before resizing"
+    );
+    let dev = part.node.to_string_lossy();
+    let raw = match fs {
+        "ntfs" => {
+            ensure!(
+                part.kind.eq_ignore_ascii_case(BASIC_TYPE),
+                "Only ordinary NTFS data partitions can be resized; recovery and system partitions are preserved"
+            );
+            run(runner, "ntfs-3g.probe", &["--readwrite", &dev]).wrap_err("NTFS is not safely writable. Shut down Windows fully, disable Fast Startup/hibernation, and check the filesystem in Windows")?;
+            let info = run(runner, "ntfsresize", &["--info", "--no-progress-bar", &dev])?;
+            number_after(&info, "You might resize at ")?
+        }
+        "ext4" => {
+            ensure!(
+                part.kind.eq_ignore_ascii_case(LINUX_TYPE),
+                "Only ordinary Linux filesystem partitions can be resized"
+            );
+            run(runner, "e2fsck", &["-f", "-n", &dev]).wrap_err("ext4 needs filesystem maintenance; check it from the existing system before resizing")?;
+            let (block, count, free) = ext_size(runner, &dev)?;
+            let info = run(runner, "resize2fs", &["-P", &dev])?;
+            let min = number_after(&info, "Estimated minimum size of the filesystem:")?;
+            min.max(count - free)
+                .checked_mul(block)
+                .ok_or_else(|| eyre!("Filesystem size overflow"))?
+        }
+        _ => unreachable!("required_tools rejected an unsupported filesystem"),
+    };
+    // Leave working space for the retained OS, and avoid trusting a minimum
+    // estimate as an exact safe boundary (notably resize2fs with small blocks).
+    raw.checked_add(raw / 5)
+        .and_then(|n| n.checked_add(GIB))
+        .ok_or_else(|| eyre!("Minimum size overflow"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn exact_bytes_are_required_and_localized_or_missing_output_fails() {
+        assert_eq!(
+            number_after(
+                "You might resize at 123456 bytes or 1 MB",
+                "You might resize at "
+            )
+            .unwrap(),
+            123456
+        );
+        assert!(number_after("Minsize: unknown", "You might resize at ").is_err());
+    }
+}

--- a/core/src/disk/mod.rs
+++ b/core/src/disk/mod.rs
@@ -1,3 +1,4 @@
+pub mod alongside;
 pub mod device;
 pub mod partition;
 

--- a/core/src/disk/partition.rs
+++ b/core/src/disk/partition.rs
@@ -145,7 +145,7 @@ const PARTITION_POLL: std::time::Duration = std::time::Duration::from_millis(200
 /// Returning without the node present only defers the failure to whatever runs
 /// next — mkfs, or zpool create — where it surfaces as a confusing "no such
 /// file" against a path the user never typed.
-fn wait_for_path(path: &Path) -> Result<()> {
+pub fn wait_for_path(path: &Path) -> Result<()> {
     let deadline = std::time::Instant::now() + PARTITION_WAIT;
     loop {
         if path.exists() {

--- a/core/src/installer/initramfs/mkinitcpio.rs
+++ b/core/src/installer/initramfs/mkinitcpio.rs
@@ -139,23 +139,38 @@ fn patch_conf_array(content: &str, key: &str, f: impl FnOnce(&mut Vec<String>)) 
 }
 
 fn set_conf_value(content: &str, key: &str, value: &str) -> String {
+    set_conf_line(content, key, &format!("{key}=\"{value}\""))
+}
+
+/// Replace every active `KEY=` assignment with `line`. When the key is only
+/// present as a commented example (stock files list several), activate the
+/// first one and leave the other examples as they are. Append when absent.
+pub(crate) fn set_conf_line(content: &str, key: &str, line: &str) -> String {
     let prefix = format!("{key}=");
+    let commented = format!("#{prefix}");
+    let has_active = content.lines().any(|l| l.trim().starts_with(&prefix));
     let mut result = String::new();
     let mut found = false;
 
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with(&prefix) || trimmed.starts_with(&format!("#{prefix}")) {
-            found = true;
-            result.push_str(&format!("{key}=\"{value}\"\n"));
+    for l in content.lines() {
+        let trimmed = l.trim();
+        let replace = if has_active {
+            trimmed.starts_with(&prefix)
         } else {
+            !found && trimmed.starts_with(&commented)
+        };
+        if replace {
+            found = true;
             result.push_str(line);
-            result.push('\n');
+        } else {
+            result.push_str(l);
         }
+        result.push('\n');
     }
 
     if !found {
-        result.push_str(&format!("{key}=\"{value}\"\n"));
+        result.push_str(line);
+        result.push('\n');
     }
 
     result
@@ -300,5 +315,30 @@ mod tests {
         let result = set_conf_value(input, "COMPRESSION", "cat");
         assert!(result.contains("COMPRESSION=\"cat\""));
         assert!(!result.contains("#COMPRESSION"));
+    }
+
+    #[test]
+    fn test_set_conf_line_activates_one_example_and_replaces_active_values() {
+        let examples = "#COMPRESSION=\"zstd\"\n#COMPRESSION=\"xz\"\n#COMPRESSION_OPTIONS=()\n";
+        assert_eq!(
+            set_conf_line(examples, "COMPRESSION", "COMPRESSION=\"xz\""),
+            "COMPRESSION=\"xz\"\n#COMPRESSION=\"xz\"\n#COMPRESSION_OPTIONS=()\n"
+        );
+        assert_eq!(
+            set_conf_line(
+                "#COMPRESSION=\"zstd\"\nCOMPRESSION=\"lz4\"\n",
+                "COMPRESSION",
+                "COMPRESSION=\"xz\""
+            ),
+            "#COMPRESSION=\"zstd\"\nCOMPRESSION=\"xz\"\n"
+        );
+        assert_eq!(
+            set_conf_line(
+                "HOOKS=(base)\n",
+                "COMPRESSION_OPTIONS",
+                "COMPRESSION_OPTIONS=(-9)"
+            ),
+            "HOOKS=(base)\nCOMPRESSION_OPTIONS=(-9)\n"
+        );
     }
 }

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -197,13 +197,19 @@ impl Installer {
         self.install_additional_packages()?;
         self.ensure_not_cancelled()?;
 
-        // Phase 11: Swap configuration
+        // Phase 11: mount entries, then swap.
         tracing::info!("Phase 11: Configuring swap...");
         tracing::info!(target: "metrics", event = "phase_start", num = 11u32, name = "Configuring swap");
-        self.configure_swap()?;
+        write_fstab_and_swap(
+            &*self.runner,
+            &self.target,
+            &self.boot_environment(),
+            &self.config,
+            self.effective_swap_partition(),
+        )?;
         self.ensure_not_cancelled()?;
 
-        // Phase 12: ZFS services + genfstab + misc files
+        // Phase 12: ZFS services + misc files
         tracing::info!("Phase 12: Finalizing ZFS configuration...");
         tracing::info!(target: "metrics", event = "phase_start", num = 12u32, name = "Finalizing ZFS configuration");
         self.finalize_zfs()?;
@@ -655,28 +661,6 @@ impl Installer {
         Ok(())
     }
 
-    fn configure_swap(&self) -> Result<()> {
-        match self.config.swap_mode {
-            SwapMode::Zram => {
-                crate::swap::configure_zram(&self.target, self.config.zram_size_expr.as_deref())?;
-            }
-            SwapMode::ZswapPartition => {
-                let part = self.effective_swap_partition();
-                if let Some(part) = part {
-                    crate::swap::setup_swap_partition(&*self.runner, &self.target, part, false)?;
-                }
-            }
-            SwapMode::ZswapPartitionEncrypted => {
-                let part = self.effective_swap_partition();
-                if let Some(part) = part {
-                    crate::swap::setup_swap_partition(&*self.runner, &self.target, part, true)?;
-                }
-            }
-            SwapMode::None => {}
-        }
-        Ok(())
-    }
-
     /// Return the swap partition path: runtime override first, then config.
     fn effective_swap_partition(&self) -> Option<&Path> {
         self.swap_partition
@@ -699,9 +683,6 @@ impl Installer {
         // on Alpm and is async (zfskit set_property). See
         // crate::zfs_trim::configure_zfs_trim, called from run_install.
 
-        // genfstab
-        fstab::generate_fstab(&*self.runner, &self.target, &be)?;
-
         // Copy misc files (hostid, zfs cache). The mountpoint the datasets are
         // currently mounted under is the install target itself — it is what
         // gets stripped from the cached mountpoints so they are correct once
@@ -722,12 +703,84 @@ impl Installer {
     }
 }
 
+/// Generate fstab from the live mounts, then add swap. The order is fixed:
+/// generation rewrites the whole file, and a swap partition is never
+/// activated during installation, so genfstab would not list it.
+fn write_fstab_and_swap(
+    runner: &dyn CommandRunner,
+    target: &Path,
+    be: &crate::boot_environment::BootEnvironment,
+    config: &GlobalConfig,
+    swap_partition: Option<&Path>,
+) -> Result<()> {
+    fstab::generate_fstab(runner, target, be)?;
+    match config.swap_mode {
+        SwapMode::Zram => {
+            crate::swap::configure_zram(target, config.zram_size_expr.as_deref())?;
+        }
+        SwapMode::ZswapPartition => {
+            if let Some(part) = swap_partition {
+                crate::swap::setup_swap_partition(runner, target, part, false)?;
+            }
+        }
+        SwapMode::ZswapPartitionEncrypted => {
+            if let Some(part) = swap_partition {
+                crate::swap::setup_swap_partition(runner, target, part, true)?;
+            }
+        }
+        SwapMode::None => {}
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::types::ZfsEncryptionMode;
-    use crate::system::cmd::tests::RecordingRunner;
+    use crate::system::cmd::tests::{CannedResponse, RecordingRunner};
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn swap_entries_survive_fstab_generation() {
+        let target = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(target.path().join("etc")).unwrap();
+        let runner = RecordingRunner::new(vec![
+            CannedResponse {
+                stdout: "UUID=1234\t/boot/efi\tvfat\trw,relatime\t0\t2\n".into(),
+                ..Default::default()
+            },
+            CannedResponse::default(), // mkswap
+        ]);
+        let config = GlobalConfig {
+            swap_mode: SwapMode::ZswapPartition,
+            ..Default::default()
+        };
+        let be = crate::boot_environment::BootEnvironment::new("zroot", "arch0");
+
+        write_fstab_and_swap(
+            &runner,
+            target.path(),
+            &be,
+            &config,
+            Some(Path::new("/dev/disk/by-id/disk-part3")),
+        )
+        .unwrap();
+
+        let fstab = std::fs::read_to_string(target.path().join("etc/fstab")).unwrap();
+        assert!(fstab.contains("zroot/arch0/root\t/\tzfs"), "{fstab}");
+        assert!(
+            fstab.contains("/boot/efi\tvfat\trw,nofail,relatime\t0\t0"),
+            "{fstab}"
+        );
+        // The swap line is appended after generation; the reverse order
+        // silently dropped it and the system booted without swap.
+        assert!(
+            fstab.contains("/dev/disk/by-id/disk-part3\tnone\tswap"),
+            "{fstab}"
+        );
+        assert_eq!(runner.calls()[0].program, "genfstab");
+        assert_eq!(runner.calls()[1].program, "mkswap");
+    }
 
     fn request(config: GlobalConfig, target: &Path, cancel: CancellationToken) -> InstallRequest {
         InstallRequest {

--- a/core/src/prepare.rs
+++ b/core/src/prepare.rs
@@ -35,6 +35,17 @@ pub fn prepare_disk(
         .ok_or_else(|| eyre!("installation mode not set"))?;
 
     match mode {
+        InstallationMode::Alongside => {
+            let request = config
+                .alongside
+                .as_ref()
+                .ok_or_else(|| eyre!("Alongside plan is missing"))?;
+            let stamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_nanos();
+            let recovery = PathBuf::from(format!("/run/archinstall-zfs-storage-{stamp}"));
+            crate::disk::alongside::execute(runner, request, Default::default(), &recovery)
+        }
         InstallationMode::FullDisk => {
             let disk = config
                 .disk
@@ -133,7 +144,7 @@ pub async fn prepare_zfs(
     let key_path = crate::zfs_keyfile::key_file_path(Path::new("/"));
 
     match mode {
-        InstallationMode::FullDisk | InstallationMode::NewPool => {
+        InstallationMode::FullDisk | InstallationMode::NewPool | InstallationMode::Alongside => {
             let zfs_partition =
                 zfs_partition.ok_or_else(|| eyre!("zfs partition required for new pool modes"))?;
 

--- a/core/src/system/net.rs
+++ b/core/src/system/net.rs
@@ -80,10 +80,6 @@ async fn probe_with_client(client: &reqwest::Client, url: &str) -> Result<(), Pr
     Ok(())
 }
 
-pub fn is_uefi() -> bool {
-    std::path::Path::new("/sys/firmware/efi").exists()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/zfs_trim.rs
+++ b/core/src/zfs_trim.rs
@@ -29,6 +29,9 @@ pub async fn configure_zfs_trim(
     // mode leaves the pool's autotrim property and any timer untouched.
     let disk_path = match config.installation_mode {
         Some(InstallationMode::FullDisk) => config.disk.as_deref(),
+        Some(InstallationMode::Alongside) => {
+            config.alongside.as_ref().map(|r| r.before.device.as_path())
+        }
         Some(InstallationMode::NewPool) => config.zfs_partition.as_deref(),
         _ => None,
     };

--- a/core/tests/zbm-update-fixture.sh
+++ b/core/tests/zbm-update-fixture.sh
@@ -55,4 +55,30 @@ cmp "$stage/vmlinuz.EFI" "$esp/EFI/zbm/vmlinuz.EFI"
 printf '\000\000' | dd of="$stage/vmlinuz.EFI" bs=1 seek=220 conv=notrunc status=none
 if bash "$helper" "$stage" "$esp"; then echo 'Non-EFI PE accepted' >&2; exit 1; fi
 [[ $(stat -c %s "$esp/EFI/zbm/vmlinuz.EFI") == 18874368 ]]
-printf 'PASS: FAT publication, single-image replacement, root recovery, foreign fallback preservation, owned fallback reclamation, invalid and oversized image rejection\n'
+# With room, a fresh fallback is written and its digest recorded on root.
+rm "$esp/filler"
+make_image "$stage/vmlinuz.EFI" 12M
+bash "$helper" "$stage" "$esp"
+cmp "$stage/vmlinuz.EFI" "$esp/EFI/BOOT/BOOTX64.EFI"
+[[ -f $stage/fallback.sha256 ]]
+# Two updates that fit only in place leave the fallback two versions behind:
+# it no longer equals the current or the previous main image.
+dd if=/dev/zero of="$esp/filler" bs=1M count=30 status=none
+make_image "$stage/vmlinuz.EFI" 14M
+bash "$helper" "$stage" "$esp" | grep -q 'Skipping optional EFI fallback'
+make_image "$stage/vmlinuz.EFI" 15M
+bash "$helper" "$stage" "$esp" | grep -q 'Skipping optional EFI fallback'
+[[ $(stat -c %s "$esp/EFI/BOOT/BOOTX64.EFI") == 12582912 ]]
+# The recorded digest still identifies it as ours, so it is refreshed.
+rm "$esp/filler"
+make_image "$stage/vmlinuz.EFI" 16M
+bash "$helper" "$stage" "$esp"
+cmp "$stage/vmlinuz.EFI" "$esp/EFI/BOOT/BOOTX64.EFI"
+# An owned fallback is not sacrificed when the image would not fit anyway.
+dd if=/dev/zero of="$esp/filler" bs=1M count=28 status=none
+cp "$stage/vmlinuz.EFI" "$work/current"
+make_image "$stage/vmlinuz.EFI" 40M
+if bash "$helper" "$stage" "$esp"; then echo 'Oversized image accepted after reclaim' >&2; exit 1; fi
+cmp "$work/current" "$esp/EFI/zbm/vmlinuz.EFI"
+cmp "$work/current" "$esp/EFI/BOOT/BOOTX64.EFI"
+printf 'PASS: FAT publication, single-image replacement, root recovery, foreign fallback preservation, owned fallback reclamation and retention, digest ownership, invalid and oversized image rejection\n'

--- a/core/tests/zbm-update-fixture.sh
+++ b/core/tests/zbm-update-fixture.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/bash
+# Requires root. Only mounts and modifies an image created in this fixture.
+set -euo pipefail
+[[ $EUID == 0 ]] || { echo 'Run this fixture as root' >&2; exit 1; }
+helper=$(realpath "$(dirname "$0")/../assets/azfs-install-zbm")
+work=$(mktemp -d)
+cleanup() { if mountpoint -q "$work/esp"; then umount "$work/esp"; fi; rm -rf -- "$work"; }
+trap cleanup EXIT
+mkdir "$work/esp" "$work/stage"
+truncate -s 64M "$work/esp.img"
+mkfs.fat -F32 "$work/esp.img" >/dev/null
+mount -o loop "$work/esp.img" "$work/esp"
+esp=$work/esp
+stage=$work/stage
+mkdir -p "$esp/EFI/BOOT"
+printf 'Foreign bootloader\n' > "$esp/EFI/BOOT/BOOTX64.EFI"
+cp "$esp/EFI/BOOT/BOOTX64.EFI" "$work/foreign"
+make_image() {
+    truncate -s "$2" "$1"
+    printf MZ | dd of="$1" conv=notrunc status=none
+    printf '\200\000\000\000' | dd of="$1" bs=1 seek=60 conv=notrunc status=none
+    printf 'PE\000\000\144\206' | dd of="$1" bs=1 seek=128 conv=notrunc status=none
+    printf '\013\002' | dd of="$1" bs=1 seek=152 conv=notrunc status=none
+    printf '\012\000' | dd of="$1" bs=1 seek=220 conv=notrunc status=none
+}
+make_image "$stage/vmlinuz.EFI" 8M
+bash "$helper" "$stage" "$esp"
+cmp "$stage/vmlinuz.EFI" "$esp/EFI/zbm/vmlinuz.EFI"
+cmp "$work/foreign" "$esp/EFI/BOOT/BOOTX64.EFI"
+[[ ! -e $esp/EFI/zbm/vmlinuz-backup.EFI ]]
+cp "$stage/vmlinuz.EFI" "$work/old"
+# Occupy enough space that old and new cannot coexist on the ESP.
+dd if=/dev/zero of="$esp/filler" bs=1M count=49 status=none
+make_image "$stage/vmlinuz.EFI" 10M
+bash "$helper" "$stage" "$esp"
+cmp "$stage/vmlinuz.EFI" "$esp/EFI/zbm/vmlinuz.EFI"
+cmp "$work/old" "$stage/previous-installed.EFI"
+cmp "$work/foreign" "$esp/EFI/BOOT/BOOTX64.EFI"
+cp "$stage/vmlinuz.EFI" "$work/current"
+make_image "$stage/vmlinuz.EFI" 70M
+if bash "$helper" "$stage" "$esp"; then echo 'Oversized image accepted' >&2; exit 1; fi
+cmp "$work/current" "$esp/EFI/zbm/vmlinuz.EFI"
+printf 'invalid image' > "$stage/vmlinuz.EFI"
+if bash "$helper" "$stage" "$esp"; then echo 'Invalid image accepted' >&2; exit 1; fi
+cmp "$work/current" "$esp/EFI/zbm/vmlinuz.EFI"
+# Reclaim only a verified owned fallback when it would block the main update.
+rm "$esp/filler" "$esp/EFI/BOOT/BOOTX64.EFI"
+cp "$work/current" "$esp/EFI/BOOT/BOOTX64.EFI"
+dd if=/dev/zero of="$esp/filler" bs=1M count=40 status=none
+make_image "$stage/vmlinuz.EFI" 18M
+bash "$helper" "$stage" "$esp"
+cmp "$stage/vmlinuz.EFI" "$esp/EFI/zbm/vmlinuz.EFI"
+[[ ! -e $esp/EFI/BOOT/BOOTX64.EFI ]]
+# MZ alone is not enough: reject a non-EFI PE before replacing anything.
+printf '\000\000' | dd of="$stage/vmlinuz.EFI" bs=1 seek=220 conv=notrunc status=none
+if bash "$helper" "$stage" "$esp"; then echo 'Non-EFI PE accepted' >&2; exit 1; fi
+[[ $(stat -c %s "$esp/EFI/zbm/vmlinuz.EFI") == 18874368 ]]
+printf 'PASS: FAT publication, single-image replacement, root recovery, foreign fallback preservation, owned fallback reclamation, invalid and oversized image rejection\n'

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 | Document | Purpose |
 | --- | --- |
 | [Developer guide](development.md) | Build environments, checks, release/USB workflow and validation boundaries |
+| [Alongside installation development](dual-boot-development.md) | Storage safety contract, EFI policy and disposable resize tests; integration in progress |
 | [Slint coding and visual review](slint-ui-review.md) | Practical design, interaction, rendering and implementation procedure |
 | [GUI development](../slint-ui/README.md) | Preview scenes, fixtures and executable review commands |
 | [Live binary updates](../gen_iso/LIVE_UPDATE.md) | Update the installer on Ventoy without rebuilding its base ISO |

--- a/docs/dual-boot-development.md
+++ b/docs/dual-boot-development.md
@@ -24,15 +24,24 @@ does not claim verified bootability of an existing operating system.
 
 ## EFI policy
 
-Reuse an existing ESP on the selected disk by default. Only offer an additional
-ESP when a successful capacity check establishes insufficient space, and require
-an explicit selection. A corrupt or unreadable ESP is not evidence of low space.
-Repeat capacity validation before applying the plan.
+Reuse an existing ESP on the selected disk by default; it is the recommended
+option. A separate 512 MiB ESP is always an explicit selection and never an
+automatic fallback: it costs allocation and leaves two ESPs for firmware and the
+other operating system to choose between. When the capacity check shows the
+existing ESP cannot take the image, reuse is disabled with the reason and the
+separate ESP remains the only way forward. A corrupt or unreadable ESP blocks
+both choices; it is not evidence of low space. Repeat capacity validation before
+applying the plan.
 
-Space planning reserves **100 MiB for one locally built ZFSBootMenu image plus
-8 MiB overhead**. This is a growth allowance, not an exact prediction: the host
-image measured 48.33 MiB; published ordinary EFI bundles through v3.1.0 reached
-63.56 MiB. A backup or temporary second copy is not a prerequisite for reuse.
+Space planning reserves **48 MiB for one locally built ZFSBootMenu image plus
+8 MiB overhead**, so a stock 100 MiB Windows ESP with about 65 MiB free
+qualifies for reuse. The installer writes `/etc/zfsbootmenu/dracut.conf.d/azfs.conf`
+(host-only modules, `fs-lib` and `usrmount` omitted, `xz -9`) and sets the same
+compression in `/etc/zfsbootmenu/mkinitcpio.conf`. On a stock `linux-lts`
+6.18 target with ZFSBootMenu 3.1.0 the image measured 32.98 MiB (36.17 MiB
+with the packaged dracut configuration alone). The allowance covers kernel and
+ZFS growth, not a generic image: published EFI bundles reach 63.56 MiB and are
+not used. A backup or temporary second copy is not a prerequisite for reuse.
 
 The installed system still builds ZBM locally. `azfs-update-zbm` generates it in
 `/var/lib/zfsbootmenu` and then runs `azfs-install-zbm`. Publication checks the
@@ -66,8 +75,8 @@ The fixture accepts filesystem/mode names, never a target disk argument. It
 creates a sparse image, attaches its own loop device, and detaches it before
 removing the image. It checks retained file contents, existing ESP contents,
 recovery-partition metadata, new partition geometry and stale-plan rejection.
-The `new-esp` fixture fills the existing ESP before explicitly requesting a
-second one. It does not simulate a booted Windows installation or prove Windows
+The `new-esp` fixture fills the existing ESP and then explicitly requests a
+separate one. It does not simulate a booted Windows installation or prove Windows
 bootability.
 
 NTFS shrinking intentionally schedules a Windows consistency check. The test
@@ -80,9 +89,9 @@ and devtmpfs nodes directly; aliases can be populated after releasing the lock.
 
 Validated on 2026-09-10: all four fixture commands above passed, including file
 content comparisons and stale-plan rejection. Workspace tests, formatting and
-clippy with warnings denied also passed. No installation or guest-OS boot was
-performed by these fixtures; These original fixture runs did not cover guest boot; the GUI and VM checks
-below were added subsequently. Windows boot remains unverified.
+clippy with warnings denied also passed. These fixture runs do not install a
+system or boot a guest; the GUI and VM checks below were added separately.
+Windows boot remains unverified.
 
 ## Graphical editor and integration checks
 
@@ -128,7 +137,7 @@ shellcheck core/assets/azfs-install-zbm core/assets/azfs-update-zbm \
 ## Visual review coverage (2026-09-10)
 
 Real headless Slint captures and callbacks were exercised at 1920×1080 / 100%,
-1366×768 / 100%, and 1920×1080 / 150%. Individual captures were inspected,
+1366×768 / 100%, 1920×1080 / 150% and 1920×1080 / 200%. Individual captures were inspected,
 including maps, the compact layout and the review summary.
 
 | Case | Interaction checked |
@@ -136,7 +145,7 @@ including maps, the compact layout and the review summary.
 | Reuse ESP | Select source, enter allocation, switch to unallocated space |
 | Swap | Choose disk swap on Disk; map and Review subtract its size from the pool |
 | Whole extent | Default to all MiB-aligned space; preserve fractional-GiB capacity |
-| Insufficient ESP | Reach consent by keyboard, explicitly enable second ESP |
+| Insufficient ESP | Reuse option disabled with reason; select the separate ESP by keyboard |
 | Return navigation | Open Review, return to Disk, switch installation modes and return |
 | Missing NTFS tools | Select unavailable source; readable package hint; Install disabled |
 | Missing ESP / MBR | Readable reason; Install disabled; disk selector remains available |
@@ -169,4 +178,8 @@ The swap fixture reserves 8 GiB inside a 40 GiB allocation, leaving 32 GiB for
 ZFS. Both filesystem fixtures passed with retained payload comparisons. The
 first complete alongside VM install with ZRAM passed; the installed system
 booted and all 13 health checks passed after updating the check for the new
-ZBM wrapper. The additional disk-swap VM run is a separate verification.
+ZBM wrapper. The additional disk-swap VM run installed and booted successfully,
+but caught a missing swap entry: final fstab generation overwrote the earlier
+swap configuration. Mount entries are now generated before swap configuration;
+the complete disk-swap installation/boot test must pass before this check is
+considered complete.

--- a/docs/dual-boot-development.md
+++ b/docs/dual-boot-development.md
@@ -110,6 +110,10 @@ uv run slint-ui/scripts/alongside_review.py --output /tmp/alongside-review
 SLINT_BACKEND=headless target/debug/azfs --preview alongside
 ```
 
+Filesystem minimum-size probes are reused across refreshes and disk
+re-selection while the partition table and filesystem type are unchanged; the
+ESP capacity check always runs again, and execution re-probes before writing.
+
 `AZFS_PREVIEW_ESP=small` exercises explicit additional-ESP consent.
 `AZFS_PREVIEW_ALONGSIDE=ext4|missing-tools|no-efi|mbr` selects edge cases without
 probing or changing the host. Preview mode remains mandatory.

--- a/docs/dual-boot-development.md
+++ b/docs/dual-boot-development.md
@@ -130,7 +130,8 @@ fixture, allocates 32 GiB by shrinking ext4, and checks retained payloads before
 booting the newly installed system. It does not represent a bootable Windows or
 second Linux installation. Do not claim existing-OS bootability from this test.
 
-The boot publisher has an independent real FAT test, using only its own image:
+The boot publisher has an independent real FAT test, using only its own image.
+CI runs it on the VM runner (`zbm-publisher` job in `check.yml`):
 
 ```sh
 sudo bash core/tests/zbm-update-fixture.sh

--- a/docs/dual-boot-development.md
+++ b/docs/dual-boot-development.md
@@ -1,0 +1,81 @@
+# Alongside installation development
+
+The core planner and execution helper are under development in
+`core/src/disk/alongside/`. They are not yet connected to the installation flow
+or graphical wizard. This document does not claim end-to-end dual-boot support.
+
+## Storage contract
+
+- Require UEFI and GPT. Reuse the existing UEFI detector; reject MBR and hybrid
+  layouts rather than converting them while preserving data.
+- Only ordinary, unmounted NTFS and ext4 partitions can be shrunk. LUKS,
+  BitLocker, LVM, RAID and Btrfs resizing are not implemented. Missing tools
+  disable the operation with a package hint, not the whole application.
+- Existing unallocated extents are selectable independently. Never combine
+  gaps across an intervening partition or move a partition's starting sector.
+- Check current usage, geometry, GUIDs and filesystem minimum before writing.
+  Shrink the filesystem first, then its partition. A failed shrink must not be
+  followed by partition creation or formatting.
+- Preserve existing ESP and recovery partitions. Save the original partition
+  table outside the target disk. This is not a backup of filesystem data.
+- Do not cancel between filesystem shrink and partition-boundary update.
+  Report partial failures and retain recovery information; never automatically
+  restore GPT or retry a stale plan.
+
+## EFI policy
+
+Reuse an existing ESP on the selected disk by default. Only offer an additional
+ESP when a successful capacity check establishes insufficient space, and require
+an explicit selection. A corrupt or unreadable ESP is not evidence of low space.
+Repeat capacity validation before applying the plan.
+
+Space calculation takes the actual EFI bundle size, reserves one replacement
+image and 8 MiB for allocation overhead, and adds persistent backup/fallback
+copies only when enabled. A permanent previous-version backup is optional.
+The inspected host bundle was 50,681,856 bytes; this measurement is a reference,
+not a constant to assume for other builds.
+
+The source of the pre-installation bundle remains to be integrated: the current
+installer builds ZBM in the target after installation, too late for exact
+pre-resize capacity checks. The live-image packaging or a preliminary build
+must supply the actual artifact before the new workflow can be enabled.
+
+## Disposable execution tests
+
+Build the fixture as the normal development user:
+
+```sh
+cargo build -p archinstall-zfs-core --example alongside_fixture --locked
+```
+
+Then run the built executable as root (adapt the binary path if overriding
+`CARGO_TARGET_DIR`):
+
+```sh
+sudo target/debug/examples/alongside_fixture ext4
+sudo target/debug/examples/alongside_fixture ntfs
+sudo target/debug/examples/alongside_fixture ext4 free
+sudo target/debug/examples/alongside_fixture ext4 new-esp
+```
+
+The fixture accepts filesystem/mode names, never a target disk argument. It
+creates a sparse image, attaches its own loop device, and detaches it before
+removing the image. It checks retained file contents, existing ESP contents,
+recovery-partition metadata, new partition geometry and stale-plan rejection.
+The `new-esp` fixture fills the existing ESP before explicitly requesting a
+second one. It does not simulate a booted Windows installation or prove Windows
+bootability.
+
+NTFS shrinking intentionally schedules a Windows consistency check. The test
+uses `ntfscat --force` only to read its known payload afterwards; production
+resizing never forces dirty/hibernated NTFS or clears its check-required flag.
+
+The disk lock stays held during mutations. Do not run `udevadm settle` while
+holding it: udev may be waiting for that lock. Check kernel partition geometry
+and devtmpfs nodes directly; aliases can be populated after releasing the lock.
+
+Validated on 2026-09-10: all four fixture commands above passed, including file
+content comparisons and stale-plan rejection. Workspace tests, formatting and
+clippy with warnings denied also passed. No installation or guest-OS boot was
+performed by these fixtures; Windows boot, full installer integration and GUI
+review remain outstanding.

--- a/docs/dual-boot-development.md
+++ b/docs/dual-boot-development.md
@@ -1,8 +1,8 @@
 # Alongside installation development
 
-The core planner and execution helper are under development in
-`core/src/disk/alongside/`. They are not yet connected to the installation flow
-or graphical wizard. This document does not claim end-to-end dual-boot support.
+The planner in `core/src/disk/alongside/` is connected to the graphical wizard
+and installation pipeline. Integration validation is in progress; this document
+does not claim verified bootability of an existing operating system.
 
 ## Storage contract
 
@@ -29,16 +29,20 @@ ESP when a successful capacity check establishes insufficient space, and require
 an explicit selection. A corrupt or unreadable ESP is not evidence of low space.
 Repeat capacity validation before applying the plan.
 
-Space calculation takes the actual EFI bundle size, reserves one replacement
-image and 8 MiB for allocation overhead, and adds persistent backup/fallback
-copies only when enabled. A permanent previous-version backup is optional.
-The inspected host bundle was 50,681,856 bytes; this measurement is a reference,
-not a constant to assume for other builds.
+Space planning reserves **100 MiB for one locally built ZFSBootMenu image plus
+8 MiB overhead**. This is a growth allowance, not an exact prediction: the host
+image measured 48.33 MiB; published ordinary EFI bundles through v3.1.0 reached
+63.56 MiB. A backup or temporary second copy is not a prerequisite for reuse.
 
-The source of the pre-installation bundle remains to be integrated: the current
-installer builds ZBM in the target after installation, too late for exact
-pre-resize capacity checks. The live-image packaging or a preliminary build
-must supply the actual artifact before the new workflow can be enabled.
+The installed system still builds ZBM locally. `azfs-update-zbm` generates it in
+`/var/lib/zfsbootmenu` and then runs `azfs-install-zbm`. Publication checks the
+actual file and available FAT space. With room for two images it stages and
+renames; otherwise it saves the current loader on the root filesystem, removes
+that loader from the ESP and writes its replacement. The latter has a short
+power-loss window requiring recovery from live media. It is an accepted tradeoff,
+not a reason to create a second ESP by default. No persistent backup is created
+on the ESP. A foreign removable-media fallback is preserved; an optional ZBM
+fallback must not block updating the main image.
 
 ## Disposable execution tests
 
@@ -77,5 +81,92 @@ and devtmpfs nodes directly; aliases can be populated after releasing the lock.
 Validated on 2026-09-10: all four fixture commands above passed, including file
 content comparisons and stale-plan rejection. Workspace tests, formatting and
 clippy with warnings denied also passed. No installation or guest-OS boot was
-performed by these fixtures; Windows boot, full installer integration and GUI
-review remain outstanding.
+performed by these fixtures; These original fixture runs did not cover guest boot; the GUI and VM checks
+below were added subsequently. Windows boot remains unverified.
+
+## Graphical editor and integration checks
+
+The GUI's **Install alongside** mode shows proportional current/planned maps,
+separate filesystem/free-space choices, and an allocation slider plus exact GiB
+input. Disk discovery and filesystem checks run off the UI thread. Errors on
+one disk leave the disk selector available. The TUI currently directs interactive
+resizing users to `azfs`; its config-driven installer uses the same core plan.
+
+Safe visual fixtures:
+
+```sh
+SLINT_EMIT_DEBUG_INFO=1 cargo build -p archinstall-zfs-slint \
+  --no-default-features --features desktop-mock,slint/mcp --locked
+uv run slint-ui/scripts/alongside_review.py --output /tmp/alongside-review
+SLINT_BACKEND=headless target/debug/azfs --preview alongside
+```
+
+`AZFS_PREVIEW_ESP=small` exercises explicit additional-ESP consent.
+`AZFS_PREVIEW_ALONGSIDE=ext4|missing-tools|no-efi|mbr` selects edge cases without
+probing or changing the host. Preview mode remains mandatory.
+
+After a production build, run the disposable installation and boot test:
+
+```sh
+just cargo-build
+just test-vm --alongside --zfs-mode dkms --tmpfs --timeout 1800
+```
+
+This option creates an 80 GiB QEMU disk with a preserved ext4 filesystem and EFI
+fixture, allocates 32 GiB by shrinking ext4, and checks retained payloads before
+booting the newly installed system. It does not represent a bootable Windows or
+second Linux installation. Do not claim existing-OS bootability from this test.
+
+The boot publisher has an independent real FAT test, using only its own image:
+
+```sh
+sudo bash core/tests/zbm-update-fixture.sh
+shellcheck core/assets/azfs-install-zbm core/assets/azfs-update-zbm \
+  core/tests/zbm-update-fixture.sh
+```
+
+## Visual review coverage (2026-09-10)
+
+Real headless Slint captures and callbacks were exercised at 1920×1080 / 100%,
+1366×768 / 100%, and 1920×1080 / 150%. Individual captures were inspected,
+including maps, the compact layout and the review summary.
+
+| Case | Interaction checked |
+| --- | --- |
+| Reuse ESP | Select source, enter allocation, switch to unallocated space |
+| Swap | Choose disk swap on Disk; map and Review subtract its size from the pool |
+| Whole extent | Default to all MiB-aligned space; preserve fractional-GiB capacity |
+| Insufficient ESP | Reach consent by keyboard, explicitly enable second ESP |
+| Return navigation | Open Review, return to Disk, switch installation modes and return |
+| Missing NTFS tools | Select unavailable source; readable package hint; Install disabled |
+| Missing ESP / MBR | Readable reason; Install disabled; disk selector remains available |
+| ext4 | Alternate filesystem fixture |
+
+Large and small partition widths represent disk proportions; small EFI/recovery
+regions cannot carry a full label inside the bar. Their role is identified by
+color and the EFI selector. A free extent is preferred over shrinking when one
+can satisfy the minimum allocation. These preview results do not establish real
+filesystem safety or existing-OS bootability; use the execution tests separately.
+
+
+Allocation defaults to the entire selected free extent (or the maximum safe
+shrink allocation), aligned down to MiB without discarding a fractional GiB.
+The Disk page owns swap selection for alongside installs. None/ZRAM consume no
+disk space; plain/encrypted swap reserves the chosen GiB inside the allocation.
+A minimum of 32 GiB remains for ZFS after subtracting swap and an optional new
+ESP. The later ZFS page shows the same setting read-only. Encrypted swap uses a
+random key per boot and is not a hibernation target.
+
+Additional tests:
+
+```sh
+sudo target/debug/examples/alongside_fixture ext4 swap
+sudo target/debug/examples/alongside_fixture ntfs swap
+just test-vm --alongside --config xtask/configs/alongside-swap.json --tmpfs --timeout 1800
+```
+
+The swap fixture reserves 8 GiB inside a 40 GiB allocation, leaving 32 GiB for
+ZFS. Both filesystem fixtures passed with retained payload comparisons. The
+first complete alongside VM install with ZRAM passed; the installed system
+booted and all 13 health checks passed after updating the check for the new
+ZBM wrapper. The additional disk-swap VM run is a separate verification.

--- a/docs/slint-ui-review.md
+++ b/docs/slint-ui-review.md
@@ -259,3 +259,10 @@ findings fixed, artifact paths, and what remains untested. Keep dated reports su
 as [Design review](../slint-ui/DESIGN_REVIEW.md) distinct from this living workflow.
 Do not recycle an old screenshot as evidence of a new build. Documentation-only
 edits do not constitute another visual review of the application.
+
+When revealing a focused control inside conditional/nested layouts, compare
+its `absolute-position.y` and height with the ScrollView's absolute position
+and visible height. Mixing a child's local `y` with an ancestor's local `y`
+can leave the field partially clipped, especially with preview banners or
+scaling. Test Tab navigation at 150% as well as 100%; a successful click on a
+partially visible control is not proof that keyboard reveal works correctly.

--- a/docs/zfs-root-install-guide.md
+++ b/docs/zfs-root-install-guide.md
@@ -718,8 +718,8 @@ Global:
 Components:
   Enabled: false             # no separate kernel+initramfs pair…
 EFI:
-  ImageDir: /boot/efi/EFI/zbm
-  Versions: false            # …one bundle, overwritten in place
+  ImageDir: /var/lib/zfsbootmenu
+  Versions: false            # current and previous build stay on root
   Enabled: true              # …a single bundled UEFI executable
 Kernel:
   CommandLine: zbm.import_policy=hostid zbm.timeout=10 ro quiet loglevel=0
@@ -729,9 +729,9 @@ Kernel:
   `vmlinuz.EFI`. The command line is *baked into the executable*, which matters
   because some firmware silently discards the `-u` load-options of an
   `efibootmgr` entry.
-* `Versions: false` → `generate-zbm` overwrites in place and renames the previous
-  image to `vmlinuz-backup.EFI`, giving you exactly one known-good fallback rather
-  than an ESP slowly filling with versioned images.
+* `Versions: false` keeps the previous generated image on the root filesystem,
+  outside the ESP. The publisher additionally preserves the previously installed
+  loader as `/var/lib/zfsbootmenu/previous-installed.EFI`.
 * `zbm.import_policy=hostid` → if the pool's recorded hostid does not match, ZBM
   adopts it rather than refusing. This is the forgiving-but-safe middle ground
   between `strict` and `force`.
@@ -739,17 +739,25 @@ Kernel:
   **This only works if the pool's `bootfs` property is set** — without it ZBM waits
   for input forever.
 
-Build and install the bundle:
+The installer installs `azfs-update-zbm` and `azfs-install-zbm` from
+[`core/assets`](../core/assets). After installation, rebuild and publish with:
 
 ```bash
-arch-chroot /mnt generate-zbm
-install -Dm0644 /mnt/boot/efi/EFI/zbm/vmlinuz.EFI \
-                /mnt/boot/efi/EFI/BOOT/BOOTX64.EFI
+azfs-update-zbm
+# From live media with the target mounted:
+arch-chroot /mnt azfs-update-zbm
 ```
 
-The copy to `EFI/BOOT/BOOTX64.EFI` is the removable-media fallback path. If NVRAM
-is cleared, the board is replaced, or the disk is moved to another machine, the
-firmware still finds a boot loader.
+The wrapper builds on the root filesystem, validates the generated EFI header,
+and publishes `/boot/efi/EFI/zbm/vmlinuz.EFI`. If space permits, it writes and
+verifies a temporary file before renaming. On a small ESP it saves the old loader
+on root, removes it from the ESP and writes the new one. Power loss during that
+short replacement window can require recovery from a USB stick. Two simultaneous
+images and a permanent backup on the ESP are not required.
+
+An optional copy at `EFI/BOOT/BOOTX64.EFI` helps when firmware entries are lost.
+The publisher preserves any existing foreign fallback and skips this duplicate
+when space is insufficient. Normal boot uses the main firmware entry below.
 
 A pacman hook keeps it fresh — `/mnt/etc/pacman.d/hooks/95-zfsbootmenu.hook`:
 
@@ -771,7 +779,7 @@ Target = zfs-utils
 [Action]
 Description = Regenerating ZFSBootMenu...
 When = PostTransaction
-Exec = /usr/bin/generate-zbm
+Exec = /usr/local/sbin/azfs-update-zbm
 Depends = zfsbootmenu
 ```
 
@@ -785,7 +793,6 @@ unrelated kernel update happened to rebuild it.
 
 ```bash
 efibootmgr -c -d "$DISK" -p 1 -L "ZFSBootMenu"          -l '\EFI\zbm\vmlinuz.EFI'
-efibootmgr -c -d "$DISK" -p 1 -L "ZFSBootMenu (Backup)" -l '\EFI\zbm\vmlinuz-backup.EFI'
 ```
 
 No `-u` load options: the command line is already embedded in the bundle.

--- a/docs/zfs-root-install-guide.md
+++ b/docs/zfs-root-install-guide.md
@@ -739,6 +739,23 @@ Kernel:
   **This only works if the pool's `bootfs` property is set** — without it ZBM waits
   for input forever.
 
+`/mnt/etc/zfsbootmenu/dracut.conf.d/azfs.conf` keeps the image small enough to
+share a stock 100 MiB Windows ESP (about 33 MiB on `linux-lts` instead of 36 MiB
+with the packaged configuration alone, or 48–64 MiB for a generic image):
+
+```sh
+hostonly="yes"                            # this machine's drivers; dracut's default
+hostonly_cmdline="no"                     # mode still keeps all storage/USB/keyboard drivers
+omit_dracutmodules+=" fs-lib usrmount "   # ZBM never runs fsck or mounts /usr
+compress="xz -9 --check=crc32 -T0"        # slower build than zstd, smaller image
+```
+
+The `i18n` module stays: in host-only mode it adds only the keymap from
+`/etc/vconsole.conf` (about 50 KiB), which ZBM loads for menu and passphrase
+input. On mkinitcpio the packaged `/etc/zfsbootmenu/mkinitcpio.conf` already
+uses `autodetect`; the installer only sets `COMPRESSION="xz"` with
+`COMPRESSION_OPTIONS=(-9 -T0)`.
+
 The installer installs `azfs-update-zbm` and `azfs-install-zbm` from
 [`core/assets`](../core/assets). After installation, rebuild and publish with:
 
@@ -757,7 +774,12 @@ images and a permanent backup on the ESP are not required.
 
 An optional copy at `EFI/BOOT/BOOTX64.EFI` helps when firmware entries are lost.
 The publisher preserves any existing foreign fallback and skips this duplicate
-when space is insufficient. Normal boot uses the main firmware entry below.
+when space is insufficient. It records the digest of its own copy in
+`/var/lib/zfsbootmenu/fallback.sha256`, so a copy that could not be refreshed
+for a few updates is still recognised as ours later. `azfs-update-zbm` mounts
+`/boot/efi` itself when it is not mounted and leaves it mounted, because
+`generate-zbm` would otherwise unmount it again before publication. Normal boot
+uses the main firmware entry below.
 
 A pacman hook keeps it fresh — `/mnt/etc/pacman.d/hooks/95-zfsbootmenu.hook`:
 

--- a/gen_iso/profile/packages.x86_64.j2
+++ b/gen_iso/profile/packages.x86_64.j2
@@ -22,6 +22,9 @@ reflector
 gptfdisk
 python-pyparted
 parted
+mtools
+ntfs-3g
+e2fsprogs
 dosfstools
 efibootmgr
 cryptsetup

--- a/slint-ui/README.md
+++ b/slint-ui/README.md
@@ -137,3 +137,7 @@ The `shell` interaction flow checks the simulated completion/return states.
 The `logs` flow verifies that completion opens at the latest output, scrolling
 back preserves earlier lines, and **Latest output** resumes following. Both
 flows check that the action panel stays below the log and inside the window.
+
+The `--preview alongside` scene exercises graphical disk resizing. See
+[Alongside development and verification](../docs/dual-boot-development.md) for
+fixtures, runtime tool requirements and test boundaries.

--- a/slint-ui/scripts/alongside_review.py
+++ b/slint-ui/scripts/alongside_review.py
@@ -2,9 +2,22 @@
 """Exercise alongside controls and review on safe preview fixtures only."""
 import argparse
 import os
+import time
 from pathlib import Path
 from review import Preview
 from interactions import reveal_by_tab
+
+
+def wait_value(p, role, label, value):
+    """Reveal a focusable control and wait until Rust has set its value."""
+    reveal_by_tab(p, role, label)
+    end = time.monotonic() + 15
+    while time.monotonic() < end:
+        e = p.element(role, label)
+        if e and e.get('accessibleValue') == value:
+            return
+        time.sleep(.1)
+    raise AssertionError(f'{label} did not reach {value}')
 
 
 def run(binary, output, size, scale, small):
@@ -13,7 +26,7 @@ def run(binary, output, size, scale, small):
     prefix = f'{size}-{scale}-{ "small-esp" if small else "reuse" }'
     try:
         p.ready()
-        p.wait('Combobox', 'Space source')
+        reveal_by_tab(p, 'Combobox', 'Space source')
         p.screenshot(prefix + '-initial')
         p.click('Combobox', 'Space source')
         p.click('ListItem', '/dev/nvme0n1p2')
@@ -22,10 +35,28 @@ def run(binary, output, size, scale, small):
         p.data('set_element_value', elementHandle=p.wait('TextInput', 'Allocation in GiB')['handle'], value='100')
         p.key('\n')
         if small:
-            reveal_by_tab(p, 'Checkbox', 'Create an additional')
-            p.click('Checkbox', 'Create an additional')
+            reveal_by_tab(p, 'RadioButton', 'Create a separate')
+            reuse = p.data('get_element_properties', elementHandle=p.wait('RadioButton', 'Reuse the selected')['handle'])
+            assert not reuse.get('accessibleEnabled'), reuse
+            p.click('RadioButton', 'Create a separate')
+        # Widgets must follow state set by Rust after the user has touched
+        # them: "Use all" moves the slider and the input to the capacity.
+        reveal_by_tab(p, 'Checkbox', 'Use all available space')
+        p.click('Checkbox', 'Use all available space')
+        wait_value(p, 'Slider', 'Space for installation', '240')
+        wait_value(p, 'TextInput', 'Allocation in GiB', '240')
+        # A refresh keeps the current plan while the layout is unchanged.
+        reveal_by_tab(p, 'Button', 'Refresh disks')
+        p.click('Button', 'Refresh disks')
+        wait_value(p, 'Combobox', 'Space source', '/dev/nvme0n1p2 — NTFS — 450 GiB')
+        wait_value(p, 'TextInput', 'Allocation in GiB', '240')
+        assert p.wait('Combobox', 'Space source')['accessibleValue'].startswith('/dev/nvme0n1p2'), 'refresh discarded the selected source'
+        p.click('TextInput', 'Allocation in GiB')
+        p.data('set_element_value', elementHandle=p.wait('TextInput', 'Allocation in GiB')['handle'], value='100')
+        p.key('\n')
         p.click('Button', 'Review')
         p.click('Button', 'Disk')
+        reveal_by_tab(p, 'Combobox', 'Space source')
         p.wait('Text', '/dev/nvme0n1p2: 450 →')
         p.screenshot(prefix + '-100gib')
         p.click('Combobox', 'Space source')
@@ -40,10 +71,12 @@ def run(binary, output, size, scale, small):
         p.wait('Text', 'Storage changes during installation')
         p.screenshot(prefix + '-review')
         p.click('Button', 'Disk')
-        p.wait('Combobox', 'Space source')
+        reveal_by_tab(p, 'Combobox', 'Space source')
         p.screenshot(prefix + '-return')
         p.screenshot(prefix + '-swap-map')
+        reveal_by_tab(p, 'RadioButton', 'Erase a disk')
         p.click('RadioButton', 'Erase a disk')
+        reveal_by_tab(p, 'RadioButton', 'Install alongside')
         p.click('RadioButton', 'Install alongside')
         p.click('Button', 'Review')
         install = p.data('get_element_properties', elementHandle=p.wait('Button', 'Install')['handle'])
@@ -91,7 +124,7 @@ if __name__ == '__main__':
     parser.add_argument('--output', type=Path, required=True)
     args = parser.parse_args()
     args.output.mkdir(parents=True, exist_ok=True)
-    for size, scale in [('1920x1080','1'), ('1366x768','1'), ('1920x1080','1.5')]:
+    for size, scale in [('1920x1080','1'), ('1366x768','1'), ('1920x1080','1.5'), ('1920x1080','2')]:
         for small in [False, True]:
             run(args.binary.resolve(), args.output, size, scale, small)
 

--- a/slint-ui/scripts/alongside_review.py
+++ b/slint-ui/scripts/alongside_review.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env -S uv run
+"""Exercise alongside controls and review on safe preview fixtures only."""
+import argparse
+import os
+from pathlib import Path
+from review import Preview
+from interactions import reveal_by_tab
+
+
+def run(binary, output, size, scale, small):
+    os.environ['AZFS_PREVIEW_ESP'] = 'small' if small else 'normal'
+    p = Preview(binary, 'alongside', size, scale, output)
+    prefix = f'{size}-{scale}-{ "small-esp" if small else "reuse" }'
+    try:
+        p.ready()
+        p.wait('Combobox', 'Space source')
+        p.screenshot(prefix + '-initial')
+        p.click('Combobox', 'Space source')
+        p.click('ListItem', '/dev/nvme0n1p2')
+        reveal_by_tab(p, 'TextInput', 'Allocation in GiB')
+        p.click('TextInput', 'Allocation in GiB')
+        p.data('set_element_value', elementHandle=p.wait('TextInput', 'Allocation in GiB')['handle'], value='100')
+        p.key('\n')
+        if small:
+            reveal_by_tab(p, 'Checkbox', 'Create an additional')
+            p.click('Checkbox', 'Create an additional')
+        p.click('Button', 'Review')
+        p.click('Button', 'Disk')
+        p.wait('Text', '/dev/nvme0n1p2: 450 →')
+        p.screenshot(prefix + '-100gib')
+        p.click('Combobox', 'Space source')
+        p.click('ListItem', 'Unallocated space')
+        p.screenshot(prefix + '-unallocated')
+        reveal_by_tab(p, 'Combobox', 'Swap method')
+        p.click('Combobox', 'Swap method')
+        p.click('ListItem', 'Swap partition')
+        reveal_by_tab(p, 'TextInput', 'Swap size in GiB')
+        p.screenshot(prefix + '-swap-controls')
+        p.click('Button', 'Review')
+        p.wait('Text', 'Storage changes during installation')
+        p.screenshot(prefix + '-review')
+        p.click('Button', 'Disk')
+        p.wait('Combobox', 'Space source')
+        p.screenshot(prefix + '-return')
+        p.screenshot(prefix + '-swap-map')
+        p.click('RadioButton', 'Erase a disk')
+        p.click('RadioButton', 'Install alongside')
+        p.click('Button', 'Review')
+        install = p.data('get_element_properties', elementHandle=p.wait('Button', 'Install')['handle'])
+        assert install.get('accessibleEnabled'), install
+        p.screenshot(prefix + '-mode-return')
+    except Exception:
+        p.screenshot(prefix + "-failure")
+        raise
+    finally:
+        p.close()
+
+
+def errors(binary, output):
+    os.environ.pop('AZFS_PREVIEW_ESP', None)
+    for case in ('ext4', 'missing-tools', 'no-efi', 'mbr'):
+        os.environ['AZFS_PREVIEW_ALONGSIDE'] = case
+        p = Preview(binary, 'alongside', '1920x1080', '1', output)
+        try:
+            p.ready()
+            p.wait('Combobox', 'Installation disk')
+            if case == 'missing-tools':
+                p.click('Combobox', 'Space source')
+                p.click('ListItem', '/dev/nvme0n1p2')
+                p.wait('Text', 'Resizing NTFS requires')
+            elif case == 'mbr':
+                p.wait('Text', 'This disk does not use GPT')
+            elif case == 'no-efi':
+                p.wait('Text', 'No existing EFI partition')
+            else:
+                p.wait('Combobox', 'Space source')
+            p.screenshot(case)
+            if case != 'ext4':
+                p.click('Button', 'Review')
+                props = p.data('get_element_properties', elementHandle=p.wait('Button', 'Install')['handle'])
+                assert not props.get('accessibleEnabled'), (case, props)
+                p.screenshot(case + '-review')
+        finally:
+            p.close()
+    os.environ.pop('AZFS_PREVIEW_ALONGSIDE', None)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, default=Path('target/debug/azfs'))
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    for size, scale in [('1920x1080','1'), ('1366x768','1'), ('1920x1080','1.5')]:
+        for small in [False, True]:
+            run(args.binary.resolve(), args.output, size, scale, small)
+
+    errors(args.binary.resolve(), args.output)

--- a/slint-ui/scripts/review.py
+++ b/slint-ui/scripts/review.py
@@ -16,7 +16,7 @@ import time
 import urllib.error
 import urllib.request
 
-SCENES = 'welcome offline no-uefi zfs-preparing zfs-failed wifi-empty wifi-unavailable wifi-no-internet wifi-verifying cancelling disk new-pool existing-pool zfs system users desktop review install done failed cancelled inspect invalid'.split()
+SCENES = 'welcome offline no-uefi zfs-preparing zfs-failed wifi-empty wifi-unavailable wifi-no-internet wifi-verifying cancelling disk new-pool alongside existing-pool zfs system users desktop review install done failed cancelled inspect invalid'.split()
 
 class Preview:
     def __init__(self, binary, scene, size, scale, output):

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -11,6 +11,7 @@ use archinstall_zfs_core::{
 use slint::{ComponentHandle, ModelRc, VecModel};
 use std::{cell::RefCell, path::PathBuf, rc::Rc};
 
+#[derive(Clone)]
 struct Source {
     source: SpaceSource,
     label: String,
@@ -18,11 +19,13 @@ struct Source {
     detail: String,
     error: String,
 }
+#[derive(Clone)]
 struct Efi {
     number: u32,
     label: String,
     space: Result<EfiSpace, String>,
 }
+#[derive(Clone)]
 struct Survey {
     layout: Layout,
     sources: Vec<Source>,
@@ -51,7 +54,12 @@ fn strings(values: Vec<String>) -> ModelRc<slint::SharedString> {
     ))
 }
 
-fn survey(disk: &std::path::Path) -> Result<Survey, String> {
+/// Filesystem minimum-size probes (e2fsck, resize2fs -P, ntfsresize) take
+/// seconds to minutes per partition. Their results from `previous` are reused
+/// while the partition table and filesystem type are unchanged; the ESP
+/// capacity check is cheap and always repeated. Execution probes again before
+/// touching anything.
+fn survey(disk: &std::path::Path, previous: Option<&Survey>) -> Result<Survey, String> {
     check_tools(&[
         ("sfdisk", "util-linux"),
         ("sgdisk", "gptfdisk"),
@@ -81,8 +89,25 @@ fn survey(disk: &std::path::Path) -> Result<Survey, String> {
             .find(|f| f.path == p.node)
             .and_then(|f| f.fstype.as_deref())
             .unwrap_or("unknown filesystem");
-        let minimum = minimum_size(&RealRunner, p, fs);
         let size = p.size * layout.sectorsize;
+        let label = format!(
+            "{} — {} — {:.1} GiB",
+            p.node.display(),
+            fs,
+            size as f64 / GIB as f64
+        );
+        if let Some(cached) = previous
+            .filter(|prev| prev.layout == layout)
+            .and_then(|prev| {
+                prev.sources.iter().find(|s| {
+                    s.source == SpaceSource::Shrink { partition: number } && s.label == label
+                })
+            })
+        {
+            sources.push(cached.clone());
+            continue;
+        }
+        let minimum = minimum_size(&RealRunner, p, fs);
         let (capacity, error) = match minimum {
             Ok(min) => (
                 size.saturating_sub(min.saturating_add(2 * MIB)),
@@ -90,7 +115,7 @@ fn survey(disk: &std::path::Path) -> Result<Survey, String> {
             ),
             Err(e) => (0, format!("{e:#}")),
         };
-        sources.push(Source { source: SpaceSource::Shrink { partition: number }, label: format!("{} — {} — {:.1} GiB", p.node.display(), fs, size as f64 / GIB as f64), capacity, detail: format!("Keep {} at its current start; reduce only its end. Up to {:.0} GiB can be allocated here.", p.node.display(), capacity as f64 / GIB as f64), error });
+        sources.push(Source { source: SpaceSource::Shrink { partition: number }, label, capacity, detail: format!("Keep {} at its current start; reduce only its end. Up to {:.0} GiB can be allocated here.", p.node.display(), capacity as f64 / GIB as f64), error });
     }
     for (start, end) in layout.free_extents().map_err(|e| e.to_string())? {
         let alignment = MIB / layout.sectorsize;
@@ -187,6 +212,7 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
     let disk = index
         .and_then(|i| SESSION.with_borrow(|s| s.disks.get(i).cloned()))
         .or_else(|| keep.as_ref().map(|r| r.before.device.clone()));
+    let previous = SESSION.with_borrow(|s| s.survey.clone());
     let weak = app.as_weak();
     tokio::spawn(async move {
         let result = tokio::task::spawn_blocking(move || -> Result<_, String> {
@@ -212,7 +238,7 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
             let inspected = paths
                 .get(selected_index)
                 .ok_or_else(|| "No disks found".to_string())
-                .and_then(|p| survey(p));
+                .and_then(|p| survey(p, previous.as_ref()));
             Ok((paths, names, selected_index, inspected))
         })
         .await
@@ -395,6 +421,21 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         return;
     }
     state.set_swap_mode(config.swap_mode.index() as i32);
+    // A kept plan whose swap no longer matches the configured method (changed
+    // while another storage mode was selected) is rebuilt from the controls.
+    let wants_swap = matches!(
+        config.swap_mode,
+        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+    );
+    SESSION.with_borrow_mut(|s| {
+        if s.kept
+            .as_ref()
+            .is_some_and(|k| (k.swap_bytes > 0) != wants_swap)
+        {
+            s.kept = None;
+            s.notice.clear();
+        }
+    });
     state.set_allocation_summary("".into());
     state.set_insufficient(false);
     state.set_efi_details("".into());

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -1,5 +1,5 @@
 //! Read-only discovery and editable preview of the shared alongside plan.
-use crate::ui::{AlongsideState, App, DiskSegment};
+use crate::ui::{AlongsideState, App, DiskSegment, WizardState};
 use archinstall_zfs_core::{
     config::{
         choices::Choice,
@@ -32,6 +32,17 @@ struct Survey {
 struct Session {
     disks: Vec<PathBuf>,
     survey: Option<Survey>,
+    /// A plan loaded from a configuration file that matches the surveyed
+    /// layout. It is used verbatim until the user changes any control.
+    kept: Option<Request>,
+    notice: String,
+}
+/// The user changed a control: the loaded plan no longer applies.
+fn touched() {
+    SESSION.with_borrow_mut(|s| {
+        s.kept = None;
+        s.notice.clear();
+    });
 }
 thread_local! { static SESSION: RefCell<Session> = RefCell::default(); }
 fn strings(values: Vec<String>) -> ModelRc<slint::SharedString> {
@@ -162,14 +173,20 @@ fn fixture() -> Survey {
     survey
 }
 
-fn load(app: &App, index: Option<usize>) {
+fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
     let state = app.global::<AlongsideState>();
     let generation = state.get_generation() + 1;
     state.set_generation(generation);
     state.set_busy(true);
     state.set_error("".into());
+    SESSION.with_borrow_mut(|s| {
+        s.kept = None;
+        s.notice.clear();
+    });
     state.invoke_rebuild();
-    let disk = index.and_then(|i| SESSION.with_borrow(|s| s.disks.get(i).cloned()));
+    let disk = index
+        .and_then(|i| SESSION.with_borrow(|s| s.disks.get(i).cloned()))
+        .or_else(|| keep.as_ref().map(|r| r.before.device.clone()));
     let weak = app.as_weak();
     tokio::spawn(async move {
         let result = tokio::task::spawn_blocking(move || -> Result<_, String> {
@@ -187,9 +204,10 @@ fn load(app: &App, index: Option<usize>) {
                 .iter()
                 .map(|d| format!("{} — {} — {}", d.label, d.model, d.size))
                 .collect::<Vec<_>>();
+            let same = |a: &PathBuf, b: &PathBuf| a == b || a.canonicalize().ok() == b.canonicalize().ok();
             let selected_index = disk
                 .as_ref()
-                .and_then(|d| paths.iter().position(|p| p == d))
+                .and_then(|d| paths.iter().position(|p| same(p, d)))
                 .unwrap_or(0);
             let inspected = paths
                 .get(selected_index)
@@ -219,6 +237,34 @@ fn load(app: &App, index: Option<usize>) {
                     state.set_efi_partitions(strings(
                         survey.efis.iter().map(|s| s.label.clone()).collect(),
                     ));
+                    // A plan from a configuration file, or the current plan on
+                    // a refresh, is shown and executed as written when it
+                    // still describes this disk.
+                    let kept = keep.as_ref().and_then(|r| {
+                        let source = survey.sources.iter().position(|s| s.source == r.source)?;
+                        let efi = survey.efis.iter().position(|e| e.number == r.efi.existing_partition())?;
+                        (r.before == survey.layout).then_some((source, efi))
+                    });
+                    if let Some((source, efi)) = kept {
+                        let r = keep.clone().expect("kept implies keep");
+                        state.set_source_index(source as i32);
+                        state.set_efi_index(efi as i32);
+                        state.set_additional_efi(matches!(r.efi, EfiChoice::CreateSeparate { .. }));
+                        state.set_use_all(false);
+                        state.set_allocation(r.allocation_bytes as f32 / GIB as f32);
+                        if r.swap_bytes > 0 {
+                            state.set_swap_size((r.swap_bytes / GIB) as f32);
+                        }
+                        SESSION.with_borrow_mut(|s| {
+                            s.survey = Some(survey);
+                            s.kept = Some(r);
+                        });
+                        state.invoke_rebuild();
+                        return;
+                    }
+                    if keep.is_some() {
+                        SESSION.with_borrow_mut(|s| s.notice = "The previous plan no longer matches this disk; this is a new plan built from the current layout.".into());
+                    }
                     state.set_source_index(
                         survey
                             .sources
@@ -352,33 +398,35 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
     state.set_allocation_summary("".into());
     state.set_insufficient(false);
     state.set_efi_details("".into());
-    let result = SESSION.with_borrow(|s| -> Result<Request, String> {
-        let s = s.survey.as_ref().ok_or("Select a disk")?;
+    let result = SESSION.with_borrow(|session| -> Result<Request, String> {
+        let kept = session.kept.as_ref();
+        let s = session.survey.as_ref().ok_or("Select a disk")?;
         state.set_before(segments(&s.layout, None)); state.set_after(segments(&s.layout, None));
         let source = s.sources.get(state.get_source_index() as usize).ok_or("No suitable partitions or unallocated space")?;
         state.set_details(source.detail.clone().into());
-        let swap_bytes = if matches!(config.swap_mode, SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted) { state.get_swap_size().round().clamp(1.0, 1024.0) as u64 * GIB } else { 0 };
+        let swap_bytes = if let Some(k) = kept { k.swap_bytes } else if matches!(config.swap_mode, SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted) { state.get_swap_size().round().clamp(1.0, 1024.0) as u64 * GIB } else { 0 };
         let min = (MIN_LINUX_BYTES + swap_bytes + if state.get_additional_efi() { ESP_BYTES } else { 0 }) as f32 / GIB as f32;
         let max = source.capacity as f64 / GIB as f64;
         let max = max as f32;
         state.set_minimum(min); state.set_maximum(max);
         let all_bytes = source.capacity / MIB * MIB;
-        let allocation_bytes = if state.get_use_all() { all_bytes } else { (state.get_allocation().round().max(min) as u64).saturating_mul(GIB).min(all_bytes) };
+        let allocation_bytes = if let Some(k) = kept { k.allocation_bytes } else if state.get_use_all() { all_bytes } else { (state.get_allocation().round().max(min) as u64).saturating_mul(GIB).min(all_bytes) };
         state.set_allocation((allocation_bytes as f64 / GIB as f64 * 10.0).round() as f32 / 10.0);
         let efi = s.efis.get(state.get_efi_index() as usize).ok_or("No existing EFI partition on this disk. Prepare an EFI partition before using this mode.")?;
         let space = efi.space.as_ref().map_err(Clone::clone)?;
-        let insufficient = !space.sufficient(Default::default()).map_err(|e| e.to_string())?;
+        let budget = BootSpace::default();
+        let insufficient = !space.sufficient(budget).map_err(|e| e.to_string())?;
         state.set_insufficient(insufficient);
-        if !insufficient { state.set_additional_efi(false); }
-        state.set_efi_details(format!("{} MiB free. {}", space.free_bytes / MIB, if insufficient { "The minimum does not fit. A second EFI partition requires your explicit choice." } else { "Reuse without formatting. Existing bootloaders are preserved." }).into());
+        let required = budget.required_bytes().map_err(|e| e.to_string())?.div_ceil(MIB);
+        state.set_efi_details(format!("{} MiB free; {required} MiB is needed to reuse it. {}", space.free_bytes / MIB, if insufficient { "It cannot be reused; select a separate EFI partition to continue." } else if space.free_bytes < required + budget.image_bytes { "Later ZFSBootMenu updates replace the image in place instead of writing a second copy first." } else { "Reusing it formats nothing and keeps the existing loaders." }).into());
         if !source.error.is_empty() { return Err(source.error.clone()); }
         if max < min { return Err(format!("At least {min:.0} GiB is needed for the ZFS pool, swap and EFI; only {max:.1} GiB is available. Reduce swap or choose another source.")); }
-        let efi_choice = if state.get_additional_efi() { EfiChoice::CreateAfterInsufficientSpace { existing_partition: efi.number } } else { EfiChoice::Reuse { partition: efi.number } };
-        efi_choice.validate_space(space, Default::default()).map_err(|e| e.to_string())?;
-        let request = Request { before: s.layout.clone(), source: source.source.clone(), efi: efi_choice, allocation_bytes, swap_bytes };
+        let efi_choice = if state.get_additional_efi() { EfiChoice::CreateSeparate { existing_partition: efi.number } } else { EfiChoice::Reuse { partition: efi.number } };
+        efi_choice.validate_space(space, budget).map_err(|e| e.to_string())?;
+        let request = match kept { Some(k) => k.clone(), None => Request { before: s.layout.clone(), source: source.source.clone(), efi: efi_choice, allocation_bytes, swap_bytes } };
         let plan = request.plan().map_err(|e| e.to_string())?;
         state.set_after(segments(&s.layout, Some(&plan)));
-        state.set_allocation_summary(format!("New ZFS pool: {:.1} GiB · Swap: {} GiB{}", (plan.swap_start.unwrap_or(plan.end) - plan.zfs_start) as f64 * s.layout.sectorsize as f64 / GIB as f64, swap_bytes / GIB, if plan.efi_start.is_some() { " · New EFI: 1 GiB" } else { " · Existing EFI reused" }).into());
+        state.set_allocation_summary(format!("New ZFS pool: {:.1} GiB · Swap: {} GiB{}", (plan.swap_start.unwrap_or(plan.end) - plan.zfs_start) as f64 * s.layout.sectorsize as f64 / GIB as f64, swap_bytes / GIB, if plan.efi_start.is_some() { " · New EFI: 512 MiB" } else { " · Existing EFI reused" }).into());
         if let Some((old, size)) = &plan.shrink {
             state.set_details(format!("{}: {:.0} → {:.0} GiB. Its start and existing data are preserved.", old.node.display(), old.size as f64 * s.layout.sectorsize as f64 / GIB as f64, *size as f64 * s.layout.sectorsize as f64 / GIB as f64).into());
         }
@@ -388,23 +436,39 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         Ok(request) => {
             config.alongside = Some(request);
             state.set_error("".into());
+            let notice = SESSION.with_borrow(|s| s.notice.clone());
+            if !notice.is_empty() {
+                state.set_details(format!("{notice} {}", state.get_details()).into());
+            }
         }
         Err(e) => state.set_error(e.into()),
     }
-    crate::refresh::refresh_items(app, config);
+    // The survey finishes asynchronously. Rebuilding the item model resets
+    // keyboard focus, which must not happen under the user's hands on another
+    // step; those steps rebuild their items when shown.
+    if app.global::<WizardState>().get_current_step() == DISK_STEP {
+        crate::refresh::refresh_items(app, config);
+    } else {
+        crate::refresh::refresh_validation(app, config);
+    }
 }
+
+/// Index of the Disk step in `WizardState.step-labels`.
+const DISK_STEP: i32 = 1;
 
 pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let weak = app.as_weak();
+    let cfg = config.clone();
     app.global::<AlongsideState>().on_reload(move || {
         if let Some(app) = weak.upgrade() {
-            load(&app, None);
+            let keep = cfg.borrow().alongside.clone();
+            load(&app, None, keep);
         }
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_select_disk(move |index| {
         if let Some(app) = weak.upgrade() {
-            load(&app, Some(index as usize));
+            load(&app, Some(index as usize), None);
         }
     });
     let weak = app.as_weak();
@@ -417,6 +481,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let weak = app.as_weak();
     app.global::<AlongsideState>()
         .on_select_source(move |index| {
+            touched();
             if let Some(app) = weak.upgrade() {
                 let s = app.global::<AlongsideState>();
                 s.set_source_index(index);
@@ -426,6 +491,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
         });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_select_efi(move |index| {
+        touched();
         if let Some(app) = weak.upgrade() {
             let s = app.global::<AlongsideState>();
             s.set_efi_index(index);
@@ -435,6 +501,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_allocate(move |value| {
+        touched();
         if let Some(app) = weak.upgrade()
             && value.is_finite()
         {
@@ -446,6 +513,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_all_space(move |value| {
+        touched();
         if let Some(app) = weak.upgrade() {
             let s = app.global::<AlongsideState>();
             s.set_use_all(value);
@@ -455,6 +523,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let weak = app.as_weak();
     let cfg = config.clone();
     app.global::<AlongsideState>().on_select_swap(move |index| {
+        touched();
         if let Some(app) = weak.upgrade()
             && let Some(mode) = SwapMode::from_index(index as usize)
         {
@@ -464,6 +533,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_size_swap(move |value| {
+        touched();
         if let Some(app) = weak.upgrade()
             && value.is_finite()
         {
@@ -474,9 +544,10 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_additional(move |value| {
+        touched();
         if let Some(app) = weak.upgrade() {
             let s = app.global::<AlongsideState>();
-            s.set_additional_efi(value && s.get_insufficient());
+            s.set_additional_efi(value);
             s.invoke_rebuild();
         }
     });

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -1,0 +1,483 @@
+//! Read-only discovery and editable preview of the shared alongside plan.
+use crate::ui::{AlongsideState, App, DiskSegment};
+use archinstall_zfs_core::{
+    config::{
+        choices::Choice,
+        types::{GlobalConfig, InstallationMode, SwapMode},
+    },
+    disk::{alongside::*, device},
+    system::cmd::RealRunner,
+};
+use slint::{ComponentHandle, ModelRc, VecModel};
+use std::{cell::RefCell, path::PathBuf, rc::Rc};
+
+struct Source {
+    source: SpaceSource,
+    label: String,
+    capacity: u64,
+    detail: String,
+    error: String,
+}
+struct Efi {
+    number: u32,
+    label: String,
+    space: Result<EfiSpace, String>,
+}
+struct Survey {
+    layout: Layout,
+    sources: Vec<Source>,
+    efis: Vec<Efi>,
+}
+#[derive(Default)]
+struct Session {
+    disks: Vec<PathBuf>,
+    survey: Option<Survey>,
+}
+thread_local! { static SESSION: RefCell<Session> = RefCell::default(); }
+fn strings(values: Vec<String>) -> ModelRc<slint::SharedString> {
+    ModelRc::new(VecModel::from(
+        values.into_iter().map(Into::into).collect::<Vec<_>>(),
+    ))
+}
+
+fn survey(disk: &std::path::Path) -> Result<Survey, String> {
+    check_tools(&[
+        ("sfdisk", "util-linux"),
+        ("sgdisk", "gptfdisk"),
+        ("lsblk", "util-linux"),
+    ])
+    .map_err(|e| e.to_string())?;
+    let (layout, filesystems) = inspect(&RealRunner, disk).map_err(|e| format!("{e:#}"))?;
+    let mut sources = Vec::new();
+    let mut efis = Vec::new();
+    for p in &layout.partitions {
+        let number = p.number(&layout.device).map_err(|e| e.to_string())?;
+        if p.kind.eq_ignore_ascii_case(EFI_TYPE) {
+            efis.push(Efi {
+                number,
+                label: format!(
+                    "{} — {:.0} MiB",
+                    p.node.display(),
+                    (p.size * layout.sectorsize) as f64 / MIB as f64
+                ),
+                space: inspect_efi(&RealRunner, &layout, number, &filesystems)
+                    .map_err(|e| format!("{e:#}")),
+            });
+            continue;
+        }
+        let fs = filesystems
+            .iter()
+            .find(|f| f.path == p.node)
+            .and_then(|f| f.fstype.as_deref())
+            .unwrap_or("unknown filesystem");
+        let minimum = minimum_size(&RealRunner, p, fs);
+        let size = p.size * layout.sectorsize;
+        let (capacity, error) = match minimum {
+            Ok(min) => (
+                size.saturating_sub(min.saturating_add(2 * MIB)),
+                String::new(),
+            ),
+            Err(e) => (0, format!("{e:#}")),
+        };
+        sources.push(Source { source: SpaceSource::Shrink { partition: number }, label: format!("{} — {} — {:.1} GiB", p.node.display(), fs, size as f64 / GIB as f64), capacity, detail: format!("Keep {} at its current start; reduce only its end. Up to {:.0} GiB can be allocated here.", p.node.display(), capacity as f64 / GIB as f64), error });
+    }
+    for (start, end) in layout.free_extents().map_err(|e| e.to_string())? {
+        let alignment = MIB / layout.sectorsize;
+        let bytes = end.saturating_sub(start.div_ceil(alignment) * alignment) * layout.sectorsize;
+        if bytes >= MIN_LINUX_BYTES {
+            sources.push(Source {
+                source: SpaceSource::Unallocated { start, end },
+                label: format!("Unallocated space — {:.1} GiB", bytes as f64 / GIB as f64),
+                capacity: bytes,
+                detail: "Create a ZFS partition here without shrinking an existing filesystem."
+                    .into(),
+                error: String::new(),
+            });
+        }
+    }
+    Ok(Survey {
+        layout,
+        sources,
+        efis,
+    })
+}
+
+fn fixture() -> Survey {
+    let layout = Layout {
+        label: "gpt".into(),
+        id: "preview-disk".into(),
+        device: "/dev/nvme0n1".into(),
+        unit: "sectors".into(),
+        sectorsize: 512,
+        firstlba: 2048,
+        lastlba: 512 * GIB / 512 - 34,
+        partitions: vec![
+            Partition {
+                node: "/dev/nvme0n1p1".into(),
+                start: 2048,
+                size: 500 * MIB / 512,
+                kind: EFI_TYPE.into(),
+                uuid: "preview-efi".into(),
+                name: "EFI".into(),
+                attrs: "".into(),
+            },
+            Partition {
+                node: "/dev/nvme0n1p2".into(),
+                start: GIB / 512,
+                size: 450 * GIB / 512,
+                kind: BASIC_TYPE.into(),
+                uuid: "preview-data".into(),
+                name: "Windows".into(),
+                attrs: "".into(),
+            },
+            Partition {
+                node: "/dev/nvme0n1p3".into(),
+                start: 451 * GIB / 512,
+                size: GIB / 512,
+                kind: BASIC_TYPE.into(),
+                uuid: "preview-recovery".into(),
+                name: "Recovery".into(),
+                attrs: "".into(),
+            },
+        ],
+    };
+    let low = std::env::var("AZFS_PREVIEW_ESP").as_deref() == Ok("small");
+    let mut survey = Survey { layout: layout.clone(), sources: vec![
+        Source { source: SpaceSource::Shrink { partition: 2 }, label: "/dev/nvme0n1p2 — NTFS — 450 GiB".into(), capacity: 240 * GIB, detail: "Windows keeps at least 210 GiB, including working space. Only the end of this partition will move.".into(), error: String::new() },
+        Source { source: SpaceSource::Unallocated { start: 452 * GIB / 512, end: layout.lastlba + 1 }, label: "Unallocated space — 60 GiB".into(), capacity: ((layout.lastlba + 1) * 512 - 452 * GIB) / MIB * MIB, detail: "Use free space without resizing Windows.".into(), error: String::new() },
+    ], efis: vec![Efi { number: 1, label: "/dev/nvme0n1p1 — EFI — 500 MiB".into(), space: Ok(EfiSpace { partition: 1, free_bytes: if low { 40 * MIB } else { 350 * MIB } }) }] };
+    match std::env::var("AZFS_PREVIEW_ALONGSIDE").as_deref() {
+        Ok("ext4") => {
+            survey.layout.partitions[1].kind = LINUX_TYPE.into();
+            survey.layout.partitions[1].name = "Linux".into();
+            survey.sources[0].label = "/dev/nvme0n1p2 — ext4 — 450 GiB".into();
+        }
+        Ok("missing-tools") => {
+            survey.sources[0].capacity = 0;
+            survey.sources[0].error = "Resizing NTFS requires ntfsresize (package ntfs-3g). Install it in the live system and refresh, or use unallocated space.".into();
+        }
+        Ok("no-efi") => survey.efis.clear(),
+        _ => {}
+    }
+    survey
+}
+
+fn load(app: &App, index: Option<usize>) {
+    let state = app.global::<AlongsideState>();
+    let generation = state.get_generation() + 1;
+    state.set_generation(generation);
+    state.set_busy(true);
+    state.set_error("".into());
+    state.invoke_rebuild();
+    let disk = index.and_then(|i| SESSION.with_borrow(|s| s.disks.get(i).cloned()));
+    let weak = app.as_weak();
+    tokio::spawn(async move {
+        let result = tokio::task::spawn_blocking(move || -> Result<_, String> {
+            if crate::preview::enabled() {
+                return Ok((
+                    vec![PathBuf::from("/dev/nvme0n1")],
+                    vec!["Samsung SSD — 512 GiB".into()],
+                    0,
+                    if std::env::var("AZFS_PREVIEW_ALONGSIDE").as_deref() == Ok("mbr") { Err("This disk does not use GPT. Automatic MBR conversion is not supported; existing data has not been changed.".into()) } else { Ok(fixture()) },
+                ));
+            }
+            let disks = device::disk_choices().map_err(|e| e.to_string())?;
+            let paths: Vec<_> = disks.iter().map(|d| d.path.clone()).collect();
+            let names = disks
+                .iter()
+                .map(|d| format!("{} — {} — {}", d.label, d.model, d.size))
+                .collect::<Vec<_>>();
+            let selected_index = disk
+                .as_ref()
+                .and_then(|d| paths.iter().position(|p| p == d))
+                .unwrap_or(0);
+            let inspected = paths
+                .get(selected_index)
+                .ok_or_else(|| "No disks found".to_string())
+                .and_then(|p| survey(p));
+            Ok((paths, names, selected_index, inspected))
+        })
+        .await
+        .unwrap_or_else(|e| Err(e.to_string()));
+        let _ = weak.upgrade_in_event_loop(move |app| {
+            let state = app.global::<AlongsideState>();
+            if state.get_generation() != generation {
+                return;
+            }
+            state.set_busy(false);
+            let result = result.and_then(|(paths, names, selected_index, inspected)| {
+                state.set_disks(strings(names));
+                state.set_disk_index(selected_index as i32);
+                SESSION.with_borrow_mut(|s| s.disks = paths);
+                inspected
+            });
+            match result {
+                Ok(survey) => {
+                    state.set_sources(strings(
+                        survey.sources.iter().map(|s| s.label.clone()).collect(),
+                    ));
+                    state.set_efi_partitions(strings(
+                        survey.efis.iter().map(|s| s.label.clone()).collect(),
+                    ));
+                    state.set_source_index(
+                        survey
+                            .sources
+                            .iter()
+                            .position(|s| {
+                                matches!(s.source, SpaceSource::Unallocated { .. })
+                                    && s.error.is_empty()
+                                    && s.capacity >= MIN_LINUX_BYTES
+                            })
+                            .or_else(|| {
+                                survey.sources.iter().position(|s| {
+                                    s.error.is_empty() && s.capacity >= MIN_LINUX_BYTES
+                                })
+                            })
+                            .map(|i| i as i32)
+                            .unwrap_or(0),
+                    );
+                    state.set_efi_index(
+                        survey
+                            .efis
+                            .iter()
+                            .position(|e| {
+                                e.space.as_ref().is_ok_and(|s| {
+                                    s.sufficient(Default::default()).unwrap_or(false)
+                                })
+                            })
+                            .unwrap_or(0) as i32,
+                    );
+                    state.set_additional_efi(false);
+                    state.set_use_all(true);
+                    SESSION.with_borrow_mut(|s| {
+                        s.survey = Some(survey);
+                    });
+                    state.invoke_rebuild();
+                }
+                Err(error) => {
+                    SESSION.with_borrow_mut(|s| s.survey = None);
+                    state.set_before(Default::default());
+                    state.set_after(Default::default());
+                    state.set_sources(Default::default());
+                    state.set_efi_partitions(Default::default());
+                    state.set_error(error.into());
+                }
+            }
+        });
+    });
+}
+
+fn segments(layout: &Layout, plan: Option<&Plan>) -> ModelRc<DiskSegment> {
+    let total = layout.lastlba + 1;
+    let mut regions = Vec::new();
+    for p in &layout.partitions {
+        let resized = plan
+            .and_then(|p2| p2.shrink.as_ref())
+            .filter(|(old, _)| old.node == p.node);
+        let size = resized.map(|(_, size)| *size).unwrap_or(p.size);
+        let kind = if p.kind.eq_ignore_ascii_case(EFI_TYPE) {
+            2
+        } else if resized.is_some() {
+            3
+        } else {
+            0
+        };
+        let name = if p.name.is_empty() {
+            p.node.to_string_lossy().into_owned()
+        } else {
+            p.name.clone()
+        };
+        regions.push((p.start, p.start + size, kind, name));
+    }
+    if let Some(p) = plan {
+        regions.push((
+            p.zfs_start,
+            p.swap_start.unwrap_or(p.end),
+            1,
+            "New ZFS".into(),
+        ));
+        if let Some(start) = p.swap_start {
+            regions.push((start, p.end, 5, "Swap".into()));
+        }
+        if let Some(start) = p.efi_start {
+            regions.push((start, p.zfs_start, 2, "New EFI".into()));
+        }
+    }
+    regions.sort_by_key(|r| r.0);
+    let mut cursor = layout.firstlba;
+    let mut gaps = Vec::new();
+    for &(start, end, _, _) in &regions {
+        if start > cursor {
+            gaps.push((cursor, start, 4, "Free".into()));
+        }
+        cursor = end;
+    }
+    if cursor < total {
+        gaps.push((cursor, total, 4, "Free".into()));
+    }
+    regions.extend(gaps);
+    ModelRc::new(VecModel::from(
+        regions
+            .into_iter()
+            .map(|(start, end, kind, name)| DiskSegment {
+                offset: start as f32 / total as f32,
+                fraction: (end - start) as f32 / total as f32,
+                kind,
+                short_label: format!(
+                    "{:.0} GiB",
+                    (end - start) as f64 * layout.sectorsize as f64 / GIB as f64
+                )
+                .into(),
+                label: format!(
+                    "{name} · {:.0} GiB",
+                    (end - start) as f64 * layout.sectorsize as f64 / GIB as f64
+                )
+                .into(),
+            })
+            .collect::<Vec<_>>(),
+    ))
+}
+
+fn rebuild(app: &App, config: &mut GlobalConfig) {
+    if config.installation_mode != Some(InstallationMode::Alongside) {
+        return;
+    }
+    config.alongside = None;
+    let state = app.global::<AlongsideState>();
+    if state.get_busy() {
+        crate::refresh::refresh_validation(app, config);
+        return;
+    }
+    state.set_swap_mode(config.swap_mode.index() as i32);
+    state.set_allocation_summary("".into());
+    state.set_insufficient(false);
+    state.set_efi_details("".into());
+    let result = SESSION.with_borrow(|s| -> Result<Request, String> {
+        let s = s.survey.as_ref().ok_or("Select a disk")?;
+        state.set_before(segments(&s.layout, None)); state.set_after(segments(&s.layout, None));
+        let source = s.sources.get(state.get_source_index() as usize).ok_or("No suitable partitions or unallocated space")?;
+        state.set_details(source.detail.clone().into());
+        let swap_bytes = if matches!(config.swap_mode, SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted) { state.get_swap_size().round().clamp(1.0, 1024.0) as u64 * GIB } else { 0 };
+        let min = (MIN_LINUX_BYTES + swap_bytes + if state.get_additional_efi() { ESP_BYTES } else { 0 }) as f32 / GIB as f32;
+        let max = source.capacity as f64 / GIB as f64;
+        let max = max as f32;
+        state.set_minimum(min); state.set_maximum(max);
+        let all_bytes = source.capacity / MIB * MIB;
+        let allocation_bytes = if state.get_use_all() { all_bytes } else { (state.get_allocation().round().max(min) as u64).saturating_mul(GIB).min(all_bytes) };
+        state.set_allocation((allocation_bytes as f64 / GIB as f64 * 10.0).round() as f32 / 10.0);
+        let efi = s.efis.get(state.get_efi_index() as usize).ok_or("No existing EFI partition on this disk. Prepare an EFI partition before using this mode.")?;
+        let space = efi.space.as_ref().map_err(Clone::clone)?;
+        let insufficient = !space.sufficient(Default::default()).map_err(|e| e.to_string())?;
+        state.set_insufficient(insufficient);
+        if !insufficient { state.set_additional_efi(false); }
+        state.set_efi_details(format!("{} MiB free. {}", space.free_bytes / MIB, if insufficient { "The minimum does not fit. A second EFI partition requires your explicit choice." } else { "Reuse without formatting. Existing bootloaders are preserved." }).into());
+        if !source.error.is_empty() { return Err(source.error.clone()); }
+        if max < min { return Err(format!("At least {min:.0} GiB is needed for the ZFS pool, swap and EFI; only {max:.1} GiB is available. Reduce swap or choose another source.")); }
+        let efi_choice = if state.get_additional_efi() { EfiChoice::CreateAfterInsufficientSpace { existing_partition: efi.number } } else { EfiChoice::Reuse { partition: efi.number } };
+        efi_choice.validate_space(space, Default::default()).map_err(|e| e.to_string())?;
+        let request = Request { before: s.layout.clone(), source: source.source.clone(), efi: efi_choice, allocation_bytes, swap_bytes };
+        let plan = request.plan().map_err(|e| e.to_string())?;
+        state.set_after(segments(&s.layout, Some(&plan)));
+        state.set_allocation_summary(format!("New ZFS pool: {:.1} GiB · Swap: {} GiB{}", (plan.swap_start.unwrap_or(plan.end) - plan.zfs_start) as f64 * s.layout.sectorsize as f64 / GIB as f64, swap_bytes / GIB, if plan.efi_start.is_some() { " · New EFI: 1 GiB" } else { " · Existing EFI reused" }).into());
+        if let Some((old, size)) = &plan.shrink {
+            state.set_details(format!("{}: {:.0} → {:.0} GiB. Its start and existing data are preserved.", old.node.display(), old.size as f64 * s.layout.sectorsize as f64 / GIB as f64, *size as f64 * s.layout.sectorsize as f64 / GIB as f64).into());
+        }
+        Ok(request)
+    });
+    match result {
+        Ok(request) => {
+            config.alongside = Some(request);
+            state.set_error("".into());
+        }
+        Err(e) => state.set_error(e.into()),
+    }
+    crate::refresh::refresh_items(app, config);
+}
+
+pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
+    let weak = app.as_weak();
+    app.global::<AlongsideState>().on_reload(move || {
+        if let Some(app) = weak.upgrade() {
+            load(&app, None);
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<AlongsideState>().on_select_disk(move |index| {
+        if let Some(app) = weak.upgrade() {
+            load(&app, Some(index as usize));
+        }
+    });
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    app.global::<AlongsideState>().on_rebuild(move || {
+        if let Some(app) = weak.upgrade() {
+            rebuild(&app, &mut cfg.borrow_mut());
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<AlongsideState>()
+        .on_select_source(move |index| {
+            if let Some(app) = weak.upgrade() {
+                let s = app.global::<AlongsideState>();
+                s.set_source_index(index);
+                s.set_use_all(true);
+                s.invoke_rebuild();
+            }
+        });
+    let weak = app.as_weak();
+    app.global::<AlongsideState>().on_select_efi(move |index| {
+        if let Some(app) = weak.upgrade() {
+            let s = app.global::<AlongsideState>();
+            s.set_efi_index(index);
+            s.set_additional_efi(false);
+            s.invoke_rebuild();
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<AlongsideState>().on_allocate(move |value| {
+        if let Some(app) = weak.upgrade()
+            && value.is_finite()
+        {
+            let s = app.global::<AlongsideState>();
+            s.set_use_all(false);
+            s.set_allocation(value);
+            s.invoke_rebuild();
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<AlongsideState>().on_all_space(move |value| {
+        if let Some(app) = weak.upgrade() {
+            let s = app.global::<AlongsideState>();
+            s.set_use_all(value);
+            s.invoke_rebuild();
+        }
+    });
+    let weak = app.as_weak();
+    let cfg = config.clone();
+    app.global::<AlongsideState>().on_select_swap(move |index| {
+        if let Some(app) = weak.upgrade()
+            && let Some(mode) = SwapMode::from_index(index as usize)
+        {
+            cfg.borrow_mut().swap_mode = mode;
+            app.global::<AlongsideState>().invoke_rebuild();
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<AlongsideState>().on_size_swap(move |value| {
+        if let Some(app) = weak.upgrade()
+            && value.is_finite()
+        {
+            let s = app.global::<AlongsideState>();
+            s.set_swap_size(value.round().clamp(1.0, 1024.0));
+            s.invoke_rebuild();
+        }
+    });
+    let weak = app.as_weak();
+    app.global::<AlongsideState>().on_additional(move |value| {
+        if let Some(app) = weak.upgrade() {
+            let s = app.global::<AlongsideState>();
+            s.set_additional_efi(value && s.get_insufficient());
+            s.invoke_rebuild();
+        }
+    });
+}

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -24,6 +24,7 @@ pub const STEP_LABELS: [&str; TOTAL_STEPS] = [
 pub fn build_step_items(step: usize, c: &GlobalConfig) -> Vec<ConfigItem> {
     let mut items = match step {
         0 => build_welcome_items(c),
+        1 if c.installation_mode == Some(InstallationMode::Alongside) => vec![],
         1 => build_disk_items(c),
         2 => build_zfs_items(c),
         3 => build_system_items(c),
@@ -64,6 +65,42 @@ fn build_welcome_items(_c: &GlobalConfig) -> Vec<ConfigItem> {
 fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     let mut items = vec![section_header("Storage assignments")];
     match c.installation_mode {
+        Some(InstallationMode::Alongside) => {
+            if let Some(r) = &c.alongside {
+                items.push(ConfigItem {
+                    label: "Planned allocation".into(),
+                    value: format!(
+                        "{} — {:.0} GiB",
+                        r.before.device.display(),
+                        r.allocation_bytes as f64 / 1073741824.0
+                    )
+                    .into(),
+                    description: {
+                        use archinstall_zfs_core::disk::alongside::{EfiChoice, SpaceSource};
+                        let source = match r.source {
+                            SpaceSource::Shrink { partition } => format!(
+                                "Shrink partition {partition} from its end; preserve its data"
+                            ),
+                            SpaceSource::Unallocated { .. } => {
+                                "Use unallocated space; preserve existing partitions".into()
+                            }
+                        };
+                        let efi = match r.efi {
+                            EfiChoice::Reuse { partition } => {
+                                format!("Reuse EFI partition {partition} without formatting")
+                            }
+                            EfiChoice::CreateAfterInsufficientSpace { .. } => {
+                                "Create the explicitly selected additional 1 GiB EFI partition"
+                                    .into()
+                            }
+                        };
+                        format!("{source}. {efi}. {} GiB reserved for swap; the remainder is the new ZFS pool.", r.swap_bytes / 1073741824).into()
+                    },
+                    item_type: ItemType::Storage,
+                    ..Default::default()
+                });
+            }
+        }
         Some(InstallationMode::FullDisk) => {
             items.push(storage_item("disk", "Disk to erase", c.disk.as_deref(), c))
         }
@@ -257,31 +294,48 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             ..Default::default()
         });
     }
-    items.push(section_header("Swap"));
-    items.push(compact_choice(
-        ChoiceSetting::SwapMode,
-        "Swap method",
-        c.swap_mode,
-        "ZRAM uses compressed RAM. A swap partition uses disk space.",
-    ));
-    if matches!(
-        c.swap_mode,
-        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-    ) {
-        if c.installation_mode == Some(InstallationMode::FullDisk) {
-            items.push(inline_text(
-                TextSetting::SwapPartitionSize,
-                "Swap size",
-                c.swap_partition_size.as_deref().unwrap_or(""),
-                "Created on the selected disk, for example 8G",
-            ));
+    if c.installation_mode == Some(InstallationMode::Alongside) {
+        let value = if let Some(r) = &c.alongside
+            && r.swap_bytes > 0
+        {
+            format!("{} — {} GiB", c.swap_mode, r.swap_bytes / 1073741824)
         } else {
-            items.push(storage_item(
-                "swap_partition",
-                "Swap partition",
-                c.swap_partition.as_deref(),
-                c,
-            ));
+            c.swap_mode.to_string()
+        };
+        items.push(ConfigItem {
+            label: "Swap method".into(),
+            value: value.into(),
+            description: "Configured with the space allocation on the Disk page".into(),
+            item_type: ItemType::Readonly,
+            ..Default::default()
+        });
+    } else {
+        items.push(section_header("Swap"));
+        items.push(compact_choice(
+            ChoiceSetting::SwapMode,
+            "Swap method",
+            c.swap_mode,
+            "ZRAM uses compressed RAM. A swap partition uses disk space.",
+        ));
+        if matches!(
+            c.swap_mode,
+            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+        ) {
+            if c.installation_mode == Some(InstallationMode::FullDisk) {
+                items.push(inline_text(
+                    TextSetting::SwapPartitionSize,
+                    "Swap size",
+                    c.swap_partition_size.as_deref().unwrap_or(""),
+                    "Created on the selected disk, for example 8G",
+                ));
+            } else {
+                items.push(storage_item(
+                    "swap_partition",
+                    "Swap partition",
+                    c.swap_partition.as_deref(),
+                    c,
+                ));
+            }
         }
     }
     let mut compression = compact_choice(
@@ -584,12 +638,13 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         item.key = "".into();
         items.push(item);
     }
-    if c.installation_mode != Some(InstallationMode::FullDisk)
-        && matches!(
-            c.swap_mode,
-            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-        )
-    {
+    if matches!(
+        c.installation_mode,
+        Some(InstallationMode::NewPool | InstallationMode::ExistingPool)
+    ) && matches!(
+        c.swap_mode,
+        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
+    ) {
         let mut item = storage_item(
             "swap_partition",
             "Swap partition",

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -89,8 +89,8 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                             EfiChoice::Reuse { partition } => {
                                 format!("Reuse EFI partition {partition} without formatting")
                             }
-                            EfiChoice::CreateAfterInsufficientSpace { .. } => {
-                                "Create the explicitly selected additional 1 GiB EFI partition"
+                            EfiChoice::CreateSeparate { .. } => {
+                                "Create the explicitly selected separate 512 MiB EFI partition"
                                     .into()
                             }
                         };

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -1,3 +1,4 @@
+mod alongside;
 mod completion;
 mod config_items;
 #[cfg(feature = "linuxkms")]
@@ -231,6 +232,7 @@ fn run_gui(
     controllers::lists::setup(&app, &config, &models);
     controllers::wizard::setup(&app, &config, &kernel_scan);
     storage::setup(&app, &config);
+    alongside::setup(&app, &config);
     controllers::install::setup(&app, &config, demo, log_rx, &completion);
     controllers::wifi::setup(&app);
 

--- a/slint-ui/src/preview.rs
+++ b/slint-ui/src/preview.rs
@@ -43,6 +43,7 @@ pub enum Scene {
     Cancelling,
     Disk,
     NewPool,
+    Alongside,
     ExistingPool,
     Zfs,
     System,
@@ -231,6 +232,7 @@ pub fn config(scene: Scene) -> GlobalConfig {
     GlobalConfig {
         installation_mode: Some(match scene {
             Scene::NewPool => InstallationMode::NewPool,
+            Scene::Alongside => InstallationMode::Alongside,
             Scene::ExistingPool => InstallationMode::ExistingPool,
             _ => InstallationMode::FullDisk,
         }),
@@ -425,7 +427,7 @@ pub fn show(app: &App, scene: Scene, size: Size) {
         | Scene::WifiUnavailable
         | Scene::WifiNoInternet
         | Scene::WifiVerifying => 0,
-        Scene::Disk | Scene::NewPool | Scene::ExistingPool => 1,
+        Scene::Disk | Scene::NewPool | Scene::ExistingPool | Scene::Alongside => 1,
         Scene::Zfs => 2,
         Scene::System => 3,
         Scene::Users => 4,

--- a/slint-ui/src/storage.rs
+++ b/slint-ui/src/storage.rs
@@ -510,6 +510,9 @@ async fn pool_inventory() -> Result<(Vec<PoolRow>, Vec<String>), String> {
 
 /// Review uses the same eligibility rules as the picker, including loaded configs.
 pub fn issues(c: &GlobalConfig) -> Vec<String> {
+    if c.installation_mode == Some(InstallationMode::Alongside) {
+        return Vec::new();
+    }
     let roles = if c.installation_mode == Some(InstallationMode::FullDisk) {
         vec![("disk", c.disk.as_deref())]
     } else {

--- a/slint-ui/ui/app.slint
+++ b/slint-ui/ui/app.slint
@@ -1,3 +1,5 @@
+import { AlongsideState, DiskSegment } from "state/alongside-state.slint";
+export { AlongsideState, DiskSegment }
 import { Palette as StandardPalette } from "std-widgets.slint";
 import { StorageState, StorageCandidate } from "state/storage-state.slint";
 export { StorageState, StorageCandidate }

--- a/slint-ui/ui/components/alongside-panel.slint
+++ b/slint-ui/ui/components/alongside-panel.slint
@@ -3,6 +3,8 @@ import { AlongsideState, DiskSegment } from "../state/alongside-state.slint";
 import { Theme } from "../styling.slint";
 import { StyledButton } from "styled-button.slint";
 import { StyledTextInput } from "styled-text-input.slint";
+import { RadioDot } from "radio-dot.slint";
+import { FocusTouchArea } from "internal/state-layer.slint";
 
 component DiskMap inherits Rectangle {
     in property <[DiskSegment]> segments;
@@ -63,15 +65,20 @@ export component AlongsidePanel inherits Rectangle {
         if AlongsideState.sources.length > 0: VerticalLayout {
             spacing: 8px;
             Text { text: "Where to make space"; font-weight: 600; color: Theme.c.text; }
-            source-choice := ComboBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "Space source"; model: AlongsideState.sources; current-index: AlongsideState.source-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-source(self.current-index); } }
+            source-choice := ComboBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "Space source"; model: AlongsideState.sources; current-index <=> AlongsideState.source-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-source(self.current-index); } }
             Text { text: AlongsideState.details; color: Theme.c.subtext1; wrap: word-wrap; }
             CheckBox { text: "Use all available space"; checked: AlongsideState.use-all; enabled: !AlongsideState.busy; toggled => { AlongsideState.all-space(self.checked); } changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } }
             HorizontalLayout {
                 spacing: 16px;
                 Text { text: "Allocate to this installation"; color: Theme.c.text; }
-                allocation-slider := Slider { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "Space for installation"; minimum: AlongsideState.minimum; maximum: max(AlongsideState.minimum, AlongsideState.maximum); value: AlongsideState.allocation; enabled: !AlongsideState.busy && AlongsideState.maximum >= AlongsideState.minimum; changed(value) => { AlongsideState.allocate(round(value)); } }
+                allocation-slider := Slider { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "Space for installation"; minimum: AlongsideState.minimum; maximum: max(AlongsideState.minimum, AlongsideState.maximum); value <=> AlongsideState.allocation; enabled: !AlongsideState.busy && AlongsideState.maximum >= AlongsideState.minimum; changed(value) => { AlongsideState.allocate(round(value)); } }
                 allocation-input := StyledTextInput {
                     property <bool> dirty: false;
+                    // Typing replaces the `text` binding; follow later state
+                    // changes (Use all, refresh, a loaded plan) explicitly
+                    // unless an edit is in progress.
+                    property <float> bound: AlongsideState.allocation;
+                    changed bound => { if !self.dirty { self.text = "\{self.bound}"; } }
                     changed has-focus => {
                         if self.has-focus { root.reveal(self.absolute-position.y, self.height); }
                         else if self.dirty { self.dirty = false; if self.text.is-float() { AlongsideState.allocate(self.text.to-float()); } self.text = "\{AlongsideState.allocation}"; }
@@ -87,7 +94,7 @@ export component AlongsidePanel inherits Rectangle {
             ComboBox {
                 accessible-label: "Swap method";
                 model: ["None", "ZRAM — compressed RAM", "Swap partition", "Encrypted swap partition"];
-                current-index: AlongsideState.swap-mode;
+                current-index <=> AlongsideState.swap-mode;
                 enabled: !AlongsideState.busy;
                 selected(value) => { AlongsideState.select-swap(self.current-index); }
                 changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } }
@@ -100,6 +107,8 @@ export component AlongsidePanel inherits Rectangle {
                     text: "\{AlongsideState.swap-size}";
                     width: 80px;
                     property <bool> dirty: false;
+                    property <float> bound: AlongsideState.swap-size;
+                    changed bound => { if !self.dirty { self.text = "\{self.bound}"; } }
                     edited(value) => { self.dirty = true; }
                     accepted(value) => { self.dirty = false; if value.is-float() { AlongsideState.size-swap(value.to-float()); } self.text = "\{AlongsideState.swap-size}"; }
                     changed has-focus => {
@@ -115,9 +124,44 @@ export component AlongsidePanel inherits Rectangle {
         if AlongsideState.efi-partitions.length > 0: VerticalLayout {
             spacing: 8px;
             Text { text: "EFI boot files"; font-weight: 600; color: Theme.c.text; }
-            efi-choice := ComboBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "EFI partition"; model: AlongsideState.efi-partitions; current-index: AlongsideState.efi-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-efi(self.current-index); } }
+            efi-choice := ComboBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "EFI partition"; model: AlongsideState.efi-partitions; current-index <=> AlongsideState.efi-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-efi(self.current-index); } }
             Text { text: AlongsideState.efi-details; color: Theme.c.subtext1; wrap: word-wrap; }
-            if AlongsideState.insufficient: CheckBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } text: "Create an additional 1 GiB EFI partition in the allocated space"; checked: AlongsideState.additional-efi; enabled: !AlongsideState.busy; toggled => { AlongsideState.additional(self.checked); } }
+            HorizontalLayout {
+                spacing: 12px;
+                for option[index] in ["Reuse the selected EFI partition", "Create a separate 512 MiB EFI partition"]: Rectangle {
+                    property <bool> selected: (index == 1) == AlongsideState.additional-efi;
+                    property <bool> available: index == 1 || !AlongsideState.insufficient;
+                    horizontal-stretch: 1;
+                    background: selected ? Theme.c.blue.with-alpha(0.16) : Theme.c.surface0.with-alpha(0.55);
+                    border-radius: 8px;
+                    border-width: touch.has-focus ? 2px : 1px;
+                    border-color: touch.has-focus || selected ? Theme.c.blue : Theme.c.surface1;
+                    opacity: available ? 1 : 0.5;
+                    HorizontalLayout {
+                        padding: 10px;
+                        spacing: 8px;
+                        RadioDot { filled: selected; dot-color: Theme.c.blue; }
+                        VerticalLayout {
+                            spacing: 3px;
+                            horizontal-stretch: 1;
+                            Text { text: option + (index == 0 ? " (recommended)" : ""); color: Theme.c.text; font-weight: 600; wrap: word-wrap; }
+                            Text { text: index == 0 ? "Boot files go next to the existing loaders; nothing is formatted." : "Takes 512 MiB from the allocation; firmware and the other system then see two EFI partitions."; color: Theme.c.subtext1; font-size: 12px; wrap: word-wrap; }
+                        }
+                    }
+                    touch := FocusTouchArea {
+                        width: 100%;
+                        height: 100%;
+                        enabled: available && !AlongsideState.busy;
+                        accessible-role: radio-button;
+                        accessible-label: option;
+                        accessible-checked: selected;
+                        accessible-enabled: available && !AlongsideState.busy;
+                        accessible-action-default => { AlongsideState.additional(index == 1); }
+                        clicked => { AlongsideState.additional(index == 1); }
+                        changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } }
+                    }
+                }
+            }
         }
         if AlongsideState.error != "": Text { text: AlongsideState.error; color: Theme.c.red; wrap: word-wrap; }
     }

--- a/slint-ui/ui/components/alongside-panel.slint
+++ b/slint-ui/ui/components/alongside-panel.slint
@@ -1,0 +1,124 @@
+import { ComboBox, Slider, CheckBox } from "std-widgets.slint";
+import { AlongsideState, DiskSegment } from "../state/alongside-state.slint";
+import { Theme } from "../styling.slint";
+import { StyledButton } from "styled-button.slint";
+import { StyledTextInput } from "styled-text-input.slint";
+
+component DiskMap inherits Rectangle {
+    in property <[DiskSegment]> segments;
+    height: 44px;
+    background: Theme.c.surface1;
+    clip: true;
+    // Custom drawing: exact sector ratios, not layout stretch weights.
+    for segment in root.segments: Rectangle {
+        x: parent.width * segment.offset;
+        width: max(2px, parent.width * segment.fraction);
+        height: parent.height;
+        background: segment.kind == 1 ? Theme.c.green : segment.kind == 2 ? Theme.c.yellow : segment.kind == 3 ? Theme.c.blue : segment.kind == 5 ? Theme.c.mauve : segment.kind == 4 ? Theme.c.surface0 : Theme.c.overlay0;
+        if self.width > 90px: Text {
+            x: 10px;
+            width: parent.width - 20px;
+            height: parent.height;
+            text: parent.width < 160px ? segment.short-label : segment.label;
+            overflow: elide;
+            vertical-alignment: center;
+            color: segment.kind == 4 ? Theme.c.subtext1 : Theme.c.base;
+            font-size: 13px;
+            font-weight: 600;
+        }
+        border-width: segment.fraction < 0.004 ? 0px : 1px;
+        border-color: Theme.c.base;
+    }
+}
+
+export component AlongsidePanel inherits Rectangle {
+    callback reveal(length, length);
+    background: transparent;
+    vertical-stretch: 0;
+    init => { if AlongsideState.disks.length == 0 { AlongsideState.reload(); } else { AlongsideState.rebuild(); } }
+    VerticalLayout {
+        spacing: 12px;
+        HorizontalLayout {
+            spacing: 12px;
+            disk-choice := ComboBox {
+                changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } }
+                accessible-label: "Installation disk";
+                model: AlongsideState.disks;
+                current-index: AlongsideState.disk-index;
+                enabled: !AlongsideState.busy;
+                selected(value) => { AlongsideState.select-disk(self.current-index); }
+            }
+            StyledButton { label: "Refresh disks"; outlined: true; enabled: !AlongsideState.busy; clicked => { AlongsideState.reload(); } }
+        }
+        if AlongsideState.busy: Text { text: "Checking disk layout and filesystem resize limits…"; color: Theme.c.subtext1; wrap: word-wrap; }
+        if AlongsideState.before.length > 0: VerticalLayout {
+            spacing: 8px;
+            Text { text: "CURRENT LAYOUT"; font-size: 12px; color: Theme.c.subtext0; }
+            DiskMap { segments: AlongsideState.before; }
+            Text { text: "AFTER INSTALLATION"; font-size: 12px; color: Theme.c.subtext0; }
+            DiskMap { segments: AlongsideState.after; }
+            Text { text: "Gray: preserved   ·   Blue: resized   ·   Green: new ZFS   ·   Yellow: EFI   ·   Purple: swap"; color: Theme.c.subtext1; font-size: 12px; wrap: word-wrap; }
+        }
+        if AlongsideState.allocation-summary != "": Text { text: AlongsideState.allocation-summary; color: Theme.c.text; wrap: word-wrap; }
+        if AlongsideState.sources.length > 0: VerticalLayout {
+            spacing: 8px;
+            Text { text: "Where to make space"; font-weight: 600; color: Theme.c.text; }
+            source-choice := ComboBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "Space source"; model: AlongsideState.sources; current-index: AlongsideState.source-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-source(self.current-index); } }
+            Text { text: AlongsideState.details; color: Theme.c.subtext1; wrap: word-wrap; }
+            CheckBox { text: "Use all available space"; checked: AlongsideState.use-all; enabled: !AlongsideState.busy; toggled => { AlongsideState.all-space(self.checked); } changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } }
+            HorizontalLayout {
+                spacing: 16px;
+                Text { text: "Allocate to this installation"; color: Theme.c.text; }
+                allocation-slider := Slider { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "Space for installation"; minimum: AlongsideState.minimum; maximum: max(AlongsideState.minimum, AlongsideState.maximum); value: AlongsideState.allocation; enabled: !AlongsideState.busy && AlongsideState.maximum >= AlongsideState.minimum; changed(value) => { AlongsideState.allocate(round(value)); } }
+                allocation-input := StyledTextInput {
+                    property <bool> dirty: false;
+                    changed has-focus => {
+                        if self.has-focus { root.reveal(self.absolute-position.y, self.height); }
+                        else if self.dirty { self.dirty = false; if self.text.is-float() { AlongsideState.allocate(self.text.to-float()); } self.text = "\{AlongsideState.allocation}"; }
+                    }
+                    edited(value) => { self.dirty = true; } accessible-label: "Allocation in GiB"; width: 80px; text: "\{AlongsideState.allocation}"; enabled: !AlongsideState.busy; accepted(value) => { self.dirty = false; if value.is-float() { AlongsideState.allocate(value.to-float()); } self.text = "\{AlongsideState.allocation}"; } }
+                Text { text: "GiB"; color: Theme.c.subtext1; }
+            }
+            Text { text: "Existing partition starts stay fixed. Make a backup before resizing an operating system."; color: Theme.c.subtext1; font-size: 12px; wrap: word-wrap; }
+        }
+        if AlongsideState.sources.length > 0: VerticalLayout {
+            spacing: 8px;
+            Text { text: "Swap"; font-weight: 600; color: Theme.c.text; }
+            ComboBox {
+                accessible-label: "Swap method";
+                model: ["None", "ZRAM — compressed RAM", "Swap partition", "Encrypted swap partition"];
+                current-index: AlongsideState.swap-mode;
+                enabled: !AlongsideState.busy;
+                selected(value) => { AlongsideState.select-swap(self.current-index); }
+                changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } }
+            }
+            if AlongsideState.swap-mode >= 2: HorizontalLayout {
+                spacing: 12px;
+                Text { text: "Swap size (GiB)"; color: Theme.c.text; horizontal-stretch: 0; }
+                StyledTextInput {
+                    accessible-label: "Swap size in GiB";
+                    text: "\{AlongsideState.swap-size}";
+                    width: 80px;
+                    property <bool> dirty: false;
+                    edited(value) => { self.dirty = true; }
+                    accepted(value) => { self.dirty = false; if value.is-float() { AlongsideState.size-swap(value.to-float()); } self.text = "\{AlongsideState.swap-size}"; }
+                    changed has-focus => {
+                        if self.has-focus { root.reveal(self.absolute-position.y, self.height); }
+                        else if self.dirty { self.dirty = false; if self.text.is-float() { AlongsideState.size-swap(self.text.to-float()); } self.text = "\{AlongsideState.swap-size}"; }
+                    }
+                }
+                Text { text: "Taken from the allocation above; the remainder goes to ZFS."; horizontal-stretch: 1; color: Theme.c.subtext1; wrap: word-wrap; }
+            }
+            if AlongsideState.swap-mode == 3: Text { text: "Uses a new random encryption key at each boot; cannot be used for hibernation."; color: Theme.c.subtext1; wrap: word-wrap; }
+            if AlongsideState.swap-mode < 2: Text { text: AlongsideState.swap-mode == 1 ? "ZRAM uses no disk space. The allocation remains available to ZFS." : "No space is reserved for swap."; color: Theme.c.subtext1; wrap: word-wrap; }
+        }
+        if AlongsideState.efi-partitions.length > 0: VerticalLayout {
+            spacing: 8px;
+            Text { text: "EFI boot files"; font-weight: 600; color: Theme.c.text; }
+            efi-choice := ComboBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "EFI partition"; model: AlongsideState.efi-partitions; current-index: AlongsideState.efi-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-efi(self.current-index); } }
+            Text { text: AlongsideState.efi-details; color: Theme.c.subtext1; wrap: word-wrap; }
+            if AlongsideState.insufficient: CheckBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } text: "Create an additional 1 GiB EFI partition in the allocated space"; checked: AlongsideState.additional-efi; enabled: !AlongsideState.busy; toggled => { AlongsideState.additional(self.checked); } }
+        }
+        if AlongsideState.error != "": Text { text: AlongsideState.error; color: Theme.c.red; wrap: word-wrap; }
+    }
+}

--- a/slint-ui/ui/components/storage-mode.slint
+++ b/slint-ui/ui/components/storage-mode.slint
@@ -8,7 +8,7 @@ export component StorageMode inherits Rectangle {
         spacing: 12px;
         padding-top: 8px;
         padding-bottom: 14px;
-        for label[index] in ["Erase a disk", "Use existing partitions", "Use an existing pool"]: Rectangle {
+        for label[index] in ["Erase a disk", "Use existing partitions", "Use an existing pool", "Install alongside"]: Rectangle {
             horizontal-stretch: 1;
             background: WizardState.storage-mode == index ? Theme.c.blue.with-alpha(0.16) : Theme.c.surface0.with-alpha(0.55);
             border-radius: 8px;
@@ -27,7 +27,7 @@ export component StorageMode inherits Rectangle {
                 }
 
                 Text {
-                    text: index == 0 ? "Create a new partition layout" : index == 1 ? "Create a new ZFS pool" : "Create a new boot environment";
+                    text: index == 0 ? "Create a new partition layout" : index == 1 ? "Create a new ZFS pool" : index == 2 ? "Create a new boot environment" : "Keep another operating system";
                     color: Theme.c.subtext1;
                     font-size: 12px;
                     wrap: word-wrap;

--- a/slint-ui/ui/state/alongside-state.slint
+++ b/slint-ui/ui/state/alongside-state.slint
@@ -1,0 +1,35 @@
+export struct DiskSegment { offset: float, fraction: float, kind: int, label: string, short-label: string }
+export global AlongsideState {
+    in-out property <[string]> disks;
+    in-out property <[string]> sources;
+    in-out property <[string]> efi-partitions;
+    in-out property <int> disk-index: -1;
+    in-out property <int> source-index: -1;
+    in-out property <int> efi-index: -1;
+    in-out property <bool> busy;
+    in-out property <int> generation;
+    in-out property <bool> insufficient;
+    in-out property <bool> additional-efi;
+    in-out property <bool> use-all: true;
+    in-out property <int> swap-mode;
+    in-out property <float> swap-size: 8;
+    in-out property <float> allocation: 32;
+    in-out property <float> minimum: 32;
+    in-out property <float> maximum: 32;
+    in-out property <string> error;
+    in-out property <string> details;
+    in-out property <string> allocation-summary;
+    in-out property <string> efi-details;
+    in-out property <[DiskSegment]> before;
+    in-out property <[DiskSegment]> after;
+    callback reload();
+    callback select-disk(int);
+    callback select-source(int);
+    callback select-efi(int);
+    callback allocate(float);
+    callback additional(bool);
+    callback all-space(bool);
+    callback select-swap(int);
+    callback size-swap(float);
+    callback rebuild();
+}

--- a/slint-ui/ui/views/wizard-view.slint
+++ b/slint-ui/ui/views/wizard-view.slint
@@ -1,3 +1,4 @@
+import { AlongsidePanel } from "../components/alongside-panel.slint";
 import { StorageState } from "../state/storage-state.slint";
 import { SetupRow } from "../components/setup-row.slint";
 import { StorageMode } from "../components/storage-mode.slint";
@@ -187,6 +188,12 @@ export component WizardView inherits Rectangle {
                                 }
                                 if WizardState.current-step == 1: StorageMode {
                                     activated(key) => { root.item-activated(key); }
+                                }
+                                if WizardState.current-step == 1 && WizardState.storage-mode == 3: alongside := AlongsidePanel {
+                                    reveal(y, h) => {
+                                        if y < items-scroll.absolute-position.y { items-scroll.content-y += items-scroll.absolute-position.y - y; }
+                                        else if y + h > items-scroll.absolute-position.y + items-scroll.height - 8px { items-scroll.content-y -= y + h - items-scroll.absolute-position.y - items-scroll.height + 8px; }
+                                    }
                                 }
                                 for item[index] in WizardState.config-items: Rectangle {
                                     vertical-stretch: 0;

--- a/tui/src/tui/screens/steps/disk.rs
+++ b/tui/src/tui/screens/steps/disk.rs
@@ -50,5 +50,40 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         });
     }
 
+    // The graphical installer owns alongside planning. A plan loaded from a
+    // configuration file is shown so the page is not blank; it cannot be
+    // edited here.
+    if matches!(mode, Some(InstallationMode::Alongside)) {
+        items.push(MenuItem {
+            key: "",
+            label: "Alongside plan",
+            value: config
+                .alongside
+                .as_ref()
+                .map(alongside_summary)
+                .unwrap_or_else(|| "Missing; create it with the graphical installer (azfs)".into()),
+            kind: MenuKind::SectionHeader,
+        });
+    }
+
     items
+}
+
+fn alongside_summary(request: &archinstall_zfs_core::disk::alongside::Request) -> String {
+    use archinstall_zfs_core::disk::alongside::{EfiChoice, SpaceSource};
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let source = match request.source {
+        SpaceSource::Shrink { partition } => format!("shrink partition {partition}"),
+        SpaceSource::Unallocated { .. } => "unallocated space".to_string(),
+    };
+    let efi = match request.efi {
+        EfiChoice::Reuse { partition } => format!("reuse EFI partition {partition}"),
+        EfiChoice::CreateSeparate { .. } => "separate EFI partition".to_string(),
+    };
+    format!(
+        "{}: {source}, {:.1} GiB for Linux, swap {:.0} GiB, {efi}",
+        request.before.device.display(),
+        request.allocation_bytes as f64 / GIB,
+        request.swap_bytes as f64 / GIB
+    )
 }

--- a/tui/src/tui/screens/steps/welcome.rs
+++ b/tui/src/tui/screens/steps/welcome.rs
@@ -1,14 +1,25 @@
+use archinstall_zfs_core::config::choices::Choice;
 use archinstall_zfs_core::config::edit::ChoiceSetting;
 use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode};
 
-use super::{MenuItem, choice_group};
+use super::{MenuItem, MenuKind, choice_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
-    choice_group(
+    let mut items = choice_group(
         ChoiceSetting::InstallationMode,
         "Installation mode",
         config
             .installation_mode
             .unwrap_or(InstallationMode::FullDisk),
-    )
+    );
+    // The graphical allocation editor owns alongside plan construction. Do not
+    // expose an option that this frontend cannot configure.
+    items.retain(|item| !matches!(item.kind, MenuKind::RadioOption { index, .. } if index == InstallationMode::Alongside.index()));
+    items.push(MenuItem {
+        key: "",
+        label: "For installation alongside another OS, use the graphical installer (azfs).",
+        value: String::new(),
+        kind: MenuKind::SectionHeader,
+    });
+    items
 }

--- a/xtask/configs/alongside-swap.json
+++ b/xtask/configs/alongside-swap.json
@@ -1,0 +1,31 @@
+{
+    "installation_mode": "full_disk",
+    "disk": "/dev/disk/by-id/virtio-archzfs-test-disk",
+    "pool_name": "testpool",
+    "dataset_prefix": "arch0",
+    "init_system": "dracut",
+    "zfs_module_mode": "dkms",
+    "zfs_encryption_mode": "none",
+    "compression": "lz4",
+    "swap_mode": "zswap_partition",
+    "hostname": "archzfs-test",
+    "locale": "en_US.UTF-8 UTF-8",
+    "keyboard_layout": "us",
+    "timezone": "UTC",
+    "ntp": true,
+    "root_password": "test",
+    "kernels": [
+        "linux-lts"
+    ],
+    "additional_packages": [
+        "openssh"
+    ],
+    "aur_packages": [],
+    "network_copy_iso": true,
+    "parallel_downloads": 10,
+    "zrepl_enabled": false,
+    "bluetooth": false,
+    "extra_services": [
+        "sshd"
+    ]
+}

--- a/xtask/src/alongside.rs
+++ b/xtask/src/alongside.rs
@@ -1,0 +1,89 @@
+//! Prepare and verify a preserved filesystem only inside the disposable ISO VM.
+use crate::qemu::QemuVm;
+use std::{fs, io::Write, os::unix::fs::OpenOptionsExt, path::Path};
+
+pub fn prepare(vm: &QemuVm, config: &Path) -> Result<(), String> {
+    let output = vm.ssh_run(r#"set -euo pipefail
+[ "$(readlink -f /dev/disk/by-id/virtio-archzfs-test-disk)" = /dev/vda ]
+command -v mmd >/dev/null || pacman -Sy --noconfirm --needed mtools
+sgdisk --zap-all --new=1:2048:+500M --typecode=1:ef00 --new=2:0:+50G --typecode=2:8300 --new=3:0:+1G --typecode=3:8300 /dev/vda
+udevadm settle
+mkfs.fat -F32 /dev/vda1
+mkfs.ext4 -F /dev/vda2
+mkdir -p /run/preserved
+mount /dev/vda2 /run/preserved
+printf 'preserved filesystem payload\n' > /run/preserved/KEEP.txt
+umount /run/preserved
+printf 'foreign EFI payload\n' > /run/KEEP.EFI
+mmd -i /dev/vda1 ::/EFI ::/EFI/FOREIGN
+mcopy -i /dev/vda1 /run/KEEP.EFI ::/EFI/FOREIGN/KEEP.EFI
+"#).map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err(format!(
+            "Alongside fixture preparation failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let output = vm
+        .ssh_run("sfdisk --json /dev/vda")
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err("Cannot inspect VM fixture GPT".into());
+    }
+    let layout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).map_err(|e| e.to_string())?;
+    let mut config: serde_json::Value =
+        serde_json::from_slice(&fs::read(config).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+    let swap_bytes = if matches!(
+        config["swap_mode"].as_str(),
+        Some("zswap_partition" | "zswap_partition_encrypted")
+    ) {
+        8_u64 * 1024 * 1024 * 1024
+    } else {
+        0
+    };
+    config["installation_mode"] = "alongside".into();
+    config["alongside"] = serde_json::json!({ "before": layout["partitiontable"], "source": {"Shrink":{"partition":2}}, "efi":{"Reuse":{"partition":1}}, "allocation_bytes":32_u64*1024*1024*1024 + swap_bytes, "swap_bytes": swap_bytes });
+    let path = std::env::temp_dir().join(format!("archzfs-alongside-{}.json", std::process::id()));
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(&path)
+        .map_err(|e| e.to_string())?;
+    let result = (|| {
+        file.write_all(&serde_json::to_vec(&config).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+        vm.scp_to(&path, "/root/config.json");
+        Ok(())
+    })();
+    let _ = fs::remove_file(path);
+    result
+}
+
+pub fn verify(vm: &QemuVm) -> Result<(), String> {
+    let output = vm
+        .ssh_run(
+            r#"set -euo pipefail
+[ "$(readlink -f /dev/disk/by-id/virtio-archzfs-test-disk)" = /dev/vda ]
+e2fsck -fn /dev/vda2
+mount -o ro /dev/vda2 /run/preserved
+value=$(cat /run/preserved/KEEP.txt)
+umount /run/preserved
+[ "$value" = 'preserved filesystem payload' ]
+[ "$(mtype -i /dev/vda1 ::/EFI/FOREIGN/KEEP.EFI)" = 'foreign EFI payload' ]
+mtype -i /dev/vda1 ::/EFI/zbm/vmlinuz.EFI > /run/installed-zbm.EFI
+[ "$(od -An -tx1 -N2 /run/installed-zbm.EFI | tr -d ' \n')" = 4d5a ]
+"#,
+        )
+        .map_err(|e| e.to_string())?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Preserved filesystem/ESP verification failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,4 @@
+mod alongside;
 mod iso;
 mod qemu;
 
@@ -113,6 +114,9 @@ enum Commands {
 
 #[derive(Parser, Clone)]
 struct TestOpts {
+    /// Install by shrinking an ext4 fixture in the disposable VM; verify retained files.
+    #[arg(long)]
+    alongside: bool,
     /// Testing ISO to boot. By default, use the newest *-testing-*.iso.
     /// Custom images must allow passwordless root SSH on the ISO VM.
     #[arg(long)]
@@ -432,6 +436,17 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
     // Fresh environment
     eprintln!("[1/4] Creating fresh disk and UEFI vars");
     qemu::create_fresh_disk(&opts.disk);
+    if opts.alongside {
+        let status = Command::new("qemu-img")
+            .args(["resize"])
+            .arg(&opts.disk)
+            .arg("80G")
+            .status()
+            .map_err(|e| e.to_string())?;
+        if !status.success() {
+            return Err("Cannot enlarge alongside fixture disk".into());
+        }
+    }
     qemu::reset_uefi_vars(&opts.vars);
 
     // Boot ISO
@@ -452,6 +467,9 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
     eprintln!("[3/4] Running installer");
     vm.scp_to(&opts.binary, "/root/archinstall-zfs-rs");
     vm.scp_to(&opts.config, "/root/config.json");
+    if opts.alongside {
+        alongside::prepare(&vm, &opts.config)?;
+    }
     vm.ssh_run("chmod +x /root/archinstall-zfs-rs")
         .map_err(|e| format!("chmod failed: {e}"))?;
 
@@ -473,6 +491,10 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
     let output = vm
         .ssh_run(&installer_command)
         .map_err(|e| format!("installer failed to execute: {e}"))?;
+
+    if opts.alongside && output.status.success() {
+        alongside::verify(&vm)?;
+    }
 
     // Pull installer logs from VM before shutdown (regardless of success/failure)
     let log_dest = PathBuf::from("test-install.log");
@@ -539,8 +561,7 @@ fn cmd_test_boot(opts: TestOpts) -> Result<(), String> {
 
     // Verify
     eprintln!("[3/3] Verifying system health");
-    let init_system = detect_init_system(&opts.config);
-    verify_system(&vm, &init_system)?;
+    verify_system(&vm, &opts.config)?;
 
     eprintln!("=== test-boot: PASSED ===\n");
     Ok(())
@@ -548,7 +569,8 @@ fn cmd_test_boot(opts: TestOpts) -> Result<(), String> {
 
 // ── Verification ───────────────────────────────────────
 
-fn verify_system(vm: &QemuVm, init_system: &str) -> Result<(), String> {
+fn verify_system(vm: &QemuVm, config_path: &Path) -> Result<(), String> {
+    let init_system = detect_init_system(config_path);
     let mut passed = 0;
     let mut checks = Vec::new();
 
@@ -607,13 +629,22 @@ fn verify_system(vm: &QemuVm, init_system: &str) -> Result<(), String> {
         }
     }
 
-    // zram
-    let zram = vm.ssh_stdout("cat /etc/systemd/zram-generator.conf 2>/dev/null || echo missing");
-    if zram.contains("zram0") {
-        checks.push("  zram: configured".to_string());
+    // Verify the configured swap path, including activation after boot.
+    let config: Value = serde_json::from_slice(&fs::read(config_path).map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())?;
+    let swap = vm.ssh_stdout("swapon --show=NAME --noheadings");
+    let swap_ok = match config["swap_mode"].as_str().unwrap_or("none") {
+        "none" => swap.trim().is_empty(),
+        "zram" => swap.contains("/dev/zram"),
+        "zswap_partition" => !swap.trim().is_empty() && !swap.contains("zram"),
+        "zswap_partition_encrypted" => swap.contains("cryptswap") || swap.contains("/dev/dm-"),
+        _ => false,
+    };
+    if swap_ok {
+        checks.push("  swap: configured and active as requested".into());
         passed += 1;
     } else {
-        checks.push(format!("  zram: FAIL ({zram})"));
+        checks.push(format!("  swap: FAIL ({swap})"));
     }
 
     // ZFS mounts
@@ -699,7 +730,8 @@ fn verify_system(vm: &QemuVm, init_system: &str) -> Result<(), String> {
     // ZBM pacman hook
     let zbm_hook =
         vm.ssh_stdout("cat /etc/pacman.d/hooks/95-zfsbootmenu.hook 2>/dev/null || echo missing");
-    if zbm_hook.contains("generate-zbm") {
+    if zbm_hook.contains("Exec = /usr/local/sbin/azfs-update-zbm")
+        && vm.ssh_stdout("test -x /usr/local/sbin/azfs-update-zbm && test -x /usr/local/libexec/azfs-install-zbm && echo ready").trim() == "ready" {
         checks.push("  ZBM pacman hook: installed".to_string());
         passed += 1;
     } else {


### PR DESCRIPTION
Add UEFI/GPT installation alongside an existing system by using unallocated space or shrinking an ordinary NTFS/ext4 partition. Reuse the existing EFI partition by default, preserve existing data and boot files, and show the proposed allocation before installation.

- Add guarded filesystem shrinking, geometry revalidation, GPT recovery dumps and explicit consent for a second ESP only when the existing one is too small.
- Add proportional before/after disk maps, default allocation of all available space, integrated swap selection, and graceful missing-tool/unsupported-layout states.
- Build ZFSBootMenu locally on the root filesystem and publish it without requiring two simultaneous images or a permanent backup on the ESP.
- Add repeatable preview flows, disposable filesystem fixtures and an alongside VM installation/boot scenario.

## Testing

- Real FAT publication tests passed for staging, single-image replacement, recovery copy, foreign fallback preservation and invalid/oversized image rejection.
- Disposable NTFS/ext4 shrink, unallocated-space, explicit additional-ESP and swap-allocation fixtures passed with preserved payload checks.
- Real Slint interaction flows passed at 1920×1080, 1366×768 and 150% scale, including keyboard scrolling, swap and error states.
- Alongside ext4 installation with ZRAM completed; the installed system booted and passed all 13 health checks. An additional disk-swap VM run is still in progress.
- Existing Windows/other-OS bootability has not been tested. Keep this draft until the remaining integration run and review are complete.
