### PR TITLE
Consolidate shared helpers across core, UI and tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,15 @@ jobs:
           target/release/azfs
           target/release/xtask
 
-  iso-linux:
+  iso:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.build_iso == 'true' || github.event.inputs.create_release == 'true'))
     runs-on: ubuntu-latest
+    strategy:
+      # The kernels build independently; one failing must not cancel the other.
+      fail-fast: false
+      matrix:
+        kernel: [linux, linux-lts]
     container:
       image: ghcr.io/${{ github.repository }}/ci:latest
       credentials:
@@ -83,76 +88,34 @@ jobs:
     - name: Fix binary permissions
       run: chmod +x target/release/azfs-tui target/release/azfs target/release/xtask
 
-    - name: Build ISO with linux kernel
+    - name: Build ISO with ${{ matrix.kernel }} kernel
+      env:
+        KERNEL: ${{ matrix.kernel }}
       run: |
         target/release/xtask render-profile \
           --profile-dir gen_iso/profile --out-dir gen_iso/profile_rendered \
-          --kernel linux --zfs precompiled
+          --kernel "$KERNEL" --zfs precompiled
         just _prepare-binary
         if ! sudo mkarchiso -v -w "gen_iso/workdir" -o gen_iso/out gen_iso/profile_rendered; then
           echo "Precompiled failed, retrying with DKMS..."
           rm -rf gen_iso/profile_rendered gen_iso/workdir
           target/release/xtask render-profile \
             --profile-dir gen_iso/profile --out-dir gen_iso/profile_rendered \
-            --kernel linux --zfs dkms
+            --kernel "$KERNEL" --zfs dkms
           just _prepare-binary
           sudo mkarchiso -v -w "gen_iso/workdir" -o gen_iso/out gen_iso/profile_rendered
         fi
 
+    # The release job downloads these by name: iso-linux and iso-linux-lts.
     - name: Upload ISO
       uses: actions/upload-artifact@v7
       with:
-        name: iso-linux
+        name: iso-${{ matrix.kernel }}
         path: gen_iso/out/*.iso
         if-no-files-found: error
 
-  iso-linux-lts:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.build_iso == 'true' || github.event.inputs.create_release == 'true'))
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository }}/ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged
-
-    steps:
-    - uses: actions/checkout@v7
-
-    - name: Download binaries
-      uses: actions/download-artifact@v8
-      with:
-        name: binaries
-        path: target/release/
-
-    - name: Fix binary permissions
-      run: chmod +x target/release/azfs-tui target/release/azfs target/release/xtask
-
-    - name: Build ISO with linux-lts kernel
-      run: |
-        target/release/xtask render-profile \
-          --profile-dir gen_iso/profile --out-dir gen_iso/profile_rendered \
-          --kernel linux-lts --zfs precompiled
-        just _prepare-binary
-        if ! sudo mkarchiso -v -w "gen_iso/workdir" -o gen_iso/out gen_iso/profile_rendered; then
-          echo "Precompiled failed, retrying with DKMS..."
-          rm -rf gen_iso/profile_rendered gen_iso/workdir
-          target/release/xtask render-profile \
-            --profile-dir gen_iso/profile --out-dir gen_iso/profile_rendered \
-            --kernel linux-lts --zfs dkms
-          just _prepare-binary
-          sudo mkarchiso -v -w "gen_iso/workdir" -o gen_iso/out gen_iso/profile_rendered
-        fi
-
-    - name: Upload ISO
-      uses: actions/upload-artifact@v7
-      with:
-        name: iso-linux-lts
-        path: gen_iso/out/*.iso
-
   release:
-    needs: [build, iso-linux, iso-linux-lts]
+    needs: [build, iso]
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true')
     runs-on: ubuntu-latest
     permissions:

--- a/core/assets/azfs-install-zbm
+++ b/core/assets/azfs-install-zbm
@@ -35,6 +35,20 @@ free_bytes() {
     printf '%s\n' "$((blocks * unit))"
 }
 
+# Copy the generated image next to $1 under a temporary name, verify the copy
+# and rename it into place; $2 is the failure message when it does not verify.
+# $temporary stays global so the EXIT trap removes an interrupted copy.
+publish_to() {
+    local dest=$1 message=$2
+    temporary=$(mktemp "${dest%/*}/.zbm-update.XXXXXXXX")
+    cp -- "$source_file" "$temporary"
+    cmp -s -- "$source_file" "$temporary" || fail "$message"
+    sync -f "$temporary"
+    mv -f -- "$temporary" "$dest"
+    temporary=
+    sync -f "$esp"
+}
+
 old_size=0
 if [[ -f $destination ]]; then
     old_size=$(stat -c %s "$destination")
@@ -73,13 +87,7 @@ if (( available < needed )); then
     rm -- "$destination"
     sync -f "$esp"
 fi
-temporary=$(mktemp "${destination%/*}/.zbm-update.XXXXXXXX")
-cp -- "$source_file" "$temporary"
-cmp -s -- "$source_file" "$temporary" || fail "Written image verification failed; recovery copy: $recovery"
-sync -f "$temporary"
-mv -f -- "$temporary" "$destination"
-temporary=
-sync -f "$esp"
+publish_to "$destination" "Written image verification failed; recovery copy: $recovery"
 
 # A fallback is useful but optional. Never overwrite another loader or fail a
 # successful main-image update merely because a duplicate does not fit.
@@ -95,13 +103,7 @@ if (( $(free_bytes) < needed )); then
     exit 0
 fi
 mkdir -p -- "${fallback%/*}"
-temporary=$(mktemp "${fallback%/*}/.zbm-update.XXXXXXXX")
-cp -- "$source_file" "$temporary"
-cmp -s -- "$source_file" "$temporary" || fail "Fallback verification failed; main loader is installed"
-sync -f "$temporary"
-mv -f -- "$temporary" "$fallback"
-temporary=
-sync -f "$esp"
+publish_to "$fallback" "Fallback verification failed; main loader is installed"
 sha256sum < "$fallback" > "$fallback_digest.tmp"
 mv -f -- "$fallback_digest.tmp" "$fallback_digest"
 sync -f "$stage"

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -348,11 +348,7 @@ fn ensure_efi_entry(
     Ok(())
 }
 
-pub fn create_efi_entries(
-    runner: &dyn CommandRunner,
-    efi_partition: &Path,
-    target: &Path,
-) -> Result<()> {
+pub fn create_efi_entries(runner: &dyn CommandRunner, efi_partition: &Path) -> Result<()> {
     let location = resolve_efi_location(runner, efi_partition)?;
 
     let existing = runner.run("efibootmgr", &["-v"])?;
@@ -377,8 +373,6 @@ pub fn create_efi_entries(
             tracing::warn!(number, "failed to remove the obsolete backup EFI entry");
         }
     }
-    let _ = target;
-
     tracing::info!("created ZFSBootMenu EFI boot entry");
     Ok(())
 }
@@ -549,18 +543,9 @@ mod tests {
         assert!(content.contains("Target = zfs-utils"));
     }
 
-    fn target_with_zbm() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().unwrap();
-        let zbm = dir.path().join("boot/efi/EFI/zbm");
-        fs::create_dir_all(&zbm).unwrap();
-        fs::write(zbm.join("vmlinuz.EFI"), b"main").unwrap();
-        dir
-    }
-
     #[test]
     fn test_create_efi_entries_uses_the_selected_disk_and_partition() {
         // With locally-built ZBM, cmdline is embedded - no -u needed
-        let target = target_with_zbm();
         let runner = RecordingRunner::new(vec![
             CannedResponse {
                 stdout: "/dev/nvme0n1 7 AABB-CCDD\n".into(),
@@ -573,12 +558,7 @@ mod tests {
             CannedResponse::default(), // efibootmgr -c (main)
         ]);
 
-        create_efi_entries(
-            &runner,
-            Path::new("/dev/disk/by-id/disk-part7"),
-            target.path(),
-        )
-        .unwrap();
+        create_efi_entries(&runner, Path::new("/dev/disk/by-id/disk-part7")).unwrap();
 
         let calls = runner.calls();
         let main_call = &calls[2];
@@ -595,7 +575,6 @@ mod tests {
 
     #[test]
     fn test_matching_entry_is_kept() {
-        let target = target_with_zbm();
         let runner = RecordingRunner::new(vec![
             CannedResponse {
                 stdout: "/dev/sda 1 aabb-ccdd\n".into(),
@@ -607,14 +586,13 @@ mod tests {
             },
         ]);
 
-        create_efi_entries(&runner, Path::new("/dev/sda1"), target.path()).unwrap();
+        create_efi_entries(&runner, Path::new("/dev/sda1")).unwrap();
 
         assert_eq!(runner.calls().len(), 2);
     }
 
     #[test]
     fn test_obsolete_backup_entry_is_removed_and_main_entry_created() {
-        let target = target_with_zbm();
         let runner = RecordingRunner::new(vec![
             CannedResponse {
                 stdout: "/dev/sda 1 aabb-ccdd\n".into(),
@@ -628,7 +606,7 @@ mod tests {
             CannedResponse::default(),
         ]);
 
-        create_efi_entries(&runner, Path::new("/dev/sda1"), target.path()).unwrap();
+        create_efi_entries(&runner, Path::new("/dev/sda1")).unwrap();
 
         let calls = runner.calls();
         assert_eq!(calls.len(), 4);
@@ -638,7 +616,6 @@ mod tests {
 
     #[test]
     fn test_stale_same_name_entry_is_replaced() {
-        let target = target_with_zbm();
         let runner = RecordingRunner::new(vec![
             CannedResponse {
                 stdout: "/dev/sda 3 aabb-ccdd\n".into(),
@@ -652,7 +629,7 @@ mod tests {
             CannedResponse::default(),
         ]);
 
-        create_efi_entries(&runner, Path::new("/dev/sda3"), target.path()).unwrap();
+        create_efi_entries(&runner, Path::new("/dev/sda3")).unwrap();
 
         let calls = runner.calls();
         assert_eq!(calls[2].args, ["-b", "00AF", "-B"]);

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use serde::Serialize;
 
 use crate::boot_environment::BootEnvironment;
@@ -227,7 +227,7 @@ pub async fn install_and_generate_zbm(
         install_zbm_from_aur(runner.clone(), target, cancel, download_config.clone()).await?;
     }
     if cancel.is_cancelled() {
-        color_eyre::eyre::bail!("installation cancelled");
+        bail!("installation cancelled");
     }
 
     // 2-5. Sync operations: config, hooks, generate-zbm, copy EFI
@@ -275,17 +275,22 @@ fn resolve_efi_location(runner: &dyn CommandRunner, efi_partition: &Path) -> Res
         ],
     )?;
     check_exit(&output, "resolve EFI disk and partition")?;
-    let fields: Vec<_> = output.stdout.split_whitespace().collect();
-    if fields.len() != 3 {
-        color_eyre::eyre::bail!(
+    parse_efi_location(&output.stdout, efi_partition)
+}
+
+/// The `PKNAME PARTN PARTUUID` line lsblk prints for the ESP.
+fn parse_efi_location(stdout: &str, efi_partition: &Path) -> Result<EfiLocation> {
+    let fields: Vec<&str> = stdout.split_whitespace().collect();
+    let &[disk, partition, partuuid] = fields.as_slice() else {
+        bail!(
             "cannot resolve EFI disk, partition number and PARTUUID for {}",
             efi_partition.display()
         );
-    }
+    };
     Ok(EfiLocation {
-        disk: fields[0].into(),
-        partition: fields[1].parse().wrap_err("invalid EFI partition number")?,
-        partuuid: fields[2].to_ascii_lowercase(),
+        disk: disk.into(),
+        partition: partition.parse().wrap_err("invalid EFI partition number")?,
+        partuuid: partuuid.to_ascii_lowercase(),
     })
 }
 
@@ -295,7 +300,8 @@ fn boot_entry(line: &str) -> Option<(&str, &str, &str)> {
     if !number.chars().all(|c| c.is_ascii_hexdigit()) {
         return None;
     }
-    let rest = rest.get(4..)?.strip_prefix('*').unwrap_or(&rest[4..]);
+    let tail = rest.get(4..)?;
+    let rest = tail.strip_prefix('*').unwrap_or(tail);
     let device_start = rest.find("HD(")?;
     Some((number, rest[..device_start].trim(), &rest[device_start..]))
 }
@@ -546,6 +552,34 @@ mod tests {
         assert!(content.contains("Type = Package"));
         assert!(content.contains("Target = zfsbootmenu"));
         assert!(content.contains("Target = zfs-utils"));
+    }
+
+    #[test]
+    fn efi_location_needs_all_three_lsblk_fields() {
+        let efi = Path::new("/dev/sda1");
+        let location = parse_efi_location("/dev/sda 1 AABB-CCDD\n", efi).unwrap();
+        assert_eq!(location.disk, PathBuf::from("/dev/sda"));
+        assert_eq!(location.partition, 1);
+        assert_eq!(location.partuuid, "aabb-ccdd");
+
+        assert!(parse_efi_location("/dev/sda 1\n", efi).is_err());
+        assert!(parse_efi_location("/dev/sda x AABB-CCDD\n", efi).is_err());
+        assert!(parse_efi_location("", efi).is_err());
+    }
+
+    #[test]
+    fn boot_entries_are_parsed_with_or_without_the_active_marker() {
+        let device = "HD(1,GPT,AABB-CCDD,0x800,0x1000)/File(\\EFI\\zbm\\vmlinuz.EFI)";
+        assert_eq!(
+            boot_entry(&format!("Boot0001* ZFSBootMenu\t{device}")),
+            Some(("0001", "ZFSBootMenu", device))
+        );
+        assert_eq!(
+            boot_entry(&format!("Boot00AF  Windows Boot Manager\t{device}")),
+            Some(("00AF", "Windows Boot Manager", device))
+        );
+        assert_eq!(boot_entry("BootCurrent: 0001"), None);
+        assert_eq!(boot_entry("Boot0002* Other\tPciRoot(0x0)"), None);
     }
 
     #[test]

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -7,8 +7,8 @@ use serde::Serialize;
 
 use crate::boot_environment::BootEnvironment;
 use crate::config::types::InitSystem;
-use crate::installer::initramfs::mkinitcpio::set_conf_line;
 use crate::system::cmd::{CommandRunner, check_exit, chroot_checked};
+use crate::system::conf::set_conf_line;
 
 pub const HOSTID_VALUE: &str = "0x00bab10c";
 

--- a/core/src/bootmenu.rs
+++ b/core/src/bootmenu.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::boot_environment::BootEnvironment;
 use crate::config::types::InitSystem;
 use crate::installer::initramfs::mkinitcpio::set_conf_line;
-use crate::system::cmd::{CommandRunner, check_exit, chroot_cmd};
+use crate::system::cmd::{CommandRunner, check_exit, chroot_checked};
 
 pub const HOSTID_VALUE: &str = "0x00bab10c";
 
@@ -238,8 +238,13 @@ pub async fn install_and_generate_zbm(
         install_zbm_pacman_hook(&t)?;
 
         tracing::info!("running generate-zbm to build EFI bundle");
-        let output = chroot_cmd(&*r, &t, "/usr/local/sbin/azfs-update-zbm", &[])?;
-        check_exit(&output, "generate and install ZFSBootMenu")?;
+        chroot_checked(
+            &*r,
+            &t,
+            "/usr/local/sbin/azfs-update-zbm",
+            &[],
+            "generate and install ZFSBootMenu",
+        )?;
 
         tracing::info!("ZFSBootMenu built and installed locally");
         Ok(())

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -432,6 +432,14 @@ impl GlobalConfig {
         self.zfs_encryption_mode != ZfsEncryptionMode::None
     }
 
+    /// The package download settings this configuration asks for.
+    pub fn download_config(&self) -> crate::system::async_download::DownloadConfig {
+        crate::system::async_download::DownloadConfig {
+            concurrency: self.parallel_downloads as usize,
+            ..Default::default()
+        }
+    }
+
     pub fn all_aur_packages(&self) -> Vec<&str> {
         let mut pkgs: Vec<&str> = self.aur_packages.iter().map(|s| s.as_str()).collect();
         if self.zrepl_enabled && !pkgs.contains(&"zrepl-bin") {

--- a/core/src/config/types.rs
+++ b/core/src/config/types.rs
@@ -136,6 +136,14 @@ pub enum SwapMode {
     ZswapPartitionEncrypted,
 }
 
+impl SwapMode {
+    /// Whether this method needs a swap partition on disk (plain or
+    /// encrypted), as opposed to none or zram.
+    pub fn uses_partition(self) -> bool {
+        matches!(self, Self::ZswapPartition | Self::ZswapPartitionEncrypted)
+    }
+}
+
 impl std::fmt::Display for SwapMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/core/src/config/validation.rs
+++ b/core/src/config/validation.rs
@@ -1,9 +1,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
-use super::types::{
-    GlobalConfig, InstallationMode, SwapMode, ZFS_PASSPHRASE_MIN_LENGTH, ZfsEncryptionMode,
-};
+use super::types::{GlobalConfig, InstallationMode, ZFS_PASSPHRASE_MIN_LENGTH, ZfsEncryptionMode};
 
 /// Something about the configuration that stops the installation.
 ///
@@ -159,10 +157,7 @@ impl GlobalConfig {
         errors.extend(self.validate_dataset_prefix());
         errors.extend(self.validate_device_paths());
 
-        let wants_swap_partition = matches!(
-            self.swap_mode,
-            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-        );
+        let wants_swap_partition = self.swap_mode.uses_partition();
 
         match mode {
             InstallationMode::Alongside => {
@@ -729,6 +724,7 @@ mod tests {
 #[cfg(test)]
 mod partition_role_tests {
     use super::*;
+    use crate::config::types::SwapMode;
     #[test]
     fn duplicate_roles_are_rejected_but_inactive_roles_are_ignored() {
         let mut c = GlobalConfig {

--- a/core/src/disk/alongside.rs
+++ b/core/src/disk/alongside.rs
@@ -20,11 +20,19 @@ pub use probe::{Filesystem, inspect, minimum_size};
 pub const MIB: u64 = 1024 * 1024;
 pub const GIB: u64 = 1024 * MIB;
 pub const MIN_LINUX_BYTES: u64 = 32 * GIB;
-/// Size of the optional separate ESP; matches the full-disk layout.
+/// Size of the optional separate ESP; close to the 500 MiB the full-disk
+/// layout creates.
 pub const ESP_BYTES: u64 = 512 * MIB;
+/// Allowance for FAT metadata, cluster rounding and directory entries. It is
+/// added to the boot image budget, and reserved again when checking that the
+/// budget fits a newly created ESP.
+pub const ESP_SLACK_BYTES: u64 = 8 * MIB;
 pub const EFI_TYPE: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
 pub const BASIC_TYPE: &str = "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7";
 pub const LINUX_TYPE: &str = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
+/// Solaris/illumos root, which is what sgdisk's `bf00` and ZFS itself use.
+pub const ZFS_TYPE: &str = "6A85CF4D-1DD2-11B2-99A6-080020736631";
+pub const SWAP_TYPE: &str = "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Partition {

--- a/core/src/disk/alongside/efi.rs
+++ b/core/src/disk/alongside/efi.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// Planning uses a 48 MiB image allowance. The image is built for this machine
 /// with `xz -9` (see `bootmenu::ZBM_DRACUT_CONF`); a stock `linux-lts` target
-/// measured 33 MiB. With the 8 MiB overhead, a 100 MiB Windows ESP holding only
+/// measured 33 MiB. With [`ESP_SLACK_BYTES`] added, a 100 MiB Windows ESP holding only
 /// Microsoft's loader qualifies for reuse. Actual installation verifies the
 /// generated file before replacing anything. Existing files are not credited
 /// as reclaimable: they may be other loaders.
@@ -30,10 +30,9 @@ impl BootSpace {
             "ZFSBootMenu image allowance must be nonzero"
         );
         // One image, and only explicitly enabled persistent copies.
-        // Reserve a modest allowance for cluster rounding and directory entries.
         self.image_bytes
             .checked_mul(1 + u64::from(self.backup) + u64::from(self.fallback))
-            .and_then(|size| size.checked_add(8 * MIB))
+            .and_then(|size| size.checked_add(ESP_SLACK_BYTES))
             .ok_or_else(|| eyre!("EFI space calculation overflow"))
     }
 }

--- a/core/src/disk/alongside/execute.rs
+++ b/core/src/disk/alongside/execute.rs
@@ -212,11 +212,11 @@ fn apply(
         tracing::info!(partition = %node, new_bytes = bytes, "Shrinking filesystem before partition boundary");
         match fs {
             Some("ntfs") => {
-                let out = runner.run_with_stdin(
-                    "env",
+                let out = probe::run_with_stdin(
+                    runner,
+                    &[],
+                    "ntfsresize",
                     &[
-                        "LC_ALL=C",
-                        "ntfsresize",
                         "--no-progress-bar",
                         "--size",
                         &(bytes - MIB).to_string(),
@@ -264,12 +264,12 @@ fn apply(
             _ => bail!("Unsupported filesystem; partition table was not modified"),
         }
         let number = part.number(disk)?;
-        let out = runner.run_with_stdin(
-            "env",
+        // sfdisk must not take the whole-disk lock this process already holds.
+        let out = probe::run_with_stdin(
+            runner,
+            &["LOCK_BLOCK_DEVICE=0"],
+            "sfdisk",
             &[
-                "LC_ALL=C",
-                "LOCK_BLOCK_DEVICE=0",
-                "sfdisk",
                 "--wipe",
                 "never",
                 "--wipe-partitions",

--- a/core/src/disk/alongside/execute.rs
+++ b/core/src/disk/alongside/execute.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::disk::{SGDISK_EFI, SGDISK_SWAP, SGDISK_ZFS};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::fs::{FileTypeExt, OpenOptionsExt};
@@ -54,7 +55,7 @@ pub fn execute(
     if plan.efi_start.is_some() {
         check_tools(&[("mkfs.fat", "dosfstools")])?;
         ensure!(
-            budget.required_bytes()? < ESP_BYTES - 8 * MIB,
+            budget.required_bytes()? < ESP_BYTES - ESP_SLACK_BYTES,
             "The boot image and selected copies do not fit the proposed additional ESP"
         );
     }
@@ -295,7 +296,7 @@ fn apply(
     if let Some(start) = plan.efi_start {
         args.extend([
             format!("--new={}:{}:{}", plan.efi_number, start, plan.zfs_start - 1),
-            format!("--typecode={}:ef00", plan.efi_number),
+            format!("--typecode={}:{SGDISK_EFI}", plan.efi_number),
         ]);
     }
     args.extend([
@@ -305,12 +306,12 @@ fn apply(
             plan.zfs_start,
             plan.swap_start.unwrap_or(plan.end) - 1
         ),
-        format!("--typecode={}:bf00", plan.zfs_number),
+        format!("--typecode={}:{SGDISK_ZFS}", plan.zfs_number),
     ]);
     if let (Some(number), Some(start)) = (plan.swap_number, plan.swap_start) {
         args.extend([
             format!("--new={number}:{start}:{}", plan.end - 1),
-            format!("--typecode={number}:8200"),
+            format!("--typecode={number}:{SGDISK_SWAP}"),
         ]);
     }
     args.push(dev.to_string());
@@ -350,9 +351,7 @@ fn verify_created(before: &Layout, after: &Layout, plan: &Plan) -> Result<()> {
     ensure!(
         zfs.start == plan.zfs_start
             && zfs.end()? == plan.swap_start.unwrap_or(plan.end)
-            && zfs
-                .kind
-                .eq_ignore_ascii_case("6A85CF4D-1DD2-11B2-99A6-080020736631"),
+            && zfs.kind.eq_ignore_ascii_case(ZFS_TYPE),
         "New ZFS partition differs from plan"
     );
     if let Some(start) = plan.efi_start {
@@ -377,9 +376,7 @@ fn verify_created(before: &Layout, after: &Layout, plan: &Plan) -> Result<()> {
         ensure!(
             swap.start == start
                 && swap.end()? == plan.end
-                && swap
-                    .kind
-                    .eq_ignore_ascii_case("0657FD6D-A4AB-43C4-84E5-0933C84B4F4F"),
+                && swap.kind.eq_ignore_ascii_case(SWAP_TYPE),
             "New swap partition differs from plan"
         );
     }

--- a/core/src/disk/alongside/probe.rs
+++ b/core/src/disk/alongside/probe.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::system::cmd::CmdOutput;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Filesystem {
@@ -84,12 +85,33 @@ pub fn inspect(runner: &dyn CommandRunner, disk: &Path) -> Result<(Layout, Vec<F
     Ok((layout, d.children))
 }
 
-pub(super) fn run(runner: &dyn CommandRunner, program: &str, args: &[&str]) -> Result<String> {
-    let mut argv = vec!["LC_ALL=C", program];
+/// The argv for `env LC_ALL=C [env...] program args...`: every filesystem
+/// tool is run with a C locale so its output can be parsed.
+fn env_argv<'a>(env: &[&'a str], program: &'a str, args: &[&'a str]) -> Vec<&'a str> {
+    let mut argv = Vec::with_capacity(env.len() + args.len() + 2);
+    argv.push("LC_ALL=C");
+    argv.extend_from_slice(env);
+    argv.push(program);
     argv.extend_from_slice(args);
-    let out = runner.run("env", &argv)?;
+    argv
+}
+
+pub(super) fn run(runner: &dyn CommandRunner, program: &str, args: &[&str]) -> Result<String> {
+    let out = runner.run("env", &env_argv(&[], program, args))?;
     check_exit(&out, program)?;
     Ok(out.stdout)
+}
+
+/// Like [`run`], with extra `NAME=value` pairs and input on stdin. The exit
+/// status is left to the caller, whose context message names the operation.
+pub(super) fn run_with_stdin(
+    runner: &dyn CommandRunner,
+    env: &[&str],
+    program: &str,
+    args: &[&str],
+    stdin: &[u8],
+) -> Result<CmdOutput> {
+    runner.run_with_stdin("env", &env_argv(env, program, args), stdin)
 }
 
 fn number_after(text: &str, key: &str) -> Result<u64> {
@@ -157,6 +179,64 @@ pub fn minimum_size(runner: &dyn CommandRunner, part: &Partition, fs: &str) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::system::cmd::tests::{CannedResponse, RecordingRunner};
+
+    #[test]
+    fn tools_run_under_env_with_a_c_locale_and_extra_variables_after_it() {
+        let runner = RecordingRunner::new(vec![
+            CannedResponse {
+                stdout: "No problems found.\n".into(),
+                ..Default::default()
+            },
+            CannedResponse::default(),
+        ]);
+
+        let verified = run(&runner, "sgdisk", &["--verify", "/dev/sda"]).unwrap();
+        assert_eq!(verified, "No problems found.\n");
+        let out = run_with_stdin(
+            &runner,
+            &["LOCK_BLOCK_DEVICE=0"],
+            "sfdisk",
+            &["--wipe", "never", "-N", "3", "/dev/sda"],
+            b"size=2048\n",
+        )
+        .unwrap();
+        assert!(out.success());
+
+        let calls = runner.calls();
+        assert_eq!(calls[0].program, "env");
+        assert_eq!(
+            calls[0].args,
+            ["LC_ALL=C", "sgdisk", "--verify", "/dev/sda"]
+        );
+        assert_eq!(calls[1].program, "env");
+        assert_eq!(
+            calls[1].args,
+            [
+                "LC_ALL=C",
+                "LOCK_BLOCK_DEVICE=0",
+                "sfdisk",
+                "--wipe",
+                "never",
+                "-N",
+                "3",
+                "/dev/sda"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_failing_tool_is_reported_by_name() {
+        let runner = RecordingRunner::new(vec![CannedResponse {
+            exit_code: 1,
+            stderr: "bad superblock".into(),
+            ..Default::default()
+        }]);
+        let err = run(&runner, "e2fsck", &["-f", "-n", "/dev/sda2"]).unwrap_err();
+        assert!(err.to_string().contains("e2fsck"), "{err}");
+        assert!(err.to_string().contains("bad superblock"), "{err}");
+    }
+
     #[test]
     fn exact_bytes_are_required_and_localized_or_missing_output_fails() {
         assert_eq!(

--- a/core/src/disk/device.rs
+++ b/core/src/disk/device.rs
@@ -239,11 +239,11 @@ impl BlockPartition {
             .unwrap_or_default()
     }
 
-    pub fn selection_group_model(&self) -> String {
+    pub(crate) fn selection_group_model(&self) -> String {
         self.selection_model()
     }
 
-    pub fn selection_group_serial(&self) -> String {
+    pub(crate) fn selection_group_serial(&self) -> String {
         self.selection_serial()
     }
 
@@ -251,11 +251,11 @@ impl BlockPartition {
         self.parent_size_bytes.map(format_size).unwrap_or_default()
     }
 
-    pub fn selection_group_transport(&self) -> String {
+    pub(crate) fn selection_group_transport(&self) -> String {
         self.selection_transport()
     }
 
-    pub fn selection_group_media(&self) -> String {
+    pub(crate) fn selection_group_media(&self) -> String {
         self.selection_media()
     }
 

--- a/core/src/disk/mod.rs
+++ b/core/src/disk/mod.rs
@@ -2,6 +2,16 @@ pub mod alongside;
 pub mod device;
 pub mod partition;
 
+/// sgdisk type codes for the partitions this installer creates. The GPT type
+/// GUIDs they stand for are next to [`alongside::EFI_TYPE`].
+pub const SGDISK_EFI: &str = "ef00";
+pub const SGDISK_ZFS: &str = "bf00";
+pub const SGDISK_SWAP: &str = "8200";
+
+/// Sectors taken by the protective MBR plus a GPT header and its 128 entries,
+/// at each end of a 512-byte-sector disk.
+pub const GPT_MARGIN_SECTORS: u64 = 34;
+
 /// Strip the partition suffix from a block device name, yielding the whole
 /// disk it belongs to.
 ///

--- a/core/src/disk/partition.rs
+++ b/core/src/disk/partition.rs
@@ -2,19 +2,21 @@ use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{Context, Result};
 
+use crate::disk::{GPT_MARGIN_SECTORS, SGDISK_EFI, SGDISK_SWAP, SGDISK_ZFS};
 use crate::system::cmd::{CommandRunner, check_exit};
 
 pub fn zap_disk(runner: &dyn CommandRunner, disk: &Path) -> Result<()> {
     let disk_str = disk.to_string_lossy();
 
-    // Clear first and last 34 sectors (GPT/MBR signatures)
+    // Clear the GPT/MBR signatures at both ends of the disk.
+    let count = format!("count={GPT_MARGIN_SECTORS}");
     let output = runner.run(
         "dd",
         &[
             "if=/dev/zero",
             &format!("of={disk_str}"),
             "bs=512",
-            "count=34",
+            &count,
             "conv=notrunc",
         ],
     )?;
@@ -28,15 +30,15 @@ pub fn zap_disk(runner: &dyn CommandRunner, disk: &Path) -> Result<()> {
         .trim()
         .parse()
         .wrap_err("failed to parse disk sector count from blockdev --getsz")?;
-    if sectors > 34 {
-        let seek = sectors - 34;
+    if sectors > GPT_MARGIN_SECTORS {
+        let seek = sectors - GPT_MARGIN_SECTORS;
         let _ = runner.run(
             "dd",
             &[
                 "if=/dev/zero",
                 &format!("of={disk_str}"),
                 "bs=512",
-                "count=34",
+                &count,
                 &format!("seek={seek}"),
                 "conv=notrunc",
             ],
@@ -68,12 +70,14 @@ pub fn create_partitions(
     check_exit(&output, "sgdisk create GPT")?;
 
     // Partition 1: EFI (500M)
+    let efi_type = format!("1:{SGDISK_EFI}");
     let output = runner.run(
         "sgdisk",
-        &["-n", "1:0:+500M", "-t", "1:ef00", "-c", "1:EFI", &disk_str],
+        &["-n", "1:0:+500M", "-t", &efi_type, "-c", "1:EFI", &disk_str],
     )?;
     check_exit(&output, "sgdisk create EFI partition")?;
 
+    let zfs_type = format!("2:{SGDISK_ZFS}");
     let layout = if let Some(swap_sz) = swap_size {
         // Partition 3: Swap (at end of disk)
         let swap_spec = format!("-{swap_sz}:0");
@@ -83,7 +87,7 @@ pub fn create_partitions(
                 "-n",
                 &format!("3:{swap_spec}"),
                 "-t",
-                "3:8200",
+                &format!("3:{SGDISK_SWAP}"),
                 "-c",
                 "3:swap",
                 &disk_str,
@@ -94,7 +98,7 @@ pub fn create_partitions(
         // Partition 2: ZFS (remaining space)
         let output = runner.run(
             "sgdisk",
-            &["-n", "2:0:0", "-t", "2:bf00", "-c", "2:ZFS", &disk_str],
+            &["-n", "2:0:0", "-t", &zfs_type, "-c", "2:ZFS", &disk_str],
         )?;
         check_exit(&output, "sgdisk create ZFS partition")?;
 
@@ -107,7 +111,7 @@ pub fn create_partitions(
         // Partition 2: ZFS (rest of disk)
         let output = runner.run(
             "sgdisk",
-            &["-n", "2:0:0", "-t", "2:bf00", "-c", "2:ZFS", &disk_str],
+            &["-n", "2:0:0", "-t", &zfs_type, "-c", "2:ZFS", &disk_str],
         )?;
         check_exit(&output, "sgdisk create ZFS partition")?;
 

--- a/core/src/disk/partition.rs
+++ b/core/src/disk/partition.rs
@@ -213,13 +213,6 @@ pub fn mount_efi(
     Ok(())
 }
 
-pub fn umount_efi(runner: &dyn CommandRunner, mountpoint: &Path) -> Result<()> {
-    let mount_path = mountpoint.join("boot/efi");
-    let mount_str = mount_path.to_string_lossy();
-    let _ = runner.run("umount", &[&*mount_str]);
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -24,7 +24,7 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 use crate::boot_environment::BootEnvironment;
-use crate::config::types::{GlobalConfig, SwapMode};
+use crate::config::types::GlobalConfig;
 use crate::config::validation::ValidationError;
 use crate::system::async_download::{DownloadConfig, DownloadProgress};
 use crate::system::cmd::CommandRunner;
@@ -337,10 +337,7 @@ async fn install(
     tracing::info!(target: "metrics", event = "phase_start", num = 13u32, name = "Setting up ZFSBootMenu");
     ensure_not_cancelled(&cancel)?;
 
-    let zswap_on = matches!(
-        config.swap_mode,
-        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-    );
+    let zswap_on = config.swap_mode.uses_partition();
     crate::bootmenu::set_zbm_properties(&be, config.init_system, zswap_on, config.set_bootfs)
         .await?;
 

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -26,7 +26,7 @@ use tokio_util::sync::CancellationToken;
 use crate::boot_environment::BootEnvironment;
 use crate::config::types::GlobalConfig;
 use crate::config::validation::ValidationError;
-use crate::system::async_download::{DownloadConfig, DownloadProgress};
+use crate::system::async_download::DownloadProgress;
 use crate::system::cmd::CommandRunner;
 
 /// Where the pool is mounted while the target system is assembled.
@@ -206,10 +206,7 @@ async fn install(
         .to_string();
     let be = BootEnvironment::new(&pool_name, config.dataset_prefix.as_str());
     let kernel = config.primary_kernel().to_string();
-    let download_config = DownloadConfig {
-        concurrency: config.parallel_downloads as usize,
-        ..Default::default()
-    };
+    let download_config = config.download_config();
     let config = Arc::new(config);
 
     ensure_not_cancelled(&cancel)?;

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -355,11 +355,8 @@ async fn install(
     {
         let runner = runner.clone();
         let efi = efi_partition.clone();
-        let target = mountpoint.clone();
-        tokio::task::spawn_blocking(move || {
-            crate::bootmenu::create_efi_entries(&*runner, &efi, &target)
-        })
-        .await??;
+        tokio::task::spawn_blocking(move || crate::bootmenu::create_efi_entries(&*runner, &efi))
+            .await??;
     }
 
     // Last, so they are the final thing in the log the user is looking at

--- a/core/src/installer/aur.rs
+++ b/core/src/installer/aur.rs
@@ -88,17 +88,7 @@ pub async fn install_aur_packages(
 /// a reference to it, so we must `block_on` from the same thread.
 fn resolve_aur_deps(target: &Path, packages: &[&str]) -> Result<Vec<String>> {
     let target_conf = target.join("etc/pacman.conf");
-    let conf = pacmanconf::Config::from_file(target_conf.to_str().unwrap_or("/etc/pacman.conf"))
-        .map_err(|e| color_eyre::eyre::eyre!("failed to parse pacman.conf: {e}"))?;
-
-    let target_str = target.to_string_lossy();
-    let db_path = format!("{}/var/lib/pacman", target_str);
-
-    let mut alpm = alpm::Alpm::new(target_str.as_ref(), &db_path)
-        .map_err(|e| color_eyre::eyre::eyre!("failed to init alpm: {e}"))?;
-
-    alpm_utils::configure_alpm(&mut alpm, &conf)
-        .map_err(|e| color_eyre::eyre::eyre!("failed to configure alpm: {e}"))?;
+    let alpm = crate::system::alpm_pacman::open_target_alpm(target, &target_conf)?;
 
     let raur_handle = raur::Handle::new();
     let mut cache = raur::Cache::new();
@@ -133,11 +123,12 @@ fn setup_aur_environment(
     download_config: crate::system::async_download::DownloadConfig,
 ) -> Result<()> {
     // Install git and sudo via libalpm (base-devel already in base install)
-    let target_conf = target.join("etc/pacman.conf");
-    let mut ctx =
-        crate::system::alpm_pacman::AlpmContext::for_target(target, &target_conf, download_config)?;
-    ctx.sync_databases(false)?;
-    ctx.install_packages(&["git", "sudo"], cancel, None)?;
+    crate::system::alpm_pacman::install_into_target(
+        target,
+        &["git", "sudo"],
+        cancel,
+        download_config,
+    )?;
 
     // Create temp user
     let output = chroot_cmd(runner, target, "useradd", &["-m", TEMP_USER])?;

--- a/core/src/installer/aur.rs
+++ b/core/src/installer/aur.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 
 use color_eyre::eyre::{Context, Result, bail};
 
-use crate::system::cmd::{CommandRunner, check_exit, chroot, chroot_cmd, shell_quote};
+use crate::system::cmd::{
+    CommandRunner, check_exit, chroot, chroot_checked, chroot_cmd, shell_quote,
+};
 use crate::system::fs::write_file_with_mode;
 
 const TEMP_USER: &str = "aurinstall";
@@ -131,8 +133,13 @@ fn setup_aur_environment(
     )?;
 
     // Create temp user
-    let output = chroot_cmd(runner, target, "useradd", &["-m", TEMP_USER])?;
-    check_exit(&output, "create AUR temp user")?;
+    chroot_checked(
+        runner,
+        target,
+        "useradd",
+        &["-m", TEMP_USER],
+        "create AUR temp user",
+    )?;
 
     configure_source_cache(target)?;
 

--- a/core/src/installer/autologin.rs
+++ b/core/src/installer/autologin.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use color_eyre::eyre::{Context, Result};
 
-use crate::system::cmd::{CommandRunner, check_exit, chroot_cmd};
+use crate::system::cmd::CommandRunner;
 
 /// Configure automatic login for the given user on the detected display manager.
 ///
@@ -97,9 +97,7 @@ fn configure_lightdm(runner: &dyn CommandRunner, target: &Path, username: &str) 
         .wrap_err("failed to write lightdm autologin conf")?;
 
     // Create the autologin group and add the user — LightDM requires it.
-    let _ = chroot_cmd(runner, target, "groupadd", &["-f", "autologin"]);
-    let output = chroot_cmd(runner, target, "usermod", &["-aG", "autologin", username])?;
-    check_exit(&output, &format!("add {username} to autologin group"))?;
+    super::users::add_to_group(runner, target, "autologin", &[username])?;
 
     tracing::info!(username, "configured LightDM autologin");
     Ok(())

--- a/core/src/installer/base.rs
+++ b/core/src/installer/base.rs
@@ -5,7 +5,6 @@ use tokio_util::sync::CancellationToken;
 
 use crate::config::types::GlobalConfig;
 use crate::system::alpm_pacman::{AlpmContext, TargetMounts};
-use crate::system::async_download::DownloadConfig;
 use crate::system::cmd::CommandRunner;
 use crate::system::sysinfo;
 
@@ -45,14 +44,7 @@ pub fn install_base(
     let target_mounts = TargetMounts::setup(target)?;
 
     let pacman_conf = Path::new("/etc/pacman.conf");
-    let mut ctx = AlpmContext::for_target(
-        target,
-        pacman_conf,
-        DownloadConfig {
-            concurrency: config.parallel_downloads as usize,
-            ..Default::default()
-        },
-    )?;
+    let mut ctx = AlpmContext::for_target(target, pacman_conf, config.download_config())?;
     ctx.sync_databases(false)?;
     ctx.install_packages(&packages, cancel, progress_tx)?;
     ctx.finalize_target()?;

--- a/core/src/installer/base.rs
+++ b/core/src/installer/base.rs
@@ -5,14 +5,12 @@ use tokio_util::sync::CancellationToken;
 
 use crate::config::types::GlobalConfig;
 use crate::system::alpm_pacman::{AlpmContext, TargetMounts};
-use crate::system::cmd::CommandRunner;
 use crate::system::sysinfo;
 
 /// Install base system packages into target.
 /// Returns `TargetMounts` which must be kept alive for the duration of the
 /// installation — dropping it unmounts API filesystems (proc, sys, dev, etc.).
 pub fn install_base(
-    _runner: &dyn CommandRunner,
     target: &Path,
     config: &GlobalConfig,
     cancel: &CancellationToken,

--- a/core/src/installer/base.rs
+++ b/core/src/installer/base.rs
@@ -38,7 +38,7 @@ pub fn install_base(
     }
 
     // Set parallel downloads on host before installing
-    crate::system::pacman::set_parallel_downloads(None, config.parallel_downloads)?;
+    crate::system::conf::set_parallel_downloads(None, config.parallel_downloads)?;
 
     // Mount API filesystems — returned to caller to keep alive
     let target_mounts = TargetMounts::setup(target)?;
@@ -52,7 +52,7 @@ pub fn install_base(
     // target_mounts stays alive via the return value.
 
     // Set parallel downloads on target too
-    crate::system::pacman::set_parallel_downloads(Some(target), config.parallel_downloads)?;
+    crate::system::conf::set_parallel_downloads(Some(target), config.parallel_downloads)?;
 
     Ok(target_mounts)
 }

--- a/core/src/installer/initramfs/dracut.rs
+++ b/core/src/installer/initramfs/dracut.rs
@@ -62,7 +62,7 @@ while read -r line; do
 done
 "#;
 
-pub fn configure(_runner: &dyn CommandRunner, target: &Path, encryption: bool) -> Result<()> {
+pub fn configure(target: &Path, encryption: bool) -> Result<()> {
     // Write dracut.conf.d/zfs.conf
     let conf_dir = target.join("etc/dracut.conf.d");
     fs::create_dir_all(&conf_dir)?;
@@ -215,8 +215,7 @@ mod tests {
     #[test]
     fn test_configure_dracut_creates_files() {
         let dir = tempfile::tempdir().unwrap();
-        let runner = RecordingRunner::new(vec![]);
-        configure(&runner, dir.path(), false).unwrap();
+        configure(dir.path(), false).unwrap();
 
         assert!(dir.path().join("etc/dracut.conf.d/zfs.conf").exists());
         assert!(
@@ -245,8 +244,7 @@ mod tests {
     #[test]
     fn test_configure_dracut_with_encryption() {
         let dir = tempfile::tempdir().unwrap();
-        let runner = RecordingRunner::new(vec![]);
-        configure(&runner, dir.path(), true).unwrap();
+        configure(dir.path(), true).unwrap();
 
         let conf = fs::read_to_string(dir.path().join("etc/dracut.conf.d/zfs.conf")).unwrap();
         assert!(conf.contains("zroot.key"));

--- a/core/src/installer/initramfs/dracut.rs
+++ b/core/src/installer/initramfs/dracut.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use color_eyre::eyre::{Context, Result, bail};
 
-use crate::system::cmd::{CommandRunner, check_exit, chroot_cmd};
+use crate::system::cmd::{CommandRunner, chroot_checked};
 
 const DRACUT_ZFS_CONF: &str = r#"hostonly="yes"
 hostonly_cmdline="no"
@@ -178,23 +178,20 @@ pub fn generate(runner: &dyn CommandRunner, target: &Path, with_zfs: &[&str]) ->
 
         let vmlinuz_src = format!("/usr/lib/modules/{kver}/vmlinuz");
         let vmlinuz_dst = format!("/boot/vmlinuz-{pkgbase}");
-        let output = chroot_cmd(
+        chroot_checked(
             runner,
             target,
             "install",
             &["-Dm0644", &vmlinuz_src, &vmlinuz_dst],
+            &format!("install vmlinuz for {pkgbase}"),
         )?;
-        check_exit(&output, &format!("install vmlinuz for {pkgbase}"))?;
 
         let image = format!("/boot/initramfs-{pkgbase}.img");
-        let output = chroot_cmd(
+        chroot_checked(
             runner,
             target,
             "dracut",
             &["--force", &image, "--kver", kver],
-        )?;
-        check_exit(
-            &output,
             &format!("dracut generate initramfs for {pkgbase} ({kver})"),
         )?;
     }

--- a/core/src/installer/initramfs/mkinitcpio.rs
+++ b/core/src/installer/initramfs/mkinitcpio.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use color_eyre::eyre::{Context, Result, bail};
 
 use crate::system::cmd::{CommandRunner, chroot_checked};
+use crate::system::conf::{patch_conf_array, set_conf_value};
 
 pub fn configure(target: &Path, encryption: bool) -> Result<()> {
     let conf_path = target.join("etc/mkinitcpio.conf");
@@ -96,108 +97,9 @@ pub fn generate(runner: &dyn CommandRunner, target: &Path, with_zfs: &[&str]) ->
     Ok(())
 }
 
-/// Rewrite a `KEY=(a b c)` array assignment in an mkinitcpio.conf.
-///
-/// Errors when the assignment cannot be parsed rather than falling back to an
-/// empty array. Silently emptying `HOOKS` produces a `HOOKS=(zfs)` initramfs
-/// that cannot mount root, and the installation would report success — a
-/// failure here is recoverable, an unbootable system is not.
-///
-/// Where the same key is assigned more than once the last assignment is the
-/// one the shell would use, so that is the one patched.
-fn patch_conf_array(content: &str, key: &str, f: impl FnOnce(&mut Vec<String>)) -> Result<String> {
-    let prefix = format!("{key}=(");
-    let mut lines: Vec<String> = Vec::new();
-    let mut target_line: Option<usize> = None;
-    let mut values: Vec<String> = Vec::new();
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with(&prefix) {
-            let Some(inner) = trimmed
-                .strip_prefix(&prefix)
-                .and_then(|s| s.strip_suffix(')'))
-            else {
-                bail!(
-                    "cannot patch {key} in mkinitcpio.conf: the assignment on line {} does not \
-                     close on the same line. Rewriting it would drop the existing entries and \
-                     leave an unbootable initramfs; put {key}=(...) on one line and retry.",
-                    lines.len() + 1
-                );
-            };
-            target_line = Some(lines.len());
-            values = inner.split_whitespace().map(|s| s.to_string()).collect();
-        }
-        lines.push(line.to_string());
-    }
-
-    f(&mut values);
-    let new_line = format!("{key}=({})", values.join(" "));
-    match target_line {
-        Some(index) => lines[index] = new_line,
-        None => lines.push(new_line),
-    }
-
-    let mut result = lines.join("\n");
-    result.push('\n');
-    Ok(result)
-}
-
-fn set_conf_value(content: &str, key: &str, value: &str) -> String {
-    set_conf_line(content, key, &format!("{key}=\"{value}\""))
-}
-
-/// Replace every active `KEY=` assignment with `line`. When the key is only
-/// present as a commented example (stock files list several), activate the
-/// first one and leave the other examples as they are. Append when absent.
-pub(crate) fn set_conf_line(content: &str, key: &str, line: &str) -> String {
-    let prefix = format!("{key}=");
-    let commented = format!("#{prefix}");
-    let has_active = content.lines().any(|l| l.trim().starts_with(&prefix));
-    let mut result = String::new();
-    let mut found = false;
-
-    for l in content.lines() {
-        let trimmed = l.trim();
-        let replace = if has_active {
-            trimmed.starts_with(&prefix)
-        } else {
-            !found && trimmed.starts_with(&commented)
-        };
-        if replace {
-            found = true;
-            result.push_str(line);
-        } else {
-            result.push_str(l);
-        }
-        result.push('\n');
-    }
-
-    if !found {
-        result.push_str(line);
-        result.push('\n');
-    }
-
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_patch_conf_array_adds_zfs() {
-        let input = "MODULES=()\nHOOKS=(base udev autodetect modconf block filesystems fsck)\n";
-        let result = patch_conf_array(input, "HOOKS", |hooks| {
-            if !hooks.contains(&"zfs".to_string())
-                && let Some(pos) = hooks.iter().position(|h| h == "filesystems")
-            {
-                hooks.insert(pos, "zfs".to_string());
-            }
-        })
-        .unwrap();
-        assert!(result.contains("zfs filesystems"));
-    }
 
     #[test]
     fn each_kernel_with_a_module_gets_its_own_preset_run() {
@@ -231,21 +133,6 @@ mod tests {
     }
 
     #[test]
-    fn multi_line_array_is_rejected_instead_of_emptied() {
-        // A HOOKS array split across lines used to parse as empty, so the
-        // patched config kept only the hook being added — an initramfs with no
-        // base, udev or block hooks, i.e. a system that cannot boot.
-        let input = "MODULES=()\nHOOKS=(base udev autodetect\n       block filesystems fsck)\n";
-
-        let err = patch_conf_array(input, "HOOKS", |hooks| hooks.push("zfs".to_string()))
-            .expect_err("a multi-line array must not be silently rewritten");
-
-        let msg = err.to_string();
-        assert!(msg.contains("HOOKS"), "error should name the key: {msg}");
-        assert!(msg.contains("line 2"), "error should locate it: {msg}");
-    }
-
-    #[test]
     fn configure_refuses_a_conf_it_cannot_patch_safely() {
         let dir = tempfile::tempdir().unwrap();
         let conf_path = dir.path().join("etc/mkinitcpio.conf");
@@ -256,42 +143,6 @@ mod tests {
         assert!(configure(dir.path(), false).is_err());
         // The original config must be left intact for the user to fix.
         assert_eq!(fs::read_to_string(&conf_path).unwrap(), original);
-    }
-
-    #[test]
-    fn repeated_assignment_patches_the_one_the_shell_would_use() {
-        let input = "HOOKS=(base udev)\nHOOKS=(base udev block filesystems)\n";
-
-        let result = patch_conf_array(input, "HOOKS", |hooks| {
-            let pos = hooks.iter().position(|h| h == "filesystems").unwrap();
-            hooks.insert(pos, "zfs".to_string());
-        })
-        .unwrap();
-
-        assert_eq!(
-            result,
-            "HOOKS=(base udev)\nHOOKS=(base udev block zfs filesystems)\n"
-        );
-    }
-
-    #[test]
-    fn missing_array_is_appended() {
-        let result = patch_conf_array("COMPRESSION=\"cat\"\n", "FILES", |files| {
-            files.push("/etc/zfs/zroot.key".to_string())
-        })
-        .unwrap();
-
-        assert_eq!(result, "COMPRESSION=\"cat\"\nFILES=(/etc/zfs/zroot.key)\n");
-    }
-
-    #[test]
-    fn commented_out_assignment_is_left_alone() {
-        let result = patch_conf_array("#MODULES=(vfat)\n", "MODULES", |modules| {
-            modules.push("zfs".to_string())
-        })
-        .unwrap();
-
-        assert_eq!(result, "#MODULES=(vfat)\nMODULES=(zfs)\n");
     }
 
     #[test]
@@ -312,38 +163,5 @@ mod tests {
         assert!(content.contains("zfs filesystems"));
         assert!(content.contains("COMPRESSION=\"cat\""));
         assert!(content.contains("/etc/zfs/zroot.key"));
-    }
-
-    #[test]
-    fn test_set_conf_value() {
-        let input = "#COMPRESSION=\"zstd\"\n";
-        let result = set_conf_value(input, "COMPRESSION", "cat");
-        assert!(result.contains("COMPRESSION=\"cat\""));
-        assert!(!result.contains("#COMPRESSION"));
-    }
-
-    #[test]
-    fn test_set_conf_line_activates_one_example_and_replaces_active_values() {
-        let examples = "#COMPRESSION=\"zstd\"\n#COMPRESSION=\"xz\"\n#COMPRESSION_OPTIONS=()\n";
-        assert_eq!(
-            set_conf_line(examples, "COMPRESSION", "COMPRESSION=\"xz\""),
-            "COMPRESSION=\"xz\"\n#COMPRESSION=\"xz\"\n#COMPRESSION_OPTIONS=()\n"
-        );
-        assert_eq!(
-            set_conf_line(
-                "#COMPRESSION=\"zstd\"\nCOMPRESSION=\"lz4\"\n",
-                "COMPRESSION",
-                "COMPRESSION=\"xz\""
-            ),
-            "#COMPRESSION=\"zstd\"\nCOMPRESSION=\"xz\"\n"
-        );
-        assert_eq!(
-            set_conf_line(
-                "HOOKS=(base)\n",
-                "COMPRESSION_OPTIONS",
-                "COMPRESSION_OPTIONS=(-9)"
-            ),
-            "HOOKS=(base)\nCOMPRESSION_OPTIONS=(-9)\n"
-        );
     }
 }

--- a/core/src/installer/initramfs/mkinitcpio.rs
+++ b/core/src/installer/initramfs/mkinitcpio.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use color_eyre::eyre::{Context, Result, bail};
 
-use crate::system::cmd::{CommandRunner, check_exit, chroot_cmd};
+use crate::system::cmd::{CommandRunner, chroot_checked};
 
 pub fn configure(target: &Path, encryption: bool) -> Result<()> {
     let conf_path = target.join("etc/mkinitcpio.conf");
@@ -84,8 +84,13 @@ pub fn generate(runner: &dyn CommandRunner, target: &Path, with_zfs: &[&str]) ->
     }
 
     for kernel in with_zfs {
-        let output = chroot_cmd(runner, target, "mkinitcpio", &["-p", kernel])?;
-        check_exit(&output, &format!("mkinitcpio -p {kernel}"))?;
+        chroot_checked(
+            runner,
+            target,
+            "mkinitcpio",
+            &["-p", kernel],
+            &format!("mkinitcpio -p {kernel}"),
+        )?;
         tracing::info!(kernel, "generated initramfs with mkinitcpio");
     }
     Ok(())

--- a/core/src/installer/locale.rs
+++ b/core/src/installer/locale.rs
@@ -36,7 +36,7 @@ pub fn set_locale(runner: &dyn CommandRunner, target: &Path, locale: &str) -> Re
     Ok(())
 }
 
-pub fn set_keyboard(_runner: &dyn CommandRunner, target: &Path, layout: &str) -> Result<()> {
+pub fn set_keyboard(target: &Path, layout: &str) -> Result<()> {
     let vconsole = target.join("etc/vconsole.conf");
     if let Some(parent) = vconsole.parent() {
         fs::create_dir_all(parent)?;
@@ -206,8 +206,7 @@ mod tests {
     #[test]
     fn test_set_keyboard() {
         let dir = tempfile::tempdir().unwrap();
-        let runner = crate::system::cmd::tests::RecordingRunner::new(vec![]);
-        set_keyboard(&runner, dir.path(), "de-latin1").unwrap();
+        set_keyboard(dir.path(), "de-latin1").unwrap();
 
         let content = fs::read_to_string(dir.path().join("etc/vconsole.conf")).unwrap();
         assert_eq!(content, "KEYMAP=de-latin1\n");

--- a/core/src/installer/locale.rs
+++ b/core/src/installer/locale.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use color_eyre::eyre::{Context, Result};
 
-use crate::system::cmd::{CommandRunner, check_exit, chroot_cmd};
+use crate::system::cmd::{CommandRunner, chroot_checked};
 
 pub fn set_hostname(target: &Path, hostname: &str) -> Result<()> {
     let path = target.join("etc/hostname");
@@ -25,8 +25,7 @@ pub fn set_locale(runner: &dyn CommandRunner, target: &Path, locale: &str) -> Re
     }
 
     // Run locale-gen
-    let output = chroot_cmd(runner, target, "locale-gen", &[])?;
-    check_exit(&output, "locale-gen")?;
+    chroot_checked(runner, target, "locale-gen", &[], "locale-gen")?;
 
     // Write locale.conf
     let locale_conf = target.join("etc/locale.conf");

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -500,25 +500,15 @@ impl Installer {
         seat: Option<crate::config::types::SeatAccess>,
     ) -> Result<()> {
         use crate::config::types::SeatAccess;
-        use crate::system::cmd::{check_exit, chroot_cmd};
 
         match seat {
             Some(SeatAccess::Seatd) => {
                 self.install_target_packages(&["seatd"])?;
                 services::enable_service(&*self.runner, &self.target, "seatd")?;
                 // Add all installer-created users to the `seat` group
-                if let Some(ref user_list) = self.config.users.clone() {
-                    // groupadd -f is idempotent
-                    let _ = chroot_cmd(&*self.runner, &self.target, "groupadd", &["-f", "seat"]);
-                    for user in user_list {
-                        let output = chroot_cmd(
-                            &*self.runner,
-                            &self.target,
-                            "usermod",
-                            &["-aG", "seat", &user.username],
-                        )?;
-                        check_exit(&output, &format!("add {} to seat group", user.username))?;
-                    }
+                if let Some(user_list) = &self.config.users {
+                    let users: Vec<&str> = user_list.iter().map(|u| u.username.as_str()).collect();
+                    users::add_to_group(&*self.runner, &self.target, "seat", &users)?;
                 }
                 tracing::info!("configured seatd for seat access");
             }
@@ -544,7 +534,6 @@ impl Installer {
     /// if the data directory already exists on a reinstall, and that is fine.
     fn run_post_install_steps(&self, steps: &[crate::profile::PostInstallStep]) -> Result<()> {
         use crate::profile::PostInstallStep;
-        use crate::system::cmd::{check_exit, chroot_cmd};
 
         for step in steps {
             match step {
@@ -583,20 +572,10 @@ impl Installer {
                 }
                 PostInstallStep::AddUsersToGroup { group } => {
                     tracing::info!(group, "adding installer users to group");
-                    if let Some(ref user_list) = self.config.users {
-                        let _ = chroot_cmd(&*self.runner, &self.target, "groupadd", &["-f", group]);
-                        for user in user_list {
-                            let output = chroot_cmd(
-                                &*self.runner,
-                                &self.target,
-                                "usermod",
-                                &["-aG", group, &user.username],
-                            )?;
-                            check_exit(
-                                &output,
-                                &format!("add {} to {} group", user.username, group),
-                            )?;
-                        }
+                    if let Some(user_list) = &self.config.users {
+                        let users: Vec<&str> =
+                            user_list.iter().map(|u| u.username.as_str()).collect();
+                        users::add_to_group(&*self.runner, &self.target, group, &users)?;
                     }
                 }
             }

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -17,7 +17,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::config::types::{GlobalConfig, InitSystem, SwapMode, ZfsEncryptionMode};
 use crate::system::alpm_pacman::{AlpmContext, TargetMounts};
-use crate::system::async_download::{DownloadConfig, DownloadProgress};
+use crate::system::async_download::DownloadProgress;
 use crate::system::cmd::CommandRunner;
 
 /// What an installation needs to know before it starts.
@@ -115,14 +115,7 @@ pub fn perform_installation(request: InstallRequest) -> Result<Vec<String>> {
     // The target now has pacman.conf, keyring and mirrorlist from
     // finalize_target(), so the handle for the remaining phases can be made.
     let target_conf = target.join("etc/pacman.conf");
-    let mut alpm = AlpmContext::for_target(
-        &target,
-        &target_conf,
-        DownloadConfig {
-            concurrency: config.parallel_downloads as usize,
-            ..Default::default()
-        },
-    )?;
+    let mut alpm = AlpmContext::for_target(&target, &target_conf, config.download_config())?;
     alpm.sync_databases(false)?;
 
     let mut installer = Installer {
@@ -628,10 +621,7 @@ impl Installer {
                 &self.target,
                 &aur_pkgs,
                 &self.cancel,
-                DownloadConfig {
-                    concurrency: self.config.parallel_downloads as usize,
-                    ..Default::default()
-                },
+                self.config.download_config(),
             ))?;
         }
 

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -104,13 +104,8 @@ pub fn perform_installation(request: InstallRequest) -> Result<Vec<String>> {
 
     tracing::info!("Phase 4: Installing base system...");
     tracing::info!(target: "metrics", event = "phase_start", num = 4u32, name = "Installing base system");
-    let target_mounts = base::install_base(
-        &*runner,
-        &target,
-        &config,
-        &cancel,
-        download_progress_tx.clone(),
-    )?;
+    let target_mounts =
+        base::install_base(&target, &config, &cancel, download_progress_tx.clone())?;
 
     // The target now has pacman.conf, keyring and mirrorlist from
     // finalize_target(), so the handle for the remaining phases can be made.
@@ -235,7 +230,7 @@ impl Installer {
             locale::set_locale(&*self.runner, &self.target, locale)?;
         }
 
-        locale::set_keyboard(&*self.runner, &self.target, &self.config.keyboard_layout)?;
+        locale::set_keyboard(&self.target, &self.config.keyboard_layout)?;
         locale::set_x11_keyboard(&self.target, &self.config.keyboard_layout)?;
 
         if let Some(ref tz) = self.config.timezone {
@@ -343,7 +338,7 @@ impl Installer {
 
         match self.config.init_system {
             InitSystem::Dracut => {
-                initramfs::dracut::configure(&*self.runner, &self.target, encryption)?;
+                initramfs::dracut::configure(&self.target, encryption)?;
                 initramfs::dracut::generate(&*self.runner, &self.target, &kernels)?;
             }
             InitSystem::Mkinitcpio => {

--- a/core/src/installer/network.rs
+++ b/core/src/installer/network.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use color_eyre::eyre::{Context, Result};
 
-use crate::system::cmd::{CommandRunner, check_exit};
+use crate::system::cmd::CommandRunner;
 
 pub fn copy_iso_network(runner: &dyn CommandRunner, target: &Path) -> Result<()> {
     // Copy systemd-networkd configs
@@ -40,28 +40,6 @@ pub fn copy_iso_network(runner: &dyn CommandRunner, target: &Path) -> Result<()>
     }
 
     tracing::info!("copied ISO network configuration");
-    Ok(())
-}
-
-pub fn install_network_manager(
-    runner: &dyn CommandRunner,
-    target: &Path,
-    cancel: &tokio_util::sync::CancellationToken,
-    download_config: crate::system::async_download::DownloadConfig,
-) -> Result<()> {
-    let target_conf = target.join("etc/pacman.conf");
-    let mut ctx =
-        crate::system::alpm_pacman::AlpmContext::for_target(target, &target_conf, download_config)?;
-    ctx.sync_databases(false)?;
-    ctx.install_packages(&["networkmanager"], cancel, None)?;
-
-    let target_str = target.to_string_lossy();
-    let output = runner.run(
-        "systemctl",
-        &["--root", &target_str, "enable", "NetworkManager"],
-    )?;
-    check_exit(&output, "enable NetworkManager")?;
-
     Ok(())
 }
 

--- a/core/src/installer/network.rs
+++ b/core/src/installer/network.rs
@@ -26,17 +26,15 @@ pub fn copy_iso_network(runner: &dyn CommandRunner, target: &Path) -> Result<()>
     let _ = fs::remove_file(&resolv);
     std::os::unix::fs::symlink("/run/systemd/resolve/stub-resolv.conf", &resolv)?;
 
-    // Enable services
-    let services = ["systemd-networkd", "systemd-resolved"];
-    for service in &services {
-        let target_str = target.to_string_lossy();
-        let _ = runner.run("systemctl", &["--root", &target_str, "enable", service]);
+    // Enable services. The helper already treats a non-zero exit as a
+    // warning; a systemctl that cannot be run at all is ignored here as well.
+    for service in ["systemd-networkd", "systemd-resolved"] {
+        let _ = super::services::enable_service(runner, target, service);
     }
 
     // Enable iwd if configs were copied
     if dst_iwd.exists() {
-        let target_str = target.to_string_lossy();
-        let _ = runner.run("systemctl", &["--root", &target_str, "enable", "iwd"]);
+        let _ = super::services::enable_service(runner, target, "iwd");
     }
 
     tracing::info!("copied ISO network configuration");

--- a/core/src/installer/services.rs
+++ b/core/src/installer/services.rs
@@ -12,19 +12,7 @@ use crate::system::cmd::CommandRunner;
 /// can be enabled manually post-install. The install progress screen displays
 /// WARN entries in yellow so the user will see the failure.
 pub fn enable_service(runner: &dyn CommandRunner, target: &Path, service: &str) -> Result<()> {
-    let target_str = target.to_string_lossy();
-    let output = runner.run("systemctl", &["--root", &target_str, "enable", service])?;
-    if output.success() {
-        tracing::info!(service, "enabled service");
-    } else {
-        tracing::warn!(
-            service,
-            exit_code = output.exit_code,
-            stderr = %output.stderr,
-            "failed to enable service — continuing (can be enabled manually)"
-        );
-    }
-    Ok(())
+    enable(runner, target, service, false)
 }
 
 /// Enable a user-level systemd unit globally for all users in the target.
@@ -33,19 +21,39 @@ pub fn enable_service(runner: &dyn CommandRunner, target: &Path, service: &str) 
 /// `<target>/etc/systemd/user/`. Non-zero exit is treated as a warning for the
 /// same reasons as `enable_service`.
 pub fn enable_user_service(runner: &dyn CommandRunner, target: &Path, service: &str) -> Result<()> {
+    enable(runner, target, service, true)
+}
+
+/// `systemctl --root <target> [--global] enable <service>`; a non-zero exit
+/// is a warning, not an error.
+fn enable(runner: &dyn CommandRunner, target: &Path, service: &str, global: bool) -> Result<()> {
     let target_str = target.to_string_lossy();
-    let output = runner.run(
-        "systemctl",
-        &["--root", &target_str, "--global", "enable", service],
-    )?;
+    let mut args = vec!["--root", &*target_str];
+    if global {
+        args.push("--global");
+    }
+    args.extend(["enable", service]);
+    let output = runner.run("systemctl", &args)?;
+
+    let (enabled, failed) = if global {
+        (
+            "enabled user service globally",
+            "failed to enable user service — continuing (can be enabled manually)",
+        )
+    } else {
+        (
+            "enabled service",
+            "failed to enable service — continuing (can be enabled manually)",
+        )
+    };
     if output.success() {
-        tracing::info!(service, "enabled user service globally");
+        tracing::info!(service, "{enabled}");
     } else {
         tracing::warn!(
             service,
             exit_code = output.exit_code,
             stderr = %output.stderr,
-            "failed to enable user service — continuing (can be enabled manually)"
+            "{failed}"
         );
     }
     Ok(())
@@ -72,6 +80,19 @@ mod tests {
         assert!(calls[0].args.contains(&"enable".to_string()));
         assert!(calls[0].args.contains(&"sshd".to_string()));
         assert!(calls[0].args.contains(&"/mnt".to_string()));
+    }
+
+    #[test]
+    fn a_user_service_is_enabled_globally() {
+        let runner = RecordingRunner::new(vec![CannedResponse::default()]);
+        enable_user_service(&runner, Path::new("/mnt"), "pipewire").unwrap();
+
+        let calls = runner.calls();
+        assert_eq!(calls[0].program, "systemctl");
+        assert_eq!(
+            calls[0].args,
+            ["--root", "/mnt", "--global", "enable", "pipewire"]
+        );
     }
 
     #[test]

--- a/core/src/installer/users.rs
+++ b/core/src/installer/users.rs
@@ -98,6 +98,25 @@ pub fn setup_ssh_keys(
     Ok(())
 }
 
+/// Add `users` to `group`, creating the group first.
+///
+/// `groupadd -f` succeeds whether or not the group exists, so its result is
+/// not inspected; a `usermod` that fails is an error, since the membership is
+/// what the caller needs.
+pub fn add_to_group(
+    runner: &dyn CommandRunner,
+    target: &Path,
+    group: &str,
+    users: &[&str],
+) -> Result<()> {
+    let _ = chroot_cmd(runner, target, "groupadd", &["-f", group]);
+    for user in users {
+        let output = chroot_cmd(runner, target, "usermod", &["-aG", group, user])?;
+        check_exit(&output, &format!("add {user} to {group} group"))?;
+    }
+    Ok(())
+}
+
 fn enable_sudo(target: &Path, username: &str) -> Result<()> {
     let sudoers_dir = target.join("etc/sudoers.d");
     fs::create_dir_all(&sudoers_dir)?;
@@ -146,6 +165,43 @@ mod tests {
         assert!(sudoers.exists());
         let content = fs::read_to_string(sudoers).unwrap();
         assert!(content.contains("testuser ALL=(ALL:ALL) ALL"));
+    }
+
+    #[test]
+    fn group_is_created_once_and_each_user_added() {
+        let runner = RecordingRunner::new(vec![]);
+
+        add_to_group(&runner, Path::new("/mnt"), "seat", &["alice", "bob"]).unwrap();
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 3);
+        assert_eq!(calls[0].args, ["/mnt", "groupadd", "-f", "seat"]);
+        assert_eq!(calls[1].args, ["/mnt", "usermod", "-aG", "seat", "alice"]);
+        assert_eq!(calls[2].args, ["/mnt", "usermod", "-aG", "seat", "bob"]);
+    }
+
+    #[test]
+    fn a_failed_group_creation_is_ignored_but_a_failed_usermod_is_not() {
+        let runner = RecordingRunner::new(vec![
+            CannedResponse {
+                exit_code: 9,
+                stderr: "group exists".into(),
+                ..Default::default()
+            },
+            CannedResponse {
+                exit_code: 6,
+                stderr: "user does not exist".into(),
+                ..Default::default()
+            },
+        ]);
+
+        let err = add_to_group(&runner, Path::new("/mnt"), "autologin", &["carol"]).unwrap_err();
+
+        assert!(
+            err.to_string().contains("add carol to autologin group"),
+            "{err}"
+        );
+        assert!(err.to_string().contains("user does not exist"), "{err}");
     }
 
     #[test]

--- a/core/src/installer/users.rs
+++ b/core/src/installer/users.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use color_eyre::eyre::Result;
 
-use crate::system::cmd::{CommandRunner, check_exit, chroot_cmd};
+use crate::system::cmd::{CommandRunner, check_exit, chroot_checked, chroot_cmd};
 use crate::system::fs::write_file_with_mode;
 
 pub fn set_root_password(runner: &dyn CommandRunner, target: &Path, password: &str) -> Result<()> {
@@ -26,12 +26,18 @@ pub fn create_user(
     groups: Option<&[String]>,
 ) -> Result<()> {
     // Create user — args passed directly, no shell interpretation
-    let output = if let Some(sh) = shell {
-        chroot_cmd(runner, target, "useradd", &["-m", "-s", sh, username])?
-    } else {
-        chroot_cmd(runner, target, "useradd", &["-m", username])?
-    };
-    check_exit(&output, &format!("useradd {username}"))?;
+    let mut args = vec!["-m"];
+    if let Some(sh) = shell {
+        args.extend(["-s", sh]);
+    }
+    args.push(username);
+    chroot_checked(
+        runner,
+        target,
+        "useradd",
+        &args,
+        &format!("useradd {username}"),
+    )?;
 
     // Set password via stdin (not visible in process args)
     if let Some(pw) = password {
@@ -45,8 +51,13 @@ pub fn create_user(
     // Add to groups — args passed directly, no shell interpretation
     if let Some(grps) = groups {
         for group in grps {
-            let output = chroot_cmd(runner, target, "usermod", &["-aG", group, username])?;
-            check_exit(&output, &format!("add {username} to {group}"))?;
+            chroot_checked(
+                runner,
+                target,
+                "usermod",
+                &["-aG", group, username],
+                &format!("add {username} to {group}"),
+            )?;
         }
     }
 
@@ -75,8 +86,13 @@ pub fn setup_ssh_keys(
     let ssh_dir = format!("/home/{username}/.ssh");
 
     // Create .ssh directory with correct permissions inside the chroot
-    let output = chroot_cmd(runner, target, "install", &["-d", "-m", "700", &ssh_dir])?;
-    check_exit(&output, &format!("create .ssh dir for {username}"))?;
+    chroot_checked(
+        runner,
+        target,
+        "install",
+        &["-d", "-m", "700", &ssh_dir],
+        &format!("create .ssh dir for {username}"),
+    )?;
 
     // Write authorized_keys on the host side (simpler than heredoc in chroot),
     // created 0600 directly so the keys are never briefly world-readable.
@@ -91,8 +107,13 @@ pub fn setup_ssh_keys(
 
     // Ownership still needs the chroot: the uid/gid live in the target's passwd.
     let owner = format!("{username}:{username}");
-    let output = chroot_cmd(runner, target, "chown", &["-R", &owner, &ssh_dir])?;
-    check_exit(&output, &format!("chown .ssh for {username}"))?;
+    chroot_checked(
+        runner,
+        target,
+        "chown",
+        &["-R", &owner, &ssh_dir],
+        &format!("chown .ssh for {username}"),
+    )?;
 
     tracing::info!(username, "set up SSH authorized_keys");
     Ok(())

--- a/core/src/kernel/mod.rs
+++ b/core/src/kernel/mod.rs
@@ -18,16 +18,6 @@ pub fn get_kernel_info(distro: &'static Distribution, name: &str) -> Option<&'st
     distro.kernels.iter().find(|k| k.name == name)
 }
 
-pub fn get_zfs_packages(
-    distro: &'static Distribution,
-    kernel: &str,
-    mode: ZfsModuleMode,
-) -> Vec<String> {
-    let mut packages = vec!["zfs-utils".to_string()];
-    packages.extend(zfs_module_packages(distro, kernel, mode));
-    packages
-}
-
 /// The packages that provide a ZFS module for `kernel`, without `zfs-utils`
 /// (which is shared by every kernel and installed once).
 ///
@@ -58,19 +48,6 @@ pub fn zfs_module_packages(
             vec!["zfs-dkms".to_string(), info.headers_package.to_string()]
         }
     }
-}
-
-pub fn supports_precompiled(distro: &'static Distribution, kernel: &str) -> bool {
-    get_kernel_info(distro, kernel)
-        .and_then(|k| k.precompiled_package)
-        .is_some()
-}
-
-/// Query a package version from the local pacman sync database using libalpm.
-/// Returns None if the package is not found in any configured repo.
-pub async fn query_package_version(package: &str) -> Result<Option<String>> {
-    let versions = query_packages(&[package]).await?;
-    Ok(versions.get(package).cloned())
 }
 
 /// Initialize an alpm handle from the system pacman.conf.
@@ -243,53 +220,31 @@ mod tests {
     }
 
     #[test]
-    fn test_get_zfs_packages_precompiled() {
-        let pkgs = get_zfs_packages(
+    fn precompiled_module_is_preferred_when_the_kernel_has_one() {
+        let pkgs = zfs_module_packages(
             crate::distro::default(),
             "linux-lts",
             ZfsModuleMode::Precompiled,
         );
-        assert!(pkgs.contains(&"zfs-utils".to_string()));
-        assert!(pkgs.contains(&"zfs-linux-lts".to_string()));
-        assert!(!pkgs.contains(&"zfs-dkms".to_string()));
+        assert_eq!(pkgs, ["zfs-linux-lts"]);
     }
 
     #[test]
-    fn test_get_zfs_packages_dkms() {
-        let pkgs = get_zfs_packages(crate::distro::default(), "linux", ZfsModuleMode::Dkms);
-        assert!(pkgs.contains(&"zfs-utils".to_string()));
+    fn dkms_brings_the_kernel_headers() {
+        let pkgs = zfs_module_packages(crate::distro::default(), "linux", ZfsModuleMode::Dkms);
         assert!(pkgs.contains(&"zfs-dkms".to_string()));
         assert!(pkgs.contains(&"linux-headers".to_string()));
     }
 
     #[test]
-    fn test_supports_precompiled() {
-        assert!(supports_precompiled(crate::distro::default(), "linux-lts"));
-        assert!(supports_precompiled(crate::distro::default(), "linux"));
-        assert!(!supports_precompiled(
-            crate::distro::default(),
-            "linux-custom"
-        ));
-    }
-
-    // Integration test: only runs on Arch with synced pacman DB
-    #[tokio::test]
-    async fn test_query_package_version_on_arch() {
-        if !std::path::Path::new("/var/lib/pacman/sync").exists() {
-            return; // Skip on non-Arch
-        }
-        let ver = query_package_version("linux-lts").await;
-        match ver {
-            Ok(Some(v)) => {
-                assert!(!v.is_empty());
-                tracing::info!(version = v, "linux-lts version from alpm");
-            }
-            Ok(None) => {
-                // DB might not be synced
-            }
-            Err(_) => {
-                // libalpm not available
-            }
-        }
+    fn an_unknown_kernel_has_no_module_packages() {
+        assert!(
+            zfs_module_packages(
+                crate::distro::default(),
+                "linux-custom",
+                ZfsModuleMode::Precompiled
+            )
+            .is_empty()
+        );
     }
 }

--- a/core/src/packages.rs
+++ b/core/src/packages.rs
@@ -45,8 +45,14 @@ fn search_repo_sync(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         }
     }
 
-    // Sort by fuzzy match score against package name
-    let mut scored: Vec<_> = results
+    Ok(best_matches(query, results, limit))
+}
+
+/// Order packages by how well their names fuzzy-match `query`, best first,
+/// keeping `limit` of them. The sort is stable, so packages with equal
+/// scores keep the order the search returned them in.
+fn best_matches(query: &str, packages: Vec<PackageInfo>, limit: usize) -> Vec<PackageInfo> {
+    let mut scored: Vec<_> = packages
         .into_iter()
         .map(|pkg| {
             let score = sublime_fuzzy::best_match(query, &pkg.name)
@@ -56,8 +62,7 @@ fn search_repo_sync(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         })
         .collect();
     scored.sort_by_key(|s| std::cmp::Reverse(s.0));
-
-    Ok(scored.into_iter().map(|(_, pkg)| pkg).take(limit).collect())
+    scored.into_iter().map(|(_, pkg)| pkg).take(limit).collect()
 }
 
 /// Search AUR packages via raur. Returns up to `limit` results sorted by popularity.
@@ -80,16 +85,30 @@ pub async fn search_aur(query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         })
         .collect();
 
-    let mut scored: Vec<_> = packages
-        .into_iter()
-        .map(|pkg| {
-            let score = sublime_fuzzy::best_match(query, &pkg.name)
-                .map(|m| m.score())
-                .unwrap_or(0);
-            (score, pkg)
-        })
-        .collect();
-    scored.sort_by_key(|s| std::cmp::Reverse(s.0));
+    Ok(best_matches(query, packages, limit))
+}
 
-    Ok(scored.into_iter().map(|(_, pkg)| pkg).take(limit).collect())
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg(name: &str) -> PackageInfo {
+        PackageInfo {
+            name: name.into(),
+            version: "1".into(),
+            description: String::new(),
+            repo: "extra".into(),
+        }
+    }
+
+    #[test]
+    fn closer_names_come_first_and_the_limit_is_applied() {
+        let ranked = best_matches(
+            "zfs",
+            vec![pkg("libzfs-tools"), pkg("zfs-utils"), pkg("unrelated")],
+            2,
+        );
+        let names: Vec<&str> = ranked.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, ["zfs-utils", "libzfs-tools"]);
+    }
 }

--- a/core/src/prepare.rs
+++ b/core/src/prepare.rs
@@ -11,7 +11,7 @@ use color_eyre::eyre::{Result, eyre};
 use zfskit::pool::{ExportOptions, ImportOptions, PoolCreateOptions, Vdev};
 
 use crate::boot_environment::BootEnvironment;
-use crate::config::types::{GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode};
+use crate::config::types::{GlobalConfig, InstallationMode, ZfsEncryptionMode};
 use crate::system::cmd::CommandRunner;
 
 /// Partitions selected or created for the installation.
@@ -53,12 +53,11 @@ pub fn prepare_disk(
                 .ok_or_else(|| eyre!("disk not selected for full disk mode"))?;
             crate::disk::partition::zap_disk(runner, disk)?;
 
-            let swap_size = match config.swap_mode {
-                SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted => {
-                    config.swap_partition_size.as_deref()
-                }
-                _ => None,
-            };
+            let swap_size = config
+                .swap_mode
+                .uses_partition()
+                .then_some(config.swap_partition_size.as_deref())
+                .flatten();
             let layout = crate::disk::partition::create_partitions(runner, disk, swap_size)?;
             let parts = crate::disk::partition::wait_for_partitions(disk, &layout)?;
             let efi = parts[0].clone();

--- a/core/src/prepare.rs
+++ b/core/src/prepare.rs
@@ -171,13 +171,7 @@ pub async fn prepare_zfs(
                 .set_property("cachefile", "none")
                 .await?;
 
-            let base_refs = base_dataset_props(encryption, &key_path, &compression);
-            let base_refs_view: Vec<(&str, &str)> =
-                base_refs.iter().map(|(k, v)| (*k, v.as_str())).collect();
-            crate::dataset_layout::create_base_dataset(&zfs, &be, &base_refs_view).await?;
-
-            let datasets = crate::dataset_layout::default_datasets();
-            crate::dataset_layout::create_child_datasets(&zfs, &be, &datasets).await?;
+            create_boot_environment(&zfs, &be, encryption, &key_path, &compression).await?;
             tracing::info!("Created datasets");
 
             export_pool(&zfs, pool_name).await?;
@@ -196,13 +190,7 @@ pub async fn prepare_zfs(
                     .await?;
             }
 
-            let base_refs = base_dataset_props(encryption, &key_path, &compression);
-            let base_refs_view: Vec<(&str, &str)> =
-                base_refs.iter().map(|(k, v)| (*k, v.as_str())).collect();
-            crate::dataset_layout::create_base_dataset(&zfs, &be, &base_refs_view).await?;
-
-            let datasets = crate::dataset_layout::default_datasets();
-            crate::dataset_layout::create_child_datasets(&zfs, &be, &datasets).await?;
+            create_boot_environment(&zfs, &be, encryption, &key_path, &compression).await?;
             tracing::info!("Created new BE in existing pool");
         }
     }
@@ -213,6 +201,24 @@ pub async fn prepare_zfs(
     crate::dataset_layout::mount_datasets_ordered(&zfs, &be, &datasets).await?;
     tracing::info!("Datasets mounted");
 
+    Ok(())
+}
+
+/// Create the boot environment's base dataset and the children under it,
+/// whether the pool was just created or already existed.
+async fn create_boot_environment(
+    zfs: &zfskit::Zfs,
+    be: &BootEnvironment,
+    encryption: ZfsEncryptionMode,
+    key_path: &Path,
+    compression: &str,
+) -> Result<()> {
+    let base_props = base_dataset_props(encryption, key_path, compression);
+    let base_refs: Vec<(&str, &str)> = base_props.iter().map(|(k, v)| (*k, v.as_str())).collect();
+    crate::dataset_layout::create_base_dataset(zfs, be, &base_refs).await?;
+
+    let datasets = crate::dataset_layout::default_datasets();
+    crate::dataset_layout::create_child_datasets(zfs, be, &datasets).await?;
     Ok(())
 }
 

--- a/core/src/prepare.rs
+++ b/core/src/prepare.rs
@@ -223,7 +223,7 @@ fn base_dataset_props(
 ) -> Vec<(&'static str, String)> {
     match encryption {
         ZfsEncryptionMode::Dataset => {
-            let mut p = crate::zfs_keyfile::dataset_encryption_properties(key_path);
+            let mut p = crate::zfs_keyfile::pool_encryption_properties(key_path);
             p.push(("mountpoint", "none".to_string()));
             p.push(("compression", compression.to_string()));
             p.push(("overlay", "off".to_string()));

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -342,16 +342,6 @@ impl AlpmContext {
         Ok(())
     }
 
-    /// Get a reference to the underlying alpm handle.
-    pub fn handle(&self) -> &Alpm {
-        &self.handle
-    }
-
-    /// Get a mutable reference to the underlying alpm handle.
-    pub fn handle_mut(&mut self) -> &mut Alpm {
-        &mut self.handle
-    }
-
     fn find_package(&self, name: &str) -> Result<&alpm::Package> {
         for db in self.handle.syncdbs() {
             if let Ok(pkg) = db.pkg(name) {

--- a/core/src/system/alpm_pacman.rs
+++ b/core/src/system/alpm_pacman.rs
@@ -79,12 +79,6 @@ impl AlpmContext {
         pacman_conf_path: &Path,
         download_config: DownloadConfig,
     ) -> Result<Self> {
-        let conf =
-            pacmanconf::Config::from_file(pacman_conf_path.to_str().unwrap_or("/etc/pacman.conf"))
-                .wrap_err("failed to parse pacman.conf")?;
-
-        let target_str = target.to_string_lossy();
-        let db_path = format!("{}/var/lib/pacman", target_str);
         // A cache outside the target survives it, so a later installation can
         // reuse what this one downloaded.
         let cache_dir = match download_config.cache_dir.as_ref() {
@@ -94,15 +88,10 @@ impl AlpmContext {
                 })?;
                 format!("{}/", shared.display())
             }
-            None => format!("{}/var/cache/pacman/pkg/", target_str),
+            None => format!("{}/var/cache/pacman/pkg/", target.to_string_lossy()),
         };
 
-        let mut handle = Alpm::new(target_str.as_ref(), &db_path)
-            .map_err(|e| eyre!("failed to init alpm for target: {e}"))?;
-
-        // Configure from host config but with target paths
-        alpm_utils::configure_alpm(&mut handle, &conf)
-            .map_err(|e| eyre!("failed to configure alpm for target: {e}"))?;
+        let mut handle = open_target_alpm(target, pacman_conf_path)?;
 
         // Override cache dir to target
         handle
@@ -426,6 +415,25 @@ impl AlpmContext {
             }
         });
     }
+}
+
+/// Open a libalpm handle rooted at `target`, with the target's database and
+/// the repositories from `pacman_conf_path` (the medium's own file while the
+/// base system is being installed, the target's afterwards).
+pub(crate) fn open_target_alpm(target: &Path, pacman_conf_path: &Path) -> Result<Alpm> {
+    let conf =
+        pacmanconf::Config::from_file(pacman_conf_path.to_str().unwrap_or("/etc/pacman.conf"))
+            .wrap_err("failed to parse pacman.conf")?;
+
+    let target_str = target.to_string_lossy();
+    let db_path = format!("{}/var/lib/pacman", target_str);
+    let mut handle = Alpm::new(target_str.as_ref(), &db_path)
+        .map_err(|e| eyre!("failed to init alpm for target: {e}"))?;
+
+    // Configure from the given config but with target paths.
+    alpm_utils::configure_alpm(&mut handle, &conf)
+        .map_err(|e| eyre!("failed to configure alpm for target: {e}"))?;
+    Ok(handle)
 }
 
 /// Install packages from the target's own repositories, for the phases that

--- a/core/src/system/cmd.rs
+++ b/core/src/system/cmd.rs
@@ -112,6 +112,19 @@ pub fn chroot_cmd(
     runner.run("arch-chroot", &full_args)
 }
 
+/// Run a program inside the chroot and fail, naming `context`, when it exits
+/// non-zero. For the common case where nothing but the exit status matters.
+pub fn chroot_checked(
+    runner: &dyn CommandRunner,
+    target: &Path,
+    program: &str,
+    args: &[&str],
+    context: &str,
+) -> Result<()> {
+    let output = chroot_cmd(runner, target, program, args)?;
+    check_exit(&output, context)
+}
+
 /// Shell-quote a string for safe interpolation into bash commands.
 /// Returns the string wrapped in single quotes with internal single quotes escaped.
 pub fn shell_quote(s: &str) -> String {
@@ -241,6 +254,35 @@ pub mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].program, "echo");
         assert_eq!(calls[0].args, vec!["hello"]);
+    }
+
+    #[test]
+    fn chroot_checked_passes_the_argv_through_and_reports_failures_by_context() {
+        let runner = RecordingRunner::new(vec![
+            CannedResponse::default(),
+            CannedResponse {
+                exit_code: 1,
+                stderr: "no such preset".into(),
+                ..Default::default()
+            },
+        ]);
+
+        chroot_checked(&runner, Path::new("/mnt"), "locale-gen", &[], "locale-gen").unwrap();
+        let err = chroot_checked(
+            &runner,
+            Path::new("/mnt"),
+            "mkinitcpio",
+            &["-p", "linux"],
+            "mkinitcpio -p linux",
+        )
+        .unwrap_err();
+
+        let calls = runner.calls();
+        assert_eq!(calls[0].program, "arch-chroot");
+        assert_eq!(calls[0].args, ["/mnt", "locale-gen"]);
+        assert_eq!(calls[1].args, ["/mnt", "mkinitcpio", "-p", "linux"]);
+        assert!(err.to_string().contains("mkinitcpio -p linux"), "{err}");
+        assert!(err.to_string().contains("no such preset"), "{err}");
     }
 
     #[test]

--- a/core/src/system/conf.rs
+++ b/core/src/system/conf.rs
@@ -1,0 +1,322 @@
+//! Line-based edits to shell-style and pacman configuration files.
+//!
+//! These files are small and regular enough that a line at a time is safer
+//! than a parser: nothing outside the line being changed is reformatted, so
+//! the user's comments and the package's examples survive an installation.
+
+use std::path::Path;
+
+use color_eyre::eyre::{Result, bail};
+
+/// Rewrite a `KEY=(a b c)` array assignment in an mkinitcpio.conf.
+///
+/// Errors when the assignment cannot be parsed rather than falling back to an
+/// empty array. Silently emptying `HOOKS` produces a `HOOKS=(zfs)` initramfs
+/// that cannot mount root, and the installation would report success — a
+/// failure here is recoverable, an unbootable system is not.
+///
+/// Where the same key is assigned more than once the last assignment is the
+/// one the shell would use, so that is the one patched.
+pub(crate) fn patch_conf_array(
+    content: &str,
+    key: &str,
+    f: impl FnOnce(&mut Vec<String>),
+) -> Result<String> {
+    let prefix = format!("{key}=(");
+    let mut lines: Vec<String> = Vec::new();
+    let mut target_line: Option<usize> = None;
+    let mut values: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with(&prefix) {
+            let Some(inner) = trimmed
+                .strip_prefix(&prefix)
+                .and_then(|s| s.strip_suffix(')'))
+            else {
+                bail!(
+                    "cannot patch {key} in mkinitcpio.conf: the assignment on line {} does not \
+                     close on the same line. Rewriting it would drop the existing entries and \
+                     leave an unbootable initramfs; put {key}=(...) on one line and retry.",
+                    lines.len() + 1
+                );
+            };
+            target_line = Some(lines.len());
+            values = inner.split_whitespace().map(|s| s.to_string()).collect();
+        }
+        lines.push(line.to_string());
+    }
+
+    f(&mut values);
+    let new_line = format!("{key}=({})", values.join(" "));
+    match target_line {
+        Some(index) => lines[index] = new_line,
+        None => lines.push(new_line),
+    }
+
+    let mut result = lines.join("\n");
+    result.push('\n');
+    Ok(result)
+}
+
+/// Set `KEY="value"` in a shell-style configuration file.
+pub(crate) fn set_conf_value(content: &str, key: &str, value: &str) -> String {
+    set_conf_line(content, key, &format!("{key}=\"{value}\""))
+}
+
+/// Replace every active `KEY=` assignment with `line`. When the key is only
+/// present as a commented example (stock files list several), activate the
+/// first one and leave the other examples as they are. Append when absent.
+pub(crate) fn set_conf_line(content: &str, key: &str, line: &str) -> String {
+    let prefix = format!("{key}=");
+    let commented = format!("#{prefix}");
+    let has_active = content.lines().any(|l| l.trim().starts_with(&prefix));
+    let mut result = String::new();
+    let mut found = false;
+
+    for l in content.lines() {
+        let trimmed = l.trim();
+        let replace = if has_active {
+            trimmed.starts_with(&prefix)
+        } else {
+            !found && trimmed.starts_with(&commented)
+        };
+        if replace {
+            found = true;
+            result.push_str(line);
+        } else {
+            result.push_str(l);
+        }
+        result.push('\n');
+    }
+
+    if !found {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result
+}
+
+/// Set a key in pacman.conf's `[options]`, adding it when absent.
+///
+/// Both keys this is used for appear only in that section, so a line-based
+/// replacement is enough and does not need a full parser.
+pub(crate) fn set_option(content: &str, key: &str, value: &str) -> String {
+    let line = format!("{key} = {value}");
+    let mut replaced = false;
+    let mut result: Vec<String> = content
+        .lines()
+        .map(|existing| {
+            let trimmed = existing.trim_start().trim_start_matches('#');
+            if trimmed.starts_with(&format!("{key} ")) || trimmed.starts_with(&format!("{key}=")) {
+                replaced = true;
+                line.clone()
+            } else {
+                existing.to_string()
+            }
+        })
+        .collect();
+
+    if !replaced {
+        // Straight after [options], which every pacman.conf opens with.
+        let at = result
+            .iter()
+            .position(|l| l.trim() == "[options]")
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        result.insert(at, line);
+    }
+
+    let mut out = result.join("\n");
+    out.push('\n');
+    out
+}
+
+/// Set `ParallelDownloads` in pacman.conf: the medium's own when `target` is
+/// `None`, the installed system's when given.
+///
+/// Unlike [`set_option`], a missing key is appended at the end of the file
+/// rather than placed under `[options]`.
+pub(crate) fn set_parallel_downloads(target: Option<&Path>, count: u32) -> Result<()> {
+    let pacman_conf = match target {
+        Some(t) => t.join("etc/pacman.conf"),
+        None => std::path::PathBuf::from("/etc/pacman.conf"),
+    };
+
+    let content = std::fs::read_to_string(&pacman_conf)?;
+    let new_line = format!("ParallelDownloads = {count}");
+
+    let new_content = if content.contains("ParallelDownloads") {
+        content
+            .lines()
+            .map(|line| {
+                if line.trim_start().starts_with("ParallelDownloads")
+                    || line.trim_start().starts_with("#ParallelDownloads")
+                {
+                    new_line.as_str()
+                } else {
+                    line
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        format!("{content}\n{new_line}\n")
+    };
+
+    std::fs::write(&pacman_conf, new_content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_patch_conf_array_adds_zfs() {
+        let input = "MODULES=()\nHOOKS=(base udev autodetect modconf block filesystems fsck)\n";
+        let result = patch_conf_array(input, "HOOKS", |hooks| {
+            if !hooks.contains(&"zfs".to_string())
+                && let Some(pos) = hooks.iter().position(|h| h == "filesystems")
+            {
+                hooks.insert(pos, "zfs".to_string());
+            }
+        })
+        .unwrap();
+        assert!(result.contains("zfs filesystems"));
+    }
+
+    #[test]
+    fn multi_line_array_is_rejected_instead_of_emptied() {
+        // A HOOKS array split across lines used to parse as empty, so the
+        // patched config kept only the hook being added — an initramfs with no
+        // base, udev or block hooks, i.e. a system that cannot boot.
+        let input = "MODULES=()\nHOOKS=(base udev autodetect\n       block filesystems fsck)\n";
+
+        let err = patch_conf_array(input, "HOOKS", |hooks| hooks.push("zfs".to_string()))
+            .expect_err("a multi-line array must not be silently rewritten");
+
+        let msg = err.to_string();
+        assert!(msg.contains("HOOKS"), "error should name the key: {msg}");
+        assert!(msg.contains("line 2"), "error should locate it: {msg}");
+    }
+
+    #[test]
+    fn repeated_assignment_patches_the_one_the_shell_would_use() {
+        let input = "HOOKS=(base udev)\nHOOKS=(base udev block filesystems)\n";
+
+        let result = patch_conf_array(input, "HOOKS", |hooks| {
+            let pos = hooks.iter().position(|h| h == "filesystems").unwrap();
+            hooks.insert(pos, "zfs".to_string());
+        })
+        .unwrap();
+
+        assert_eq!(
+            result,
+            "HOOKS=(base udev)\nHOOKS=(base udev block zfs filesystems)\n"
+        );
+    }
+
+    #[test]
+    fn missing_array_is_appended() {
+        let result = patch_conf_array("COMPRESSION=\"cat\"\n", "FILES", |files| {
+            files.push("/etc/zfs/zroot.key".to_string())
+        })
+        .unwrap();
+
+        assert_eq!(result, "COMPRESSION=\"cat\"\nFILES=(/etc/zfs/zroot.key)\n");
+    }
+
+    #[test]
+    fn commented_out_assignment_is_left_alone() {
+        let result = patch_conf_array("#MODULES=(vfat)\n", "MODULES", |modules| {
+            modules.push("zfs".to_string())
+        })
+        .unwrap();
+
+        assert_eq!(result, "#MODULES=(vfat)\nMODULES=(zfs)\n");
+    }
+
+    #[test]
+    fn test_set_conf_value() {
+        let input = "#COMPRESSION=\"zstd\"\n";
+        let result = set_conf_value(input, "COMPRESSION", "cat");
+        assert!(result.contains("COMPRESSION=\"cat\""));
+        assert!(!result.contains("#COMPRESSION"));
+    }
+
+    #[test]
+    fn test_set_conf_line_activates_one_example_and_replaces_active_values() {
+        let examples = "#COMPRESSION=\"zstd\"\n#COMPRESSION=\"xz\"\n#COMPRESSION_OPTIONS=()\n";
+        assert_eq!(
+            set_conf_line(examples, "COMPRESSION", "COMPRESSION=\"xz\""),
+            "COMPRESSION=\"xz\"\n#COMPRESSION=\"xz\"\n#COMPRESSION_OPTIONS=()\n"
+        );
+        assert_eq!(
+            set_conf_line(
+                "#COMPRESSION=\"zstd\"\nCOMPRESSION=\"lz4\"\n",
+                "COMPRESSION",
+                "COMPRESSION=\"xz\""
+            ),
+            "#COMPRESSION=\"zstd\"\nCOMPRESSION=\"xz\"\n"
+        );
+        assert_eq!(
+            set_conf_line(
+                "HOOKS=(base)\n",
+                "COMPRESSION_OPTIONS",
+                "COMPRESSION_OPTIONS=(-9)"
+            ),
+            "HOOKS=(base)\nCOMPRESSION_OPTIONS=(-9)\n"
+        );
+    }
+
+    #[test]
+    fn an_option_is_replaced_in_place() {
+        let conf = "[options]\nArchitecture = x86_64\nParallelDownloads = 5\n\n[core]\n";
+
+        let result = set_option(conf, "Architecture", "auto");
+
+        assert!(result.contains("Architecture = auto"));
+        assert!(!result.contains("Architecture = x86_64"));
+        assert!(result.contains("ParallelDownloads = 5"), "others untouched");
+    }
+
+    #[test]
+    fn a_commented_option_is_taken_over() {
+        let conf = "[options]\n#Architecture = auto\n\n[core]\n";
+
+        let result = set_option(conf, "Architecture", "auto");
+
+        assert_eq!(result.matches("Architecture").count(), 1);
+        assert!(!result.contains('#'));
+    }
+
+    #[test]
+    fn a_missing_option_is_added_under_options() {
+        let conf = "[options]\nHoldPkg = pacman\n\n[core]\nSigLevel = Required\n";
+
+        let result = set_option(conf, "Architecture", "auto");
+
+        let lines: Vec<&str> = result.lines().collect();
+        assert_eq!(lines[0], "[options]");
+        assert_eq!(
+            lines[1], "Architecture = auto",
+            "must land inside [options]"
+        );
+    }
+
+    #[test]
+    fn test_set_parallel_downloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let conf_path = dir.path().join("etc/pacman.conf");
+        std::fs::create_dir_all(conf_path.parent().unwrap()).unwrap();
+        std::fs::write(&conf_path, "#ParallelDownloads = 5\n").unwrap();
+
+        set_parallel_downloads(Some(dir.path()), 10).unwrap();
+
+        let content = std::fs::read_to_string(&conf_path).unwrap();
+        assert!(content.contains("ParallelDownloads = 10"));
+        assert!(!content.contains("#ParallelDownloads"));
+    }
+}

--- a/core/src/system/mod.rs
+++ b/core/src/system/mod.rs
@@ -1,6 +1,7 @@
 pub mod alpm_pacman;
 pub mod async_download;
 pub mod cmd;
+pub(crate) mod conf;
 pub mod fs;
 pub mod gpu;
 pub mod net;

--- a/core/src/system/pacman.rs
+++ b/core/src/system/pacman.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use color_eyre::eyre::{Result, bail};
 
 use super::cmd::CommandRunner;
+use super::conf::set_option;
 use crate::distro::{Distribution, Repository};
 use crate::system::sysinfo::IsaLevel;
 
@@ -139,72 +140,6 @@ fn replace_repo_block(content: &str, repo: &Repository) -> String {
     result
 }
 
-/// Set a key in pacman.conf's `[options]`, adding it when absent.
-///
-/// Both keys this is used for appear only in that section, so a line-based
-/// replacement is enough and does not need a full parser.
-fn set_option(content: &str, key: &str, value: &str) -> String {
-    let line = format!("{key} = {value}");
-    let mut replaced = false;
-    let mut result: Vec<String> = content
-        .lines()
-        .map(|existing| {
-            let trimmed = existing.trim_start().trim_start_matches('#');
-            if trimmed.starts_with(&format!("{key} ")) || trimmed.starts_with(&format!("{key}=")) {
-                replaced = true;
-                line.clone()
-            } else {
-                existing.to_string()
-            }
-        })
-        .collect();
-
-    if !replaced {
-        // Straight after [options], which every pacman.conf opens with.
-        let at = result
-            .iter()
-            .position(|l| l.trim() == "[options]")
-            .map(|i| i + 1)
-            .unwrap_or(0);
-        result.insert(at, line);
-    }
-
-    let mut out = result.join("\n");
-    out.push('\n');
-    out
-}
-
-pub fn set_parallel_downloads(target: Option<&Path>, count: u32) -> Result<()> {
-    let pacman_conf = match target {
-        Some(t) => t.join("etc/pacman.conf"),
-        None => std::path::PathBuf::from("/etc/pacman.conf"),
-    };
-
-    let content = std::fs::read_to_string(&pacman_conf)?;
-    let new_line = format!("ParallelDownloads = {count}");
-
-    let new_content = if content.contains("ParallelDownloads") {
-        content
-            .lines()
-            .map(|line| {
-                if line.trim_start().starts_with("ParallelDownloads")
-                    || line.trim_start().starts_with("#ParallelDownloads")
-                {
-                    new_line.as_str()
-                } else {
-                    line
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    } else {
-        format!("{content}\n{new_line}\n")
-    };
-
-    std::fs::write(&pacman_conf, new_content)?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,41 +152,6 @@ mod tests {
         key_ids: &[],
         signatures: Signatures::Never,
     };
-
-    #[test]
-    fn an_option_is_replaced_in_place() {
-        let conf = "[options]\nArchitecture = x86_64\nParallelDownloads = 5\n\n[core]\n";
-
-        let result = set_option(conf, "Architecture", "auto");
-
-        assert!(result.contains("Architecture = auto"));
-        assert!(!result.contains("Architecture = x86_64"));
-        assert!(result.contains("ParallelDownloads = 5"), "others untouched");
-    }
-
-    #[test]
-    fn a_commented_option_is_taken_over() {
-        let conf = "[options]\n#Architecture = auto\n\n[core]\n";
-
-        let result = set_option(conf, "Architecture", "auto");
-
-        assert_eq!(result.matches("Architecture").count(), 1);
-        assert!(!result.contains('#'));
-    }
-
-    #[test]
-    fn a_missing_option_is_added_under_options() {
-        let conf = "[options]\nHoldPkg = pacman\n\n[core]\nSigLevel = Required\n";
-
-        let result = set_option(conf, "Architecture", "auto");
-
-        let lines: Vec<&str> = result.lines().collect();
-        assert_eq!(lines[0], "[options]");
-        assert_eq!(
-            lines[1], "Architecture = auto",
-            "must land inside [options]"
-        );
-    }
 
     #[test]
     fn a_repository_is_added_once() {
@@ -291,19 +191,5 @@ mod tests {
 
         assert!(result.contains("ParallelDownloads = 5"));
         assert!(result.contains("[extra]\nSigLevel = Required"));
-    }
-
-    #[test]
-    fn test_set_parallel_downloads() {
-        let dir = tempfile::tempdir().unwrap();
-        let conf_path = dir.path().join("etc/pacman.conf");
-        std::fs::create_dir_all(conf_path.parent().unwrap()).unwrap();
-        std::fs::write(&conf_path, "#ParallelDownloads = 5\n").unwrap();
-
-        set_parallel_downloads(Some(dir.path()), 10).unwrap();
-
-        let content = std::fs::read_to_string(&conf_path).unwrap();
-        assert!(content.contains("ParallelDownloads = 10"));
-        assert!(!content.contains("#ParallelDownloads"));
     }
 }

--- a/core/src/zfs_keyfile.rs
+++ b/core/src/zfs_keyfile.rs
@@ -43,10 +43,6 @@ pub fn pool_encryption_properties(key_path: &Path) -> Vec<(&'static str, String)
     ]
 }
 
-pub fn dataset_encryption_properties(key_path: &Path) -> Vec<(&'static str, String)> {
-    pool_encryption_properties(key_path)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/zfs_trim.rs
+++ b/core/src/zfs_trim.rs
@@ -27,6 +27,11 @@ pub async fn configure_zfs_trim(
 ) -> Result<()> {
     // Only configure TRIM when we created (or know) the disk. ExistingPool
     // mode leaves the pool's autotrim property and any timer untouched.
+    //
+    // This mapping stays separate from prepare::prepare_disk: that one
+    // partitions the disk and returns the resulting partitions, whereas this
+    // only needs something whose storage type can be read from sysfs, which
+    // for NewPool is the configured ZFS partition itself.
     let disk_path = match config.installation_mode {
         Some(InstallationMode::FullDisk) => config.disk.as_deref(),
         Some(InstallationMode::Alongside) => {

--- a/gen_iso/deploy-zfs-be.sh
+++ b/gen_iso/deploy-zfs-be.sh
@@ -41,24 +41,8 @@ property is never changed.
 EOF
 }
 
-die() {
-    printf '[%s] ERROR: %s\n' "${app_name}" "$*" >&2
-    exit 1
-}
-
-info() {
-    printf '[%s] %s\n' "${app_name}" "$*"
-}
-
-require_command() {
-    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
-}
-
-cleanup() {
-    if (( mounted )) && mountpoint -q -- "${mount_dir}"; then
-        umount -- "${mount_dir}" || true
-    fi
-}
+# shellcheck source=gen_iso/zfs-be-common.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/zfs-be-common.sh"
 
 on_error() {
     local line="$1"
@@ -70,43 +54,42 @@ on_error() {
     fi
 }
 
-trap cleanup EXIT
 trap 'on_error "$LINENO"' ERR
 
 while (( $# )); do
     case "$1" in
         --dataset)
-            (( $# >= 2 )) || die "--dataset requires a value"
+            need_value "$1" "$#"
             dataset="$2"
             shift 2
             ;;
         --source-root)
-            (( $# >= 2 )) || die "--source-root requires a value"
+            need_value "$1" "$#"
             source_root="$2"
             shift 2
             ;;
         --boot-source)
-            (( $# >= 2 )) || die "--boot-source requires a value"
+            need_value "$1" "$#"
             boot_source="$2"
             shift 2
             ;;
         --kernel)
-            (( $# >= 2 )) || die "--kernel requires a value"
+            need_value "$1" "$#"
             kernel="$2"
             shift 2
             ;;
         --mount-dir)
-            (( $# >= 2 )) || die "--mount-dir requires a value"
+            need_value "$1" "$#"
             mount_dir="$2"
             shift 2
             ;;
         --snapshot)
-            (( $# >= 2 )) || die "--snapshot requires a value"
+            need_value "$1" "$#"
             snapshot="$2"
             shift 2
             ;;
         --key-file)
-            (( $# >= 2 )) || die "--key-file requires a value"
+            need_value "$1" "$#"
             key_file="$2"
             shift 2
             ;;
@@ -309,8 +292,7 @@ if [[ -n "${keysource}" ]]; then
 fi
 zfs create "${create_options[@]}" -- "${dataset}"
 
-mount -t zfs -o zfsutil -- "${dataset}" "${mount_dir}"
-mounted=1
+mount_be "${dataset}"
 
 info "copying mkarchiso rootfs into the dataset"
 rsync -aHAX --numeric-ids --delete -- "${source_root}/" "${mount_dir}/"
@@ -419,8 +401,7 @@ fi
 
 zfs snapshot -- "${dataset}@${snapshot}"
 sync -f -- "${mount_dir}"
-umount -- "${mount_dir}"
-mounted=0
+umount_be
 
 [[ "$(zfs get -H -o value mounted -- "${dataset}")" == "no" ]] \
     || die "target dataset remained mounted"

--- a/gen_iso/run-qemu.sh
+++ b/gen_iso/run-qemu.sh
@@ -45,6 +45,10 @@ cleanup_working_dir() {
     fi
 }
 
+# xtask/src/qemu.rs (find_ovmf) and the justfile (qemu-setup-uefi) keep their
+# own OVMF lists: xtask also probes /usr/share/edk2/ovmf, and the justfile
+# searches the /usr/share/{edk2,edk2-ovmf,OVMF} roots recursively while
+# skipping secboot images. Update all three together.
 find_ovmf_file() {
     local file_to_find=$1
     local paths=(

--- a/gen_iso/update-zfs-be.sh
+++ b/gen_iso/update-zfs-be.sh
@@ -46,41 +46,28 @@ somewhere already.
 EOF
 }
 
-die() {
-    printf '[%s] ERROR: %s\n' "${app_name}" "$*" >&2
-    exit 1
-}
-
-info() {
-    printf '[%s] %s\n' "${app_name}" "$*"
-}
-
-cleanup() {
-    if (( mounted )) && mountpoint -q -- "${mount_dir}"; then
-        umount -- "${mount_dir}" || true
-    fi
-}
-trap cleanup EXIT
+# shellcheck source=gen_iso/zfs-be-common.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/zfs-be-common.sh"
 
 while (( $# )); do
     case "$1" in
         --dataset)
-            (( $# >= 2 )) || die "--dataset requires a value"
+            need_value "$1" "$#"
             dataset="$2"
             shift 2
             ;;
         --binary-dir)
-            (( $# >= 2 )) || die "--binary-dir requires a value"
+            need_value "$1" "$#"
             binary_dir="$2"
             shift 2
             ;;
         --mount-dir)
-            (( $# >= 2 )) || die "--mount-dir requires a value"
+            need_value "$1" "$#"
             mount_dir="$2"
             shift 2
             ;;
         --snapshot)
-            (( $# >= 2 )) || die "--snapshot requires a value"
+            need_value "$1" "$#"
             snapshot="$2"
             shift 2
             ;;
@@ -107,7 +94,7 @@ done
     die "invalid snapshot name: ${snapshot}"
 
 for command in findmnt install mount mountpoint sync umount zfs; do
-    command -v "${command}" >/dev/null 2>&1 || die "required command not found: ${command}"
+    require_command "${command}"
 done
 
 (( EUID == 0 )) || die "must run as root (mounting a dataset needs it)"
@@ -152,8 +139,7 @@ if mountpoint -q -- "${mount_dir}"; then
 fi
 mkdir -p -- "${mount_dir}"
 
-mount -t zfs -o zfsutil -- "${dataset}" "${mount_dir}"
-mounted=1
+mount_be "${dataset}"
 
 marker="${mount_dir}/etc/archinstall-zfs/demo-be"
 if [[ ! -f "${marker}" ]]; then
@@ -175,8 +161,7 @@ for path in "${sources[@]}"; do
 done
 
 sync
-umount -- "${mount_dir}"
-mounted=0
+umount_be
 
 info "updated ${#sources[@]} binaries in ${dataset}"
 info "reboot into the environment to run them"

--- a/gen_iso/zfs-be-common.sh
+++ b/gen_iso/zfs-be-common.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Helpers shared by deploy-zfs-be.sh and update-zfs-be.sh. Sourced, not run:
+# the caller sets app_name, mount_dir and mounted before sourcing, and keeps
+# its own set -Eeuo pipefail.
+# shellcheck disable=SC2154  # app_name, mount_dir and mounted come from the caller
+
+die() {
+    printf '[%s] ERROR: %s\n' "${app_name}" "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '[%s] %s\n' "${app_name}" "$*"
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+# Option parsing: option $1 takes a value, so the remaining argument count $2
+# must cover both the option and its value.
+need_value() {
+    (( $2 >= 2 )) || die "$1 requires a value"
+}
+
+cleanup() {
+    if (( mounted )) && mountpoint -q -- "${mount_dir}"; then
+        umount -- "${mount_dir}" || true
+    fi
+}
+trap cleanup EXIT
+
+mount_be() {
+    mount -t zfs -o zfsutil -- "$1" "${mount_dir}"
+    mounted=1
+}
+
+umount_be() {
+    umount -- "${mount_dir}"
+    mounted=0
+}

--- a/justfile
+++ b/justfile
@@ -95,6 +95,17 @@ _prepare-binary:
         install -m 0755 {{BINARY_SLINT}} {{PROFILE_OUT}}/airootfs/usr/local/bin/azfs; \
     fi
 
+# Internal: native build, render, and mkarchiso into ISO_OUT.
+# FAST="--fast" selects the minimal testing profile.
+_iso MODE KERNEL FAST="":
+    just cargo-build
+    just _render-profile {{MODE}} {{KERNEL}} {{FAST}}
+    just _prepare-binary
+    @echo "Building ISO..."
+    sudo rm -rf gen_iso/workdir
+    sudo mkarchiso -v -w "gen_iso/workdir" -o {{ISO_OUT}} {{PROFILE_OUT}}
+    sudo chown -R "$(id -u):$(id -g)" {{ISO_OUT}} gen_iso/workdir
+
 # Fast, minimal packages, serial+SSH enabled. Skips wifi/bluetooth/firmware.
 # For QEMU iteration and CI.
 # Usage: just iso-test [--mode precompiled|dkms] [--kernel linux|linux-lts|linux-zen]
@@ -102,13 +113,7 @@ _prepare-binary:
 [arg("KERNEL", long="kernel")]
 iso-test MODE="precompiled" KERNEL="linux-lts":
     @echo "Building testing ISO (mode={{MODE}}, kernel={{KERNEL}})"
-    just cargo-build
-    just _render-profile {{MODE}} {{KERNEL}} "--fast"
-    just _prepare-binary
-    @echo "Building ISO..."
-    sudo rm -rf gen_iso/workdir
-    sudo mkarchiso -v -w "gen_iso/workdir" -o {{ISO_OUT}} {{PROFILE_OUT}}
-    sudo chown -R "$(id -u):$(id -g)" {{ISO_OUT}} gen_iso/workdir
+    just _iso {{MODE}} {{KERNEL}} "--fast"
     @echo "Testing ISO built in {{ISO_OUT}}"
 
 # Same package set as CI releases (iwd, wireless-regdb, linux-firmware, etc).
@@ -119,13 +124,7 @@ iso-test MODE="precompiled" KERNEL="linux-lts":
 [arg("KERNEL", long="kernel")]
 iso-full MODE="precompiled" KERNEL="linux-lts":
     @echo "Building full ISO (mode={{MODE}}, kernel={{KERNEL}})"
-    just cargo-build
-    just _render-profile {{MODE}} {{KERNEL}}
-    just _prepare-binary
-    @echo "Building ISO..."
-    sudo rm -rf gen_iso/workdir
-    sudo mkarchiso -v -w "gen_iso/workdir" -o {{ISO_OUT}} {{PROFILE_OUT}}
-    sudo chown -R "$(id -u):$(id -g)" {{ISO_OUT}} gen_iso/workdir
+    just _iso {{MODE}} {{KERNEL}}
     @echo "Full ISO built in {{ISO_OUT}}"
 
 # Build the full hardware profile into a dedicated mkarchiso workdir.
@@ -220,6 +219,14 @@ builder-clean:
     -sudo podman image rm {{CONTAINER_IMAGE}}
     -sudo podman volume rm {{PACMAN_CACHE_VOLUME}} {{CARGO_TARGET_VOLUME}} {{CARGO_REGISTRY_VOLUME}}
 
+# Internal: container build, render, and mkarchiso inside the CI image.
+# FAST="--fast" selects the minimal testing profile.
+_iso-podman MODE KERNEL FAST="":
+    just cargo-build-container
+    just _render-profile {{MODE}} {{KERNEL}} {{FAST}}
+    just _prepare-binary
+    just _mkarchiso-container
+
 # Testing ISO fully inside the CI container: cargo, xtask render, mkarchiso.
 # Produces Arch-glibc binaries that work both on the host and inside the ISO.
 # For non-Arch hosts (Fedora/Debian/…). Only requires podman + qemu on the host.
@@ -228,10 +235,7 @@ builder-clean:
 [arg("KERNEL", long="kernel")]
 iso-test-podman MODE="precompiled" KERNEL="linux-lts":
     @echo "Building testing ISO via podman (mode={{MODE}}, kernel={{KERNEL}})"
-    just cargo-build-container
-    just _render-profile {{MODE}} {{KERNEL}} "--fast"
-    just _prepare-binary
-    just _mkarchiso-container
+    just _iso-podman {{MODE}} {{KERNEL}} "--fast"
 
 # Full ISO via podman. Same build path as iso-test-podman, full package set.
 # Usage: just iso-full-podman [--mode precompiled|dkms] [--kernel linux|linux-lts|linux-zen]
@@ -239,10 +243,7 @@ iso-test-podman MODE="precompiled" KERNEL="linux-lts":
 [arg("KERNEL", long="kernel")]
 iso-full-podman MODE="precompiled" KERNEL="linux-lts":
     @echo "Building full ISO via podman (mode={{MODE}}, kernel={{KERNEL}})"
-    just cargo-build-container
-    just _render-profile {{MODE}} {{KERNEL}}
-    just _prepare-binary
-    just _mkarchiso-container
+    just _iso-podman {{MODE}} {{KERNEL}}
 
 # Internal: invoke mkarchiso inside the container with correct mounts + chown.
 _mkarchiso-container:
@@ -269,6 +270,9 @@ qemu-create-disk:
 
 # Arch ships OVMF_VARS.4m.fd; Fedora/Debian ship OVMF_VARS.fd (no 4m suffix).
 # Search for the 4m variant first, fall back to the bare name. Skip secboot.
+# xtask/src/qemu.rs (find_ovmf) and gen_iso/run-qemu.sh (find_ovmf_file) keep
+# their own lists: they probe fixed directories, mostly the x64 subdirectories,
+# while this recipe searches the roots recursively. Update all three together.
 # Copy OVMF UEFI variables template into the workspace.
 qemu-setup-uefi:
     #!/usr/bin/env bash
@@ -293,35 +297,37 @@ qemu-refresh:
 
 # ─── QEMU Execution ───────────────────────────────────
 
+# Internal: boot QEMU on the workspace disk. MODE=install boots the newest ISO,
+# creating the disk and UEFI vars when missing; MODE=run boots the installed
+# system. SERIAL="-S" attaches the serial console instead of the GUI.
+_qemu-boot MODE SERIAL="":
+    #!/usr/bin/env bash
+    if [[ "{{MODE}}" == install ]]; then
+        if [[ ! -f {{DISK_IMAGE}} ]]; then just qemu-create-disk; fi
+        if [[ ! -f {{UEFI_VARS}} ]]; then just qemu-setup-uefi; fi
+        ISO=$(ls -1t {{ISO_OUT}}/archzfs-*.iso 2>/dev/null | head -n1)
+        if [[ -z "$ISO" ]]; then echo "No ISO found. Run 'just iso-test' or 'just iso-full'."; exit 1; fi
+        bash {{QEMU_SCRIPT}} -i "$ISO" -D {{DISK_IMAGE}} -U {{UEFI_VARS}} {{SERIAL}}
+    else
+        if [[ ! -f {{DISK_IMAGE}} ]]; then echo "No disk. Run 'just qemu-install' first."; exit 1; fi
+        bash {{QEMU_SCRIPT}} -D {{DISK_IMAGE}} -U {{UEFI_VARS}} {{SERIAL}}
+    fi
+
 # Boot latest ISO in QEMU with GUI
 qemu-install:
-    #!/usr/bin/env bash
-    if [[ ! -f {{DISK_IMAGE}} ]]; then just qemu-create-disk; fi
-    if [[ ! -f {{UEFI_VARS}} ]]; then just qemu-setup-uefi; fi
-    ISO=$(ls -1t {{ISO_OUT}}/archzfs-*.iso 2>/dev/null | head -n1)
-    if [[ -z "$ISO" ]]; then echo "No ISO found. Run 'just iso-test' or 'just iso-full'."; exit 1; fi
-    bash {{QEMU_SCRIPT}} -i "$ISO" -D {{DISK_IMAGE}} -U {{UEFI_VARS}}
+    just _qemu-boot install
 
 # Boot latest ISO in QEMU with serial console
 qemu-install-serial:
-    #!/usr/bin/env bash
-    if [[ ! -f {{DISK_IMAGE}} ]]; then just qemu-create-disk; fi
-    if [[ ! -f {{UEFI_VARS}} ]]; then just qemu-setup-uefi; fi
-    ISO=$(ls -1t {{ISO_OUT}}/archzfs-*.iso 2>/dev/null | head -n1)
-    if [[ -z "$ISO" ]]; then echo "No ISO found. Run 'just iso-test' or 'just iso-full'."; exit 1; fi
-    bash {{QEMU_SCRIPT}} -i "$ISO" -D {{DISK_IMAGE}} -U {{UEFI_VARS}} -S
+    just _qemu-boot install -S
 
 # Boot existing installation in QEMU with GUI
 qemu-run:
-    #!/usr/bin/env bash
-    if [[ ! -f {{DISK_IMAGE}} ]]; then echo "No disk. Run 'just qemu-install' first."; exit 1; fi
-    bash {{QEMU_SCRIPT}} -D {{DISK_IMAGE}} -U {{UEFI_VARS}}
+    just _qemu-boot run
 
 # Boot existing installation in QEMU with serial console
 qemu-run-serial:
-    #!/usr/bin/env bash
-    if [[ ! -f {{DISK_IMAGE}} ]]; then echo "No disk. Run 'just qemu-install' first."; exit 1; fi
-    bash {{QEMU_SCRIPT}} -D {{DISK_IMAGE}} -U {{UEFI_VARS}} -S
+    just _qemu-boot run -S
 
 # SSH into running VM
 ssh:

--- a/slint-ui/scripts/alongside_review.py
+++ b/slint-ui/scripts/alongside_review.py
@@ -2,22 +2,8 @@
 """Exercise alongside controls and review on safe preview fixtures only."""
 import argparse
 import os
-import time
 from pathlib import Path
 from review import Preview
-from interactions import reveal_by_tab
-
-
-def wait_value(p, role, label, value):
-    """Reveal a focusable control and wait until Rust has set its value."""
-    reveal_by_tab(p, role, label)
-    end = time.monotonic() + 15
-    while time.monotonic() < end:
-        e = p.element(role, label)
-        if e and e.get('accessibleValue') == value:
-            return
-        time.sleep(.1)
-    raise AssertionError(f'{label} did not reach {value}')
 
 
 def run(binary, output, size, scale, small):
@@ -26,60 +12,60 @@ def run(binary, output, size, scale, small):
     prefix = f'{size}-{scale}-{ "small-esp" if small else "reuse" }'
     try:
         p.ready()
-        reveal_by_tab(p, 'Combobox', 'Space source')
+        p.reveal_by_tab('Combobox', 'Space source')
         p.screenshot(prefix + '-initial')
         p.click('Combobox', 'Space source')
         p.click('ListItem', '/dev/nvme0n1p2')
-        reveal_by_tab(p, 'TextInput', 'Allocation in GiB')
+        p.reveal_by_tab('TextInput', 'Allocation in GiB')
         p.click('TextInput', 'Allocation in GiB')
-        p.data('set_element_value', elementHandle=p.wait('TextInput', 'Allocation in GiB')['handle'], value='100')
+        p.fill_labeled('Allocation in GiB', '100')
         p.key('\n')
         if small:
-            reveal_by_tab(p, 'RadioButton', 'Create a separate')
-            reuse = p.data('get_element_properties', elementHandle=p.wait('RadioButton', 'Reuse the selected')['handle'])
+            p.reveal_by_tab('RadioButton', 'Create a separate')
+            reuse = p.properties('RadioButton', 'Reuse the selected')
             assert not reuse.get('accessibleEnabled'), reuse
             p.click('RadioButton', 'Create a separate')
         # Widgets must follow state set by Rust after the user has touched
         # them: "Use all" moves the slider and the input to the capacity.
-        reveal_by_tab(p, 'Checkbox', 'Use all available space')
+        p.reveal_by_tab('Checkbox', 'Use all available space')
         p.click('Checkbox', 'Use all available space')
-        wait_value(p, 'Slider', 'Space for installation', '240')
-        wait_value(p, 'TextInput', 'Allocation in GiB', '240')
+        p.wait_value('Slider', 'Space for installation', '240')
+        p.wait_value('TextInput', 'Allocation in GiB', '240')
         # A refresh keeps the current plan while the layout is unchanged.
-        reveal_by_tab(p, 'Button', 'Refresh disks')
+        p.reveal_by_tab('Button', 'Refresh disks')
         p.click('Button', 'Refresh disks')
-        wait_value(p, 'Combobox', 'Space source', '/dev/nvme0n1p2 — NTFS — 450 GiB')
-        wait_value(p, 'TextInput', 'Allocation in GiB', '240')
+        p.wait_value('Combobox', 'Space source', '/dev/nvme0n1p2 — NTFS — 450 GiB')
+        p.wait_value('TextInput', 'Allocation in GiB', '240')
         assert p.wait('Combobox', 'Space source')['accessibleValue'].startswith('/dev/nvme0n1p2'), 'refresh discarded the selected source'
         p.click('TextInput', 'Allocation in GiB')
-        p.data('set_element_value', elementHandle=p.wait('TextInput', 'Allocation in GiB')['handle'], value='100')
+        p.fill_labeled('Allocation in GiB', '100')
         p.key('\n')
         p.click('Button', 'Review')
         p.click('Button', 'Disk')
-        reveal_by_tab(p, 'Combobox', 'Space source')
+        p.reveal_by_tab('Combobox', 'Space source')
         p.wait('Text', '/dev/nvme0n1p2: 450 →')
         p.screenshot(prefix + '-100gib')
         p.click('Combobox', 'Space source')
         p.click('ListItem', 'Unallocated space')
         p.screenshot(prefix + '-unallocated')
-        reveal_by_tab(p, 'Combobox', 'Swap method')
+        p.reveal_by_tab('Combobox', 'Swap method')
         p.click('Combobox', 'Swap method')
         p.click('ListItem', 'Swap partition')
-        reveal_by_tab(p, 'TextInput', 'Swap size in GiB')
+        p.reveal_by_tab('TextInput', 'Swap size in GiB')
         p.screenshot(prefix + '-swap-controls')
         p.click('Button', 'Review')
         p.wait('Text', 'Storage changes during installation')
         p.screenshot(prefix + '-review')
         p.click('Button', 'Disk')
-        reveal_by_tab(p, 'Combobox', 'Space source')
+        p.reveal_by_tab('Combobox', 'Space source')
         p.screenshot(prefix + '-return')
         p.screenshot(prefix + '-swap-map')
-        reveal_by_tab(p, 'RadioButton', 'Erase a disk')
+        p.reveal_by_tab('RadioButton', 'Erase a disk')
         p.click('RadioButton', 'Erase a disk')
-        reveal_by_tab(p, 'RadioButton', 'Install alongside')
+        p.reveal_by_tab('RadioButton', 'Install alongside')
         p.click('RadioButton', 'Install alongside')
         p.click('Button', 'Review')
-        install = p.data('get_element_properties', elementHandle=p.wait('Button', 'Install')['handle'])
+        install = p.properties('Button', 'Install')
         assert install.get('accessibleEnabled'), install
         p.screenshot(prefix + '-mode-return')
     except Exception:
@@ -110,7 +96,7 @@ def errors(binary, output):
             p.screenshot(case)
             if case != 'ext4':
                 p.click('Button', 'Review')
-                props = p.data('get_element_properties', elementHandle=p.wait('Button', 'Install')['handle'])
+                props = p.properties('Button', 'Install')
                 assert not props.get('accessibleEnabled'), (case, props)
                 p.screenshot(case + '-review')
         finally:

--- a/slint-ui/scripts/design_review.py
+++ b/slint-ui/scripts/design_review.py
@@ -7,11 +7,10 @@ import argparse
 from pathlib import Path
 
 from review import Preview
-from interactions import reveal_by_tab
 
 
 def click_setting(p, name):
-    reveal_by_tab(p, 'Button', name)
+    p.reveal_by_tab('Button', name)
     p.click('Button', name)
 
 
@@ -104,7 +103,7 @@ def desktop(p):
     click_setting(p, 'Profile')
     choice(p, 'Sway')
     p.screenshot('wayland-profile')
-    reveal_by_tab(p, 'Combobox', 'Seat access')
+    p.reveal_by_tab('Combobox', 'Seat access')
     p.click('Combobox', 'Seat access')
     p.screenshot('seat-access-choices')
     p.key('\u001b')

--- a/slint-ui/scripts/interactions.py
+++ b/slint-ui/scripts/interactions.py
@@ -7,16 +7,6 @@ import time
 from review import Preview
 
 
-def reveal_by_tab(p, role, label):
-    """Navigate real focusable controls so an offscreen target scrolls into view."""
-    for _ in range(50):
-        e = p.element(role, label)
-        if e and 100 <= e['absolutePosition']['y'] and e['absolutePosition']['y'] + e['size']['height'] < p.size[1] / p.scale - 70:
-            return
-        p.key('\t')
-    raise AssertionError(f'Cannot reach {label} by Tab')
-
-
 def system(p):
     p.click('Button', 'Hostname')
     p.fill(0, 'arch-workstation-long-name')
@@ -25,7 +15,7 @@ def system(p):
     p.click('Button', 'Kernel')
     p.screenshot('kernel')
     p.click('ListItem', 'linux — compatible')
-    reveal_by_tab(p, 'Button', 'Locale')
+    p.reveal_by_tab('Button', 'Locale')
     p.click('Button', 'Locale')
     p.fill(0, 'ru_RU')
     p.screenshot('locale-filter')
@@ -65,14 +55,14 @@ def desktop(p):
     p.click('Button', 'Optional packages')
     p.screenshot('optional-packages')
     p.click('Button', 'Done')
-    reveal_by_tab(p, 'Button', 'Extra packages')
+    p.reveal_by_tab('Button', 'Extra packages')
     p.screenshot('desktop-scrolled')
     p.click('Button', 'Extra packages')
     p.fill(0, 'fire')
     p.wait('Text', 'firefox')
     p.screenshot('packages')
     p.click('Button', 'Done')
-    reveal_by_tab(p, 'Button', 'Extra services')
+    p.reveal_by_tab('Button', 'Extra services')
     p.click('Button', 'Extra services')
     p.fill(0, 'cups')
     p.click('Button', 'Add')
@@ -213,7 +203,7 @@ def installation_layout(p):
 
 
 def invalid(p):
-    assert not p.data('get_element_properties', elementHandle=p.wait('Button', 'Install')['handle']).get('accessibleEnabled', False)
+    assert not p.properties('Button', 'Install').get('accessibleEnabled', False)
     p.wait('Text', 'Complete setup before installing')
     assert p.element('Button', 'Cancel installation') is None
     p.screenshot('validation-blocks-installation')

--- a/slint-ui/scripts/review.py
+++ b/slint-ui/scripts/review.py
@@ -78,6 +78,16 @@ class Preview:
         inputs = [e for e in self.tree()['elements'] if e.get('accessibleRole') == 'TextInput']
         self.data('set_element_value', elementHandle=inputs[index]['handle'], value=value)
 
+    def fill_labeled(self, label, value):
+        self.data('set_element_value', elementHandle=self.wait('TextInput', label)['handle'], value=value)
+
+    def properties(self, role, label):
+        return self.data('get_element_properties', elementHandle=self.wait(role, label)['handle'])
+
+    def select(self, label, option):
+        self.click('Combobox', label)
+        self.click('ListItem', option)
+
     def key(self, text):
         self.data('dispatch_key_event', windowHandle=self.window, text=text)
 
@@ -92,6 +102,26 @@ class Preview:
 
     def click(self, role, label):
         self.data('click_element', elementHandle=self.wait(role, label)['handle'])
+
+    def reveal_by_tab(self, role, label):
+        """Navigate real focusable controls so an offscreen target scrolls into view."""
+        for _ in range(50):
+            e = self.element(role, label)
+            if e and 100 <= e['absolutePosition']['y'] and e['absolutePosition']['y'] + e['size']['height'] < self.size[1] / self.scale - 70:
+                return
+            self.key('\t')
+        raise AssertionError(f'Cannot reach {label} by Tab')
+
+    def wait_value(self, role, label, value):
+        """Reveal a focusable control and wait until Rust has set its value."""
+        self.reveal_by_tab(role, label)
+        end = time.monotonic() + 15
+        while time.monotonic() < end:
+            e = self.element(role, label)
+            if e and e.get('accessibleValue') == value:
+                return
+            time.sleep(.1)
+        raise AssertionError(f'{label} did not reach {value}')
 
     def close(self):
         self.process.terminate()

--- a/slint-ui/scripts/storage_review.py
+++ b/slint-ui/scripts/storage_review.py
@@ -9,22 +9,9 @@ from pathlib import Path
 from review import Preview
 
 
-def properties(p, role, label):
-    return p.data("get_element_properties", elementHandle=p.wait(role, label)["handle"])
-
-
-def fill(p, label, value):
-    p.data("set_element_value", elementHandle=p.wait("TextInput", label)["handle"], value=value)
-
-
-def select(p, label, option):
-    p.click('Combobox', label)
-    p.click('ListItem', option)
-
-
 def assign(p, label, device):
     p.click('Button', label)
-    fill(p, 'Search storage', device)
+    p.fill_labeled('Search storage', device)
     p.click('ListItem', device)
     p.click('Button', 'Use this device')
 
@@ -33,15 +20,15 @@ def storage(p):
     p.click('Button', 'Change New ZFS pool')
     p.wait('ListItem', '/dev/nvme0n1p2')
     p.screenshot('partition-picker')
-    fill(p, 'Search storage', '/dev/sdb')
+    p.fill_labeled('Search storage', '/dev/sdb')
     p.wait('ListItem', '/dev/sdb1')
-    assert properties(p, 'ListItem', '/dev/sdb1').get('accessibleEnabled', False) is False
+    assert p.properties('ListItem', '/dev/sdb1').get('accessibleEnabled', False) is False
     p.screenshot('installer-media-unavailable')
-    fill(p, 'Search storage', '/dev/nvme0n1p1')
+    p.fill_labeled('Search storage', '/dev/nvme0n1p1')
     p.wait('ListItem', '/dev/nvme0n1p1')
-    assert properties(p, 'ListItem', '/dev/nvme0n1p1').get('accessibleEnabled', False) is False
+    assert p.properties('ListItem', '/dev/nvme0n1p1').get('accessibleEnabled', False) is False
     p.screenshot('efi-role-unavailable')
-    fill(p, 'Search storage', '/dev/sda4')
+    p.fill_labeled('Search storage', '/dev/sda4')
     p.click('ListItem', '/dev/sda4')
     p.click('Button', 'Details')
     p.screenshot('selected-partition-details')
@@ -49,9 +36,9 @@ def storage(p):
     p.wait('Text', '/dev/sda4')
     p.screenshot('new-pool-assigned')
     p.click('Button', 'Change EFI boot partition')
-    fill(p, 'Search storage', '/dev/sda4')
+    p.fill_labeled('Search storage', '/dev/sda4')
     p.wait('ListItem', '/dev/sda4')
-    assert properties(p, 'ListItem', '/dev/sda4').get('accessibleEnabled', False) is False
+    assert p.properties('ListItem', '/dev/sda4').get('accessibleEnabled', False) is False
     p.key('\u001b')
     p.wait('Button', 'Change EFI boot partition')
     p.screenshot('cancel-preserves-selection')
@@ -59,13 +46,13 @@ def storage(p):
     p.click('TextInput', 'New pool name')
     p.key('\t')
     p.key('reviewbe')
-    assert properties(p, 'TextInput', 'Boot environment')['accessibleValue'] == 'reviewbe'
+    assert p.properties('TextInput', 'Boot environment')['accessibleValue'] == 'reviewbe'
     p.wait('Text', '2 / 6')  # Tab moves through fields, not wizard steps.
-    select(p, 'Encryption', 'Encrypt base dataset only')
+    p.select('Encryption', 'Encrypt base dataset only')
     p.click('TextInput', 'Encryption passphrase')
-    fill(p, 'Encryption passphrase', 'a preview passphrase 123 qjk')
+    p.fill_labeled('Encryption passphrase', 'a preview passphrase 123 qjk')
     p.key('\t')
-    select(p, 'Swap method', 'Swap partition (encrypted)')
+    p.select('Swap method', 'Swap partition (encrypted)')
     p.key('\t')
     assign(p, 'Choose Swap partition', '/dev/sda2')
     p.screenshot('zfs-encryption-swap')
@@ -74,7 +61,7 @@ def storage(p):
     p.screenshot('zfs-additional-settings')
     p.click('Button', 'Review')
     p.wait('Text', 'Storage changes during installation')
-    assert properties(p, 'Button', 'Install').get('accessibleEnabled', False) is True
+    assert p.properties('Button', 'Install').get('accessibleEnabled', False) is True
     p.screenshot('new-pool-review')
     p.click('Button', 'Edit ZFS')
     p.wait('Text', '2 / 6')
@@ -91,23 +78,23 @@ def storage(p):
     p.click('Button', 'ZFS')
     p.click('TextInput', 'Boot environment')
     p.key('\t'); p.key('\t'); p.key('\t')
-    select(p, 'Swap method', 'None')
-    fill(p, 'Boot environment', 'previous')  # Existing mode has one inline name: the environment.
+    p.select('Swap method', 'None')
+    p.fill_labeled('Boot environment', 'previous')  # Existing mode has one inline name: the environment.
     p.click('Button', 'Review')
-    assert properties(p, 'Button', 'Install').get('accessibleEnabled', False) is False
+    assert p.properties('Button', 'Install').get('accessibleEnabled', False) is False
     p.screenshot('existing-environment-conflict')
     p.click('Button', 'Edit ZFS')
-    fill(p, 'Boot environment', 'freshbe')
+    p.fill_labeled('Boot environment', 'freshbe')
     p.click('Button', 'Review')
-    assert properties(p, 'Button', 'Install').get('accessibleEnabled', False) is True
+    assert p.properties('Button', 'Install').get('accessibleEnabled', False) is True
     p.screenshot('existing-pool-review')
     p.click('Button', 'Disk')
     p.click('RadioButton', 'Erase a disk')
     p.click('Button', 'Choose Disk to erase')
     p.wait('ListItem', '/dev/sdb')
-    assert not properties(p, 'ListItem', '/dev/sdb').get('accessibleEnabled', False)
+    assert not p.properties('ListItem', '/dev/sdb').get('accessibleEnabled', False)
     p.screenshot('disk-picker')
-    fill(p, 'Search storage', '/dev/sda')
+    p.fill_labeled('Search storage', '/dev/sda')
     p.click('ListItem', '/dev/sda')
     p.click('Button', 'Details')
     p.screenshot('disk-details')
@@ -115,27 +102,27 @@ def storage(p):
     p.wait('Text', '/dev/sda')
     p.screenshot('full-disk-assigned')
     p.click('Button', 'ZFS')
-    fill(p, 'New pool name', 'newroot')
+    p.fill_labeled('New pool name', 'newroot')
     p.click('Button', 'Review')
-    assert properties(p, 'Button', 'Install').get('accessibleEnabled', False) is True
+    assert p.properties('Button', 'Install').get('accessibleEnabled', False) is True
     p.screenshot('full-disk-review')
 
 
 def keyboard(p):
     p.click('Button', 'Change EFI boot partition')
-    fill(p, 'Search storage', '/dev/sda1')
+    p.fill_labeled('Search storage', '/dev/sda1')
     p.click('ListItem', '/dev/sda1')
     p.click('TextInput', 'Search storage')
     for _ in range(6):
         p.key('\t')
     p.key('no-match')
-    assert 'no-match' in properties(p, 'TextInput', 'Search storage')['accessibleValue']
+    assert 'no-match' in p.properties('TextInput', 'Search storage')['accessibleValue']
     p.wait('Text', 'No matches.')
     p.key('\u001b')
     p.key('\t')
     p.key('\n')  # Cancel returns to EFI; Tab reaches the ZFS assignment below it.
     p.wait('Text', 'Choose a ZFS partition')
-    fill(p, 'Search storage', '/dev/sda4')
+    p.fill_labeled('Search storage', '/dev/sda4')
     p.key('\t'); p.key('\t')  # Focus the list, then select by arrows.
     p.key('\uf701')
     p.wait('Text', 'Selected: /dev/sda4')
@@ -149,14 +136,14 @@ def edge(p, fixture):
     p.click('Button', 'Choose New ZFS pool' if fixture == 'empty' else 'Change New ZFS pool')
     if fixture == 'empty':
         p.wait('Text', 'No devices found.')
-        assert properties(p, 'Button', 'Use this device').get('accessibleEnabled', False) is False
+        assert p.properties('Button', 'Use this device').get('accessibleEnabled', False) is False
     elif fixture == 'many':
-        fill(p, 'Search storage', '/dev/sda20')
+        p.fill_labeled('Search storage', '/dev/sda20')
         p.click('ListItem', '/dev/sda20')
         p.click('Button', 'Use this device')
         p.wait('Text', '/dev/sda20')
     else:
-        fill(p, 'Search storage', '/dev/sda4')
+        p.fill_labeled('Search storage', '/dev/sda4')
         p.wait('ListItem', '/dev/sda4')
     p.screenshot('fixture-' + fixture)
 

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -43,14 +43,47 @@ struct Session {
     kept: Option<Request>,
     notice: String,
 }
-/// The user changed a control: the loaded plan no longer applies.
-fn touched() {
-    SESSION.with_borrow_mut(|s| {
-        s.kept = None;
-        s.notice.clear();
-    });
-}
 thread_local! { static SESSION: RefCell<Session> = RefCell::default(); }
+impl Session {
+    fn with<R>(f: impl FnOnce(&Session) -> R) -> R {
+        SESSION.with_borrow(f)
+    }
+    fn update<R>(f: impl FnOnce(&mut Session) -> R) -> R {
+        SESSION.with_borrow_mut(f)
+    }
+    /// The user changed a control: the loaded plan no longer applies.
+    fn touch() {
+        Self::update(|s| {
+            s.kept = None;
+            s.notice.clear();
+        });
+    }
+    fn disk(index: usize) -> Option<PathBuf> {
+        Self::with(|s| s.disks.get(index).cloned())
+    }
+    fn set_disks(disks: Vec<PathBuf>) {
+        Self::update(|s| s.disks = disks);
+    }
+    fn survey() -> Option<Survey> {
+        Self::with(|s| s.survey.clone())
+    }
+    fn set_survey(survey: Option<Survey>) {
+        Self::update(|s| s.survey = survey);
+    }
+    /// Shows and executes `request` as written for the surveyed layout.
+    fn keep(survey: Survey, request: Request) {
+        Self::update(|s| {
+            s.survey = Some(survey);
+            s.kept = Some(request);
+        });
+    }
+    fn notice() -> String {
+        Self::with(|s| s.notice.clone())
+    }
+    fn set_notice(notice: &str) {
+        Self::update(|s| s.notice = notice.into());
+    }
+}
 fn strings(values: Vec<String>) -> ModelRc<slint::SharedString> {
     ModelRc::new(VecModel::from(
         values.into_iter().map(Into::into).collect::<Vec<_>>(),
@@ -240,15 +273,12 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
     state.set_generation(generation);
     state.set_busy(true);
     state.set_error("".into());
-    SESSION.with_borrow_mut(|s| {
-        s.kept = None;
-        s.notice.clear();
-    });
+    Session::touch();
     state.invoke_rebuild();
     let disk = index
-        .and_then(|i| SESSION.with_borrow(|s| s.disks.get(i).cloned()))
+        .and_then(Session::disk)
         .or_else(|| keep.as_ref().map(|r| r.before.device.clone()));
-    let previous = SESSION.with_borrow(|s| s.survey.clone());
+    let previous = Session::survey();
     let weak = app.as_weak();
     tokio::spawn(async move {
         let result = tokio::task::spawn_blocking(move || -> Result<_, String> {
@@ -297,7 +327,7 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
             let result = result.and_then(|(paths, names, selected_index, inspected)| {
                 state.set_disks(strings(names));
                 state.set_disk_index(selected_index as i32);
-                SESSION.with_borrow_mut(|s| s.disks = paths);
+                Session::set_disks(paths);
                 inspected
             });
             match result {
@@ -329,17 +359,14 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                         if r.swap_bytes > 0 {
                             state.set_swap_size((r.swap_bytes / GIB) as f32);
                         }
-                        SESSION.with_borrow_mut(|s| {
-                            s.survey = Some(survey);
-                            s.kept = Some(r);
-                        });
+                        Session::keep(survey, r);
                         state.invoke_rebuild();
                         return;
                     }
                     if keep.is_some() {
-                        SESSION.with_borrow_mut(|s| {
-                            s.notice = "The previous plan no longer matches this disk; this is a new plan built from the current layout.".into()
-                        });
+                        Session::set_notice(
+                            "The previous plan no longer matches this disk; this is a new plan built from the current layout.",
+                        );
                     }
                     state.set_source_index(
                         survey
@@ -371,13 +398,11 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                     );
                     state.set_additional_efi(false);
                     state.set_use_all(true);
-                    SESSION.with_borrow_mut(|s| {
-                        s.survey = Some(survey);
-                    });
+                    Session::set_survey(Some(survey));
                     state.invoke_rebuild();
                 }
                 Err(error) => {
-                    SESSION.with_borrow_mut(|s| s.survey = None);
+                    Session::set_survey(None);
                     state.set_before(Default::default());
                     state.set_after(Default::default());
                     state.set_sources(Default::default());
@@ -520,19 +545,18 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
     // A kept plan whose swap no longer matches the configured method (changed
     // while another storage mode was selected) is rebuilt from the controls.
     let wants_swap = config.swap_mode.uses_partition();
-    SESSION.with_borrow_mut(|s| {
-        if s.kept
+    let stale = Session::with(|s| {
+        s.kept
             .as_ref()
             .is_some_and(|k| (k.swap_bytes > 0) != wants_swap)
-        {
-            s.kept = None;
-            s.notice.clear();
-        }
     });
+    if stale {
+        Session::touch();
+    }
     state.set_allocation_summary("".into());
     state.set_insufficient(false);
     state.set_efi_details("".into());
-    let result = SESSION.with_borrow(|session| -> Result<Request, String> {
+    let result = Session::with(|session| -> Result<Request, String> {
         let kept = session.kept.as_ref();
         let s = session.survey.as_ref().ok_or("Select a disk")?;
         state.set_before(segments(&s.layout, None));
@@ -621,7 +645,7 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         Ok(request) => {
             config.alongside = Some(request);
             state.set_error("".into());
-            let notice = SESSION.with_borrow(|s| s.notice.clone());
+            let notice = Session::notice();
             if !notice.is_empty() {
                 state.set_details(format!("{notice} {}", state.get_details()).into());
             }
@@ -666,7 +690,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let weak = app.as_weak();
     app.global::<AlongsideState>()
         .on_select_source(move |index| {
-            touched();
+            Session::touch();
             if let Some(app) = weak.upgrade() {
                 let s = app.global::<AlongsideState>();
                 s.set_source_index(index);
@@ -676,7 +700,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
         });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_select_efi(move |index| {
-        touched();
+        Session::touch();
         if let Some(app) = weak.upgrade() {
             let s = app.global::<AlongsideState>();
             s.set_efi_index(index);
@@ -686,7 +710,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_allocate(move |value| {
-        touched();
+        Session::touch();
         if let Some(app) = weak.upgrade()
             && value.is_finite()
         {
@@ -698,7 +722,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_all_space(move |value| {
-        touched();
+        Session::touch();
         if let Some(app) = weak.upgrade() {
             let s = app.global::<AlongsideState>();
             s.set_use_all(value);
@@ -708,7 +732,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let weak = app.as_weak();
     let cfg = config.clone();
     app.global::<AlongsideState>().on_select_swap(move |index| {
-        touched();
+        Session::touch();
         if let Some(app) = weak.upgrade()
             && let Some(mode) = SwapMode::from_index(index as usize)
         {
@@ -718,7 +742,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_size_swap(move |value| {
-        touched();
+        Session::touch();
         if let Some(app) = weak.upgrade()
             && value.is_finite()
         {
@@ -729,7 +753,7 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     });
     let weak = app.as_weak();
     app.global::<AlongsideState>().on_additional(move |value| {
-        touched();
+        Session::touch();
         if let Some(app) = weak.upgrade() {
             let s = app.global::<AlongsideState>();
             s.set_additional_efi(value);

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -113,7 +113,17 @@ fn survey(disk: &std::path::Path, previous: Option<&Survey>) -> Result<Survey, S
             ),
             Err(e) => (0, format!("{e:#}")),
         };
-        sources.push(Source { source: SpaceSource::Shrink { partition: number }, label, capacity, detail: format!("Keep {} at its current start; reduce only its end. Up to {:.0} GiB can be allocated here.", p.node.display(), gib(capacity)), error });
+        sources.push(Source {
+            source: SpaceSource::Shrink { partition: number },
+            label,
+            capacity,
+            detail: format!(
+                "Keep {} at its current start; reduce only its end. Up to {:.0} GiB can be allocated here.",
+                p.node.display(),
+                gib(capacity)
+            ),
+            error,
+        });
     }
     for (start, end) in layout.free_extents().map_err(|e| e.to_string())? {
         let alignment = MIB / layout.sectorsize;
@@ -176,10 +186,36 @@ fn fixture() -> Survey {
         ],
     };
     let low = std::env::var("AZFS_PREVIEW_ESP").as_deref() == Ok("small");
-    let mut survey = Survey { layout: layout.clone(), sources: vec![
-        Source { source: SpaceSource::Shrink { partition: 2 }, label: "/dev/nvme0n1p2 — NTFS — 450 GiB".into(), capacity: 240 * GIB, detail: "Windows keeps at least 210 GiB, including working space. Only the end of this partition will move.".into(), error: String::new() },
-        Source { source: SpaceSource::Unallocated { start: 452 * GIB / 512, end: layout.lastlba + 1 }, label: "Unallocated space — 60 GiB".into(), capacity: ((layout.lastlba + 1) * 512 - 452 * GIB) / MIB * MIB, detail: "Use free space without resizing Windows.".into(), error: String::new() },
-    ], efis: vec![Efi { number: 1, label: "/dev/nvme0n1p1 — EFI — 500 MiB".into(), space: Ok(EfiSpace { partition: 1, free_bytes: if low { 40 * MIB } else { 350 * MIB } }) }] };
+    let mut survey = Survey {
+        layout: layout.clone(),
+        sources: vec![
+            Source {
+                source: SpaceSource::Shrink { partition: 2 },
+                label: "/dev/nvme0n1p2 — NTFS — 450 GiB".into(),
+                capacity: 240 * GIB,
+                detail: "Windows keeps at least 210 GiB, including working space. Only the end of this partition will move.".into(),
+                error: String::new(),
+            },
+            Source {
+                source: SpaceSource::Unallocated {
+                    start: 452 * GIB / 512,
+                    end: layout.lastlba + 1,
+                },
+                label: "Unallocated space — 60 GiB".into(),
+                capacity: ((layout.lastlba + 1) * 512 - 452 * GIB) / MIB * MIB,
+                detail: "Use free space without resizing Windows.".into(),
+                error: String::new(),
+            },
+        ],
+        efis: vec![Efi {
+            number: 1,
+            label: "/dev/nvme0n1p1 — EFI — 500 MiB".into(),
+            space: Ok(EfiSpace {
+                partition: 1,
+                free_bytes: if low { 40 * MIB } else { 350 * MIB },
+            }),
+        }],
+    };
     match std::env::var("AZFS_PREVIEW_ALONGSIDE").as_deref() {
         Ok("ext4") => {
             survey.layout.partitions[1].kind = LINUX_TYPE.into();
@@ -188,7 +224,9 @@ fn fixture() -> Survey {
         }
         Ok("missing-tools") => {
             survey.sources[0].capacity = 0;
-            survey.sources[0].error = "Resizing NTFS requires ntfsresize (package ntfs-3g). Install it in the live system and refresh, or use unallocated space.".into();
+            survey.sources[0].error =
+                "Resizing NTFS requires ntfsresize (package ntfs-3g). Install it in the live system and refresh, or use unallocated space."
+                    .into();
         }
         Ok("no-efi") => survey.efis.clear(),
         _ => {}
@@ -219,7 +257,14 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                     vec![PathBuf::from("/dev/nvme0n1")],
                     vec!["Samsung SSD — 512 GiB".into()],
                     0,
-                    if std::env::var("AZFS_PREVIEW_ALONGSIDE").as_deref() == Ok("mbr") { Err("This disk does not use GPT. Automatic MBR conversion is not supported; existing data has not been changed.".into()) } else { Ok(fixture()) },
+                    if std::env::var("AZFS_PREVIEW_ALONGSIDE").as_deref() == Ok("mbr") {
+                        Err(
+                            "This disk does not use GPT. Automatic MBR conversion is not supported; existing data has not been changed."
+                                .into(),
+                        )
+                    } else {
+                        Ok(fixture())
+                    },
                 ));
             }
             let disks = device::disk_choices().map_err(|e| e.to_string())?;
@@ -228,7 +273,9 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                 .iter()
                 .map(|d| format!("{} — {} — {}", d.label, d.model, d.size))
                 .collect::<Vec<_>>();
-            let same = |a: &PathBuf, b: &PathBuf| a == b || a.canonicalize().ok() == b.canonicalize().ok();
+            let same = |a: &PathBuf, b: &PathBuf| {
+                a == b || a.canonicalize().ok() == b.canonicalize().ok()
+            };
             let selected_index = disk
                 .as_ref()
                 .and_then(|d| paths.iter().position(|p| same(p, d)))
@@ -266,7 +313,10 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                     // still describes this disk.
                     let kept = keep.as_ref().and_then(|r| {
                         let source = survey.sources.iter().position(|s| s.source == r.source)?;
-                        let efi = survey.efis.iter().position(|e| e.number == r.efi.existing_partition())?;
+                        let efi = survey
+                            .efis
+                            .iter()
+                            .position(|e| e.number == r.efi.existing_partition())?;
                         (r.before == survey.layout).then_some((source, efi))
                     });
                     if let Some((source, efi)) = kept {
@@ -287,7 +337,9 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                         return;
                     }
                     if keep.is_some() {
-                        SESSION.with_borrow_mut(|s| s.notice = "The previous plan no longer matches this disk; this is a new plan built from the current layout.".into());
+                        SESSION.with_borrow_mut(|s| {
+                            s.notice = "The previous plan no longer matches this disk; this is a new plan built from the current layout.".into()
+                        });
                     }
                     state.set_source_index(
                         survey
@@ -405,6 +457,55 @@ fn segments(layout: &Layout, plan: Option<&Plan>) -> ModelRc<DiskSegment> {
     ))
 }
 
+/// Swap reserved inside the allocation: the kept plan's figure, or the
+/// configured size when a swap partition is wanted.
+fn planned_swap_bytes(
+    kept: Option<&Request>,
+    config: &GlobalConfig,
+    state: &AlongsideState,
+) -> u64 {
+    if let Some(k) = kept {
+        k.swap_bytes
+    } else if config.swap_mode.uses_partition() {
+        state.get_swap_size().round().clamp(1.0, 1024.0) as u64 * GIB
+    } else {
+        0
+    }
+}
+
+/// How much of the existing ESP the boot files need, and what reusing it means.
+fn efi_details(space: &EfiSpace, budget: BootSpace, insufficient: bool) -> Result<String, String> {
+    let required = budget
+        .required_bytes()
+        .map_err(|e| e.to_string())?
+        .div_ceil(MIB);
+    let consequence = if insufficient {
+        "It cannot be reused; select a separate EFI partition to continue."
+    } else if space.free_bytes < required + budget.image_bytes {
+        "Later ZFSBootMenu updates replace the image in place instead of writing a second copy first."
+    } else {
+        "Reusing it formats nothing and keeps the existing loaders."
+    };
+    Ok(format!(
+        "{} MiB free; {required} MiB is needed to reuse it. {consequence}",
+        space.free_bytes / MIB
+    ))
+}
+
+fn allocation_summary(plan: &Plan, layout: &Layout, swap_bytes: u64) -> String {
+    let zfs_sectors = plan.swap_start.unwrap_or(plan.end) - plan.zfs_start;
+    let efi = if plan.efi_start.is_some() {
+        " · New EFI: 512 MiB"
+    } else {
+        " · Existing EFI reused"
+    };
+    format!(
+        "New ZFS pool: {:.1} GiB · Swap: {} GiB{efi}",
+        sectors_gib(zfs_sectors, layout.sectorsize),
+        swap_bytes / GIB
+    )
+}
+
 fn rebuild(app: &App, config: &mut GlobalConfig) {
     if config.installation_mode != Some(InstallationMode::Alongside) {
         return;
@@ -434,33 +535,85 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
     let result = SESSION.with_borrow(|session| -> Result<Request, String> {
         let kept = session.kept.as_ref();
         let s = session.survey.as_ref().ok_or("Select a disk")?;
-        state.set_before(segments(&s.layout, None)); state.set_after(segments(&s.layout, None));
-        let source = s.sources.get(state.get_source_index() as usize).ok_or("No suitable partitions or unallocated space")?;
+        state.set_before(segments(&s.layout, None));
+        state.set_after(segments(&s.layout, None));
+        let source = s
+            .sources
+            .get(state.get_source_index() as usize)
+            .ok_or("No suitable partitions or unallocated space")?;
         state.set_details(source.detail.clone().into());
-        let swap_bytes = if let Some(k) = kept { k.swap_bytes } else if config.swap_mode.uses_partition() { state.get_swap_size().round().clamp(1.0, 1024.0) as u64 * GIB } else { 0 };
-        let min = gib(MIN_LINUX_BYTES + swap_bytes + if state.get_additional_efi() { ESP_BYTES } else { 0 }) as f32;
+        let swap_bytes = planned_swap_bytes(kept, config, &state);
+        let extra = if state.get_additional_efi() {
+            ESP_BYTES
+        } else {
+            0
+        };
+        let min = gib(MIN_LINUX_BYTES + swap_bytes + extra) as f32;
         let max = gib(source.capacity) as f32;
-        state.set_minimum(min); state.set_maximum(max);
+        state.set_minimum(min);
+        state.set_maximum(max);
         let all_bytes = source.capacity / MIB * MIB;
-        let allocation_bytes = if let Some(k) = kept { k.allocation_bytes } else if state.get_use_all() { all_bytes } else { (state.get_allocation().round().max(min) as u64).saturating_mul(GIB).min(all_bytes) };
+        let allocation_bytes = if let Some(k) = kept {
+            k.allocation_bytes
+        } else if state.get_use_all() {
+            all_bytes
+        } else {
+            (state.get_allocation().round().max(min) as u64)
+                .saturating_mul(GIB)
+                .min(all_bytes)
+        };
         state.set_allocation((gib(allocation_bytes) * 10.0).round() as f32 / 10.0);
-        let efi = s.efis.get(state.get_efi_index() as usize).ok_or("No existing EFI partition on this disk. Prepare an EFI partition before using this mode.")?;
+        let efi = s.efis.get(state.get_efi_index() as usize).ok_or(
+            "No existing EFI partition on this disk. Prepare an EFI partition before using this mode.",
+        )?;
         let space = efi.space.as_ref().map_err(Clone::clone)?;
         let budget = BootSpace::default();
         let insufficient = !space.sufficient(budget).map_err(|e| e.to_string())?;
         state.set_insufficient(insufficient);
-        let required = budget.required_bytes().map_err(|e| e.to_string())?.div_ceil(MIB);
-        state.set_efi_details(format!("{} MiB free; {required} MiB is needed to reuse it. {}", space.free_bytes / MIB, if insufficient { "It cannot be reused; select a separate EFI partition to continue." } else if space.free_bytes < required + budget.image_bytes { "Later ZFSBootMenu updates replace the image in place instead of writing a second copy first." } else { "Reusing it formats nothing and keeps the existing loaders." }).into());
-        if !source.error.is_empty() { return Err(source.error.clone()); }
-        if max < min { return Err(format!("At least {min:.0} GiB is needed for the ZFS pool, swap and EFI; only {max:.1} GiB is available. Reduce swap or choose another source.")); }
-        let efi_choice = if state.get_additional_efi() { EfiChoice::CreateSeparate { existing_partition: efi.number } } else { EfiChoice::Reuse { partition: efi.number } };
-        efi_choice.validate_space(space, budget).map_err(|e| e.to_string())?;
-        let request = match kept { Some(k) => k.clone(), None => Request { before: s.layout.clone(), source: source.source.clone(), efi: efi_choice, allocation_bytes, swap_bytes } };
+        state.set_efi_details(efi_details(space, budget, insufficient)?.into());
+        if !source.error.is_empty() {
+            return Err(source.error.clone());
+        }
+        if max < min {
+            return Err(format!(
+                "At least {min:.0} GiB is needed for the ZFS pool, swap and EFI; only {max:.1} GiB is available. Reduce swap or choose another source."
+            ));
+        }
+        let efi_choice = if state.get_additional_efi() {
+            EfiChoice::CreateSeparate {
+                existing_partition: efi.number,
+            }
+        } else {
+            EfiChoice::Reuse {
+                partition: efi.number,
+            }
+        };
+        efi_choice
+            .validate_space(space, budget)
+            .map_err(|e| e.to_string())?;
+        let request = match kept {
+            Some(k) => k.clone(),
+            None => Request {
+                before: s.layout.clone(),
+                source: source.source.clone(),
+                efi: efi_choice,
+                allocation_bytes,
+                swap_bytes,
+            },
+        };
         let plan = request.plan().map_err(|e| e.to_string())?;
         state.set_after(segments(&s.layout, Some(&plan)));
-        state.set_allocation_summary(format!("New ZFS pool: {:.1} GiB · Swap: {} GiB{}", sectors_gib(plan.swap_start.unwrap_or(plan.end) - plan.zfs_start, s.layout.sectorsize), swap_bytes / GIB, if plan.efi_start.is_some() { " · New EFI: 512 MiB" } else { " · Existing EFI reused" }).into());
+        state.set_allocation_summary(allocation_summary(&plan, &s.layout, swap_bytes).into());
         if let Some((old, size)) = &plan.shrink {
-            state.set_details(format!("{}: {:.0} → {:.0} GiB. Its start and existing data are preserved.", old.node.display(), sectors_gib(old.size, s.layout.sectorsize), sectors_gib(*size, s.layout.sectorsize)).into());
+            state.set_details(
+                format!(
+                    "{}: {:.0} → {:.0} GiB. Its start and existing data are preserved.",
+                    old.node.display(),
+                    sectors_gib(old.size, s.layout.sectorsize),
+                    sectors_gib(*size, s.layout.sectorsize)
+                )
+                .into(),
+            );
         }
         Ok(request)
     });

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -423,10 +423,7 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
     state.set_swap_mode(config.swap_mode.index() as i32);
     // A kept plan whose swap no longer matches the configured method (changed
     // while another storage mode was selected) is rebuilt from the controls.
-    let wants_swap = matches!(
-        config.swap_mode,
-        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-    );
+    let wants_swap = config.swap_mode.uses_partition();
     SESSION.with_borrow_mut(|s| {
         if s.kept
             .as_ref()
@@ -445,7 +442,7 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         state.set_before(segments(&s.layout, None)); state.set_after(segments(&s.layout, None));
         let source = s.sources.get(state.get_source_index() as usize).ok_or("No suitable partitions or unallocated space")?;
         state.set_details(source.detail.clone().into());
-        let swap_bytes = if let Some(k) = kept { k.swap_bytes } else if matches!(config.swap_mode, SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted) { state.get_swap_size().round().clamp(1.0, 1024.0) as u64 * GIB } else { 0 };
+        let swap_bytes = if let Some(k) = kept { k.swap_bytes } else if config.swap_mode.uses_partition() { state.get_swap_size().round().clamp(1.0, 1024.0) as u64 * GIB } else { 0 };
         let min = (MIN_LINUX_BYTES + swap_bytes + if state.get_additional_efi() { ESP_BYTES } else { 0 }) as f32 / GIB as f32;
         let max = source.capacity as f64 / GIB as f64;
         let max = max as f32;

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -687,77 +687,64 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
             rebuild(&app, &mut cfg.borrow_mut());
         }
     });
-    let weak = app.as_weak();
-    app.global::<AlongsideState>()
-        .on_select_source(move |index| {
-            Session::touch();
-            if let Some(app) = weak.upgrade() {
-                let s = app.global::<AlongsideState>();
-                s.set_source_index(index);
-                s.set_use_all(true);
-                s.invoke_rebuild();
-            }
-        });
-    let weak = app.as_weak();
-    app.global::<AlongsideState>().on_select_efi(move |index| {
-        Session::touch();
-        if let Some(app) = weak.upgrade() {
-            let s = app.global::<AlongsideState>();
-            s.set_efi_index(index);
-            s.set_additional_efi(false);
-            s.invoke_rebuild();
+    let state = app.global::<AlongsideState>();
+    state.on_select_source(edit(app, |s, index: i32| {
+        s.set_source_index(index);
+        s.set_use_all(true);
+        true
+    }));
+    state.on_select_efi(edit(app, |s, index: i32| {
+        s.set_efi_index(index);
+        s.set_additional_efi(false);
+        true
+    }));
+    state.on_allocate(edit(app, |s, value: f32| {
+        if !value.is_finite() {
+            return false;
         }
-    });
-    let weak = app.as_weak();
-    app.global::<AlongsideState>().on_allocate(move |value| {
-        Session::touch();
-        if let Some(app) = weak.upgrade()
-            && value.is_finite()
-        {
-            let s = app.global::<AlongsideState>();
-            s.set_use_all(false);
-            s.set_allocation(value);
-            s.invoke_rebuild();
-        }
-    });
-    let weak = app.as_weak();
-    app.global::<AlongsideState>().on_all_space(move |value| {
-        Session::touch();
-        if let Some(app) = weak.upgrade() {
-            let s = app.global::<AlongsideState>();
-            s.set_use_all(value);
-            s.invoke_rebuild();
-        }
-    });
-    let weak = app.as_weak();
+        s.set_use_all(false);
+        s.set_allocation(value);
+        true
+    }));
+    state.on_all_space(edit(app, |s, value: bool| {
+        s.set_use_all(value);
+        true
+    }));
     let cfg = config.clone();
-    app.global::<AlongsideState>().on_select_swap(move |index| {
-        Session::touch();
-        if let Some(app) = weak.upgrade()
-            && let Some(mode) = SwapMode::from_index(index as usize)
-        {
-            cfg.borrow_mut().swap_mode = mode;
-            app.global::<AlongsideState>().invoke_rebuild();
+    state.on_select_swap(edit(app, move |_, index: i32| {
+        let Some(mode) = SwapMode::from_index(index as usize) else {
+            return false;
+        };
+        cfg.borrow_mut().swap_mode = mode;
+        true
+    }));
+    state.on_size_swap(edit(app, |s, value: f32| {
+        if !value.is_finite() {
+            return false;
         }
-    });
+        s.set_swap_size(value.round().clamp(1.0, 1024.0));
+        true
+    }));
+    state.on_additional(edit(app, |s, value: bool| {
+        s.set_additional_efi(value);
+        true
+    }));
+}
+
+/// A handler for one edited control. The loaded plan no longer applies;
+/// `apply` changes the state and returns whether the plan must be rebuilt.
+fn edit<T: 'static>(
+    app: &App,
+    apply: impl Fn(&AlongsideState, T) -> bool + 'static,
+) -> impl Fn(T) + 'static {
     let weak = app.as_weak();
-    app.global::<AlongsideState>().on_size_swap(move |value| {
-        Session::touch();
-        if let Some(app) = weak.upgrade()
-            && value.is_finite()
-        {
-            let s = app.global::<AlongsideState>();
-            s.set_swap_size(value.round().clamp(1.0, 1024.0));
-            s.invoke_rebuild();
-        }
-    });
-    let weak = app.as_weak();
-    app.global::<AlongsideState>().on_additional(move |value| {
+    move |value| {
         Session::touch();
         if let Some(app) = weak.upgrade() {
-            let s = app.global::<AlongsideState>();
-            s.set_additional_efi(value);
-            s.invoke_rebuild();
+            let state = app.global::<AlongsideState>();
+            if apply(&state, value) {
+                state.invoke_rebuild();
+            }
         }
-    });
+    }
 }

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -1,5 +1,6 @@
 //! Read-only discovery and editable preview of the shared alongside plan.
 use crate::{
+    busy::{self, Guarded},
     format::{gib, sectors_gib, sectors_mib},
     ui::{AlongsideState, App, DiskSegment, WizardState},
 };
@@ -267,21 +268,31 @@ fn fixture() -> Survey {
     survey
 }
 
+impl Guarded for AlongsideState<'_> {
+    fn generation(app: &App) -> i32 {
+        app.global::<AlongsideState>().get_generation()
+    }
+    fn set_generation(app: &App, generation: i32) {
+        app.global::<AlongsideState>().set_generation(generation);
+    }
+    fn set_busy(app: &App, busy: bool) {
+        app.global::<AlongsideState>().set_busy(busy);
+    }
+    fn set_error(app: &App, error: slint::SharedString) {
+        app.global::<AlongsideState>().set_error(error);
+    }
+}
+
 fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
-    let state = app.global::<AlongsideState>();
-    let generation = state.get_generation() + 1;
-    state.set_generation(generation);
-    state.set_busy(true);
-    state.set_error("".into());
+    let generation = busy::begin::<AlongsideState>(app);
     Session::touch();
-    state.invoke_rebuild();
+    app.global::<AlongsideState>().invoke_rebuild();
     let disk = index
         .and_then(Session::disk)
         .or_else(|| keep.as_ref().map(|r| r.before.device.clone()));
     let previous = Session::survey();
-    let weak = app.as_weak();
-    tokio::spawn(async move {
-        let result = tokio::task::spawn_blocking(move || -> Result<_, String> {
+    let work = async move {
+        tokio::task::spawn_blocking(move || -> Result<_, String> {
             if crate::preview::enabled() {
                 return Ok((
                     vec![PathBuf::from("/dev/nvme0n1")],
@@ -317,100 +328,97 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
             Ok((paths, names, selected_index, inspected))
         })
         .await
-        .unwrap_or_else(|e| Err(e.to_string()));
-        let _ = weak.upgrade_in_event_loop(move |app| {
-            let state = app.global::<AlongsideState>();
-            if state.get_generation() != generation {
-                return;
-            }
-            state.set_busy(false);
-            let result = result.and_then(|(paths, names, selected_index, inspected)| {
-                state.set_disks(strings(names));
-                state.set_disk_index(selected_index as i32);
-                Session::set_disks(paths);
-                inspected
-            });
-            match result {
-                Ok(survey) => {
-                    state.set_sources(strings(
-                        survey.sources.iter().map(|s| s.label.clone()).collect(),
-                    ));
-                    state.set_efi_partitions(strings(
-                        survey.efis.iter().map(|s| s.label.clone()).collect(),
-                    ));
-                    // A plan from a configuration file, or the current plan on
-                    // a refresh, is shown and executed as written when it
-                    // still describes this disk.
-                    let kept = keep.as_ref().and_then(|r| {
-                        let source = survey.sources.iter().position(|s| s.source == r.source)?;
-                        let efi = survey
-                            .efis
-                            .iter()
-                            .position(|e| e.number == r.efi.existing_partition())?;
-                        (r.before == survey.layout).then_some((source, efi))
-                    });
-                    if let Some((source, efi)) = kept {
-                        let r = keep.clone().expect("kept implies keep");
-                        state.set_source_index(source as i32);
-                        state.set_efi_index(efi as i32);
-                        state.set_additional_efi(matches!(r.efi, EfiChoice::CreateSeparate { .. }));
-                        state.set_use_all(false);
-                        state.set_allocation(gib(r.allocation_bytes) as f32);
-                        if r.swap_bytes > 0 {
-                            state.set_swap_size((r.swap_bytes / GIB) as f32);
-                        }
-                        Session::keep(survey, r);
-                        state.invoke_rebuild();
-                        return;
-                    }
-                    if keep.is_some() {
-                        Session::set_notice(
-                            "The previous plan no longer matches this disk; this is a new plan built from the current layout.",
-                        );
-                    }
-                    state.set_source_index(
-                        survey
-                            .sources
-                            .iter()
-                            .position(|s| {
-                                matches!(s.source, SpaceSource::Unallocated { .. })
-                                    && s.error.is_empty()
-                                    && s.capacity >= MIN_LINUX_BYTES
-                            })
-                            .or_else(|| {
-                                survey.sources.iter().position(|s| {
-                                    s.error.is_empty() && s.capacity >= MIN_LINUX_BYTES
-                                })
-                            })
-                            .map(|i| i as i32)
-                            .unwrap_or(0),
-                    );
-                    state.set_efi_index(
-                        survey
-                            .efis
-                            .iter()
-                            .position(|e| {
-                                e.space.as_ref().is_ok_and(|s| {
-                                    s.sufficient(Default::default()).unwrap_or(false)
-                                })
-                            })
-                            .unwrap_or(0) as i32,
-                    );
-                    state.set_additional_efi(false);
-                    state.set_use_all(true);
-                    Session::set_survey(Some(survey));
-                    state.invoke_rebuild();
-                }
-                Err(error) => {
-                    Session::set_survey(None);
-                    state.set_before(Default::default());
-                    state.set_after(Default::default());
-                    state.set_sources(Default::default());
-                    state.set_efi_partitions(Default::default());
-                    state.set_error(error.into());
-                }
-            }
+        .unwrap_or_else(|e| Err(e.to_string()))
+    };
+    busy::spawn::<AlongsideState, _>(app, generation, work, move |app, result| {
+        let state = app.global::<AlongsideState>();
+        let result = result.and_then(|(paths, names, selected_index, inspected)| {
+            state.set_disks(strings(names));
+            state.set_disk_index(selected_index as i32);
+            Session::set_disks(paths);
+            inspected
         });
+        match result {
+            Ok(survey) => {
+                state.set_sources(strings(
+                    survey.sources.iter().map(|s| s.label.clone()).collect(),
+                ));
+                state.set_efi_partitions(strings(
+                    survey.efis.iter().map(|s| s.label.clone()).collect(),
+                ));
+                // A plan from a configuration file, or the current plan on
+                // a refresh, is shown and executed as written when it
+                // still describes this disk.
+                let kept = keep.as_ref().and_then(|r| {
+                    let source = survey.sources.iter().position(|s| s.source == r.source)?;
+                    let efi = survey
+                        .efis
+                        .iter()
+                        .position(|e| e.number == r.efi.existing_partition())?;
+                    (r.before == survey.layout).then_some((source, efi))
+                });
+                if let Some((source, efi)) = kept {
+                    let r = keep.clone().expect("kept implies keep");
+                    state.set_source_index(source as i32);
+                    state.set_efi_index(efi as i32);
+                    state.set_additional_efi(matches!(r.efi, EfiChoice::CreateSeparate { .. }));
+                    state.set_use_all(false);
+                    state.set_allocation(gib(r.allocation_bytes) as f32);
+                    if r.swap_bytes > 0 {
+                        state.set_swap_size((r.swap_bytes / GIB) as f32);
+                    }
+                    Session::keep(survey, r);
+                    state.invoke_rebuild();
+                    return;
+                }
+                if keep.is_some() {
+                    Session::set_notice(
+                        "The previous plan no longer matches this disk; this is a new plan built from the current layout.",
+                    );
+                }
+                state.set_source_index(
+                    survey
+                        .sources
+                        .iter()
+                        .position(|s| {
+                            matches!(s.source, SpaceSource::Unallocated { .. })
+                                && s.error.is_empty()
+                                && s.capacity >= MIN_LINUX_BYTES
+                        })
+                        .or_else(|| {
+                            survey
+                                .sources
+                                .iter()
+                                .position(|s| s.error.is_empty() && s.capacity >= MIN_LINUX_BYTES)
+                        })
+                        .map(|i| i as i32)
+                        .unwrap_or(0),
+                );
+                state.set_efi_index(
+                    survey
+                        .efis
+                        .iter()
+                        .position(|e| {
+                            e.space
+                                .as_ref()
+                                .is_ok_and(|s| s.sufficient(Default::default()).unwrap_or(false))
+                        })
+                        .unwrap_or(0) as i32,
+                );
+                state.set_additional_efi(false);
+                state.set_use_all(true);
+                Session::set_survey(Some(survey));
+                state.invoke_rebuild();
+            }
+            Err(error) => {
+                Session::set_survey(None);
+                state.set_before(Default::default());
+                state.set_after(Default::default());
+                state.set_sources(Default::default());
+                state.set_efi_partitions(Default::default());
+                state.set_error(error.into());
+            }
+        }
     });
 }
 

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -1,5 +1,8 @@
 //! Read-only discovery and editable preview of the shared alongside plan.
-use crate::ui::{AlongsideState, App, DiskSegment, WizardState};
+use crate::{
+    format::{gib, sectors_gib, sectors_mib},
+    ui::{AlongsideState, App, DiskSegment, WizardState},
+};
 use archinstall_zfs_core::{
     config::{
         choices::Choice,
@@ -77,7 +80,7 @@ fn survey(disk: &std::path::Path, previous: Option<&Survey>) -> Result<Survey, S
                 label: format!(
                     "{} — {:.0} MiB",
                     p.node.display(),
-                    (p.size * layout.sectorsize) as f64 / MIB as f64
+                    sectors_mib(p.size, layout.sectorsize)
                 ),
                 space: inspect_efi(&RealRunner, &layout, number, &filesystems)
                     .map_err(|e| format!("{e:#}")),
@@ -90,12 +93,7 @@ fn survey(disk: &std::path::Path, previous: Option<&Survey>) -> Result<Survey, S
             .and_then(|f| f.fstype.as_deref())
             .unwrap_or("unknown filesystem");
         let size = p.size * layout.sectorsize;
-        let label = format!(
-            "{} — {} — {:.1} GiB",
-            p.node.display(),
-            fs,
-            size as f64 / GIB as f64
-        );
+        let label = format!("{} — {} — {:.1} GiB", p.node.display(), fs, gib(size));
         if let Some(cached) = previous
             .filter(|prev| prev.layout == layout)
             .and_then(|prev| {
@@ -115,7 +113,7 @@ fn survey(disk: &std::path::Path, previous: Option<&Survey>) -> Result<Survey, S
             ),
             Err(e) => (0, format!("{e:#}")),
         };
-        sources.push(Source { source: SpaceSource::Shrink { partition: number }, label, capacity, detail: format!("Keep {} at its current start; reduce only its end. Up to {:.0} GiB can be allocated here.", p.node.display(), capacity as f64 / GIB as f64), error });
+        sources.push(Source { source: SpaceSource::Shrink { partition: number }, label, capacity, detail: format!("Keep {} at its current start; reduce only its end. Up to {:.0} GiB can be allocated here.", p.node.display(), gib(capacity)), error });
     }
     for (start, end) in layout.free_extents().map_err(|e| e.to_string())? {
         let alignment = MIB / layout.sectorsize;
@@ -123,7 +121,7 @@ fn survey(disk: &std::path::Path, previous: Option<&Survey>) -> Result<Survey, S
         if bytes >= MIN_LINUX_BYTES {
             sources.push(Source {
                 source: SpaceSource::Unallocated { start, end },
-                label: format!("Unallocated space — {:.1} GiB", bytes as f64 / GIB as f64),
+                label: format!("Unallocated space — {:.1} GiB", gib(bytes)),
                 capacity: bytes,
                 detail: "Create a ZFS partition here without shrinking an existing filesystem."
                     .into(),
@@ -277,7 +275,7 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                         state.set_efi_index(efi as i32);
                         state.set_additional_efi(matches!(r.efi, EfiChoice::CreateSeparate { .. }));
                         state.set_use_all(false);
-                        state.set_allocation(r.allocation_bytes as f32 / GIB as f32);
+                        state.set_allocation(gib(r.allocation_bytes) as f32);
                         if r.swap_bytes > 0 {
                             state.set_swap_size((r.swap_bytes / GIB) as f32);
                         }
@@ -395,14 +393,11 @@ fn segments(layout: &Layout, plan: Option<&Plan>) -> ModelRc<DiskSegment> {
                 offset: start as f32 / total as f32,
                 fraction: (end - start) as f32 / total as f32,
                 kind,
-                short_label: format!(
-                    "{:.0} GiB",
-                    (end - start) as f64 * layout.sectorsize as f64 / GIB as f64
-                )
-                .into(),
+                short_label: format!("{:.0} GiB", sectors_gib(end - start, layout.sectorsize))
+                    .into(),
                 label: format!(
                     "{name} · {:.0} GiB",
-                    (end - start) as f64 * layout.sectorsize as f64 / GIB as f64
+                    sectors_gib(end - start, layout.sectorsize)
                 )
                 .into(),
             })
@@ -443,13 +438,12 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         let source = s.sources.get(state.get_source_index() as usize).ok_or("No suitable partitions or unallocated space")?;
         state.set_details(source.detail.clone().into());
         let swap_bytes = if let Some(k) = kept { k.swap_bytes } else if config.swap_mode.uses_partition() { state.get_swap_size().round().clamp(1.0, 1024.0) as u64 * GIB } else { 0 };
-        let min = (MIN_LINUX_BYTES + swap_bytes + if state.get_additional_efi() { ESP_BYTES } else { 0 }) as f32 / GIB as f32;
-        let max = source.capacity as f64 / GIB as f64;
-        let max = max as f32;
+        let min = gib(MIN_LINUX_BYTES + swap_bytes + if state.get_additional_efi() { ESP_BYTES } else { 0 }) as f32;
+        let max = gib(source.capacity) as f32;
         state.set_minimum(min); state.set_maximum(max);
         let all_bytes = source.capacity / MIB * MIB;
         let allocation_bytes = if let Some(k) = kept { k.allocation_bytes } else if state.get_use_all() { all_bytes } else { (state.get_allocation().round().max(min) as u64).saturating_mul(GIB).min(all_bytes) };
-        state.set_allocation((allocation_bytes as f64 / GIB as f64 * 10.0).round() as f32 / 10.0);
+        state.set_allocation((gib(allocation_bytes) * 10.0).round() as f32 / 10.0);
         let efi = s.efis.get(state.get_efi_index() as usize).ok_or("No existing EFI partition on this disk. Prepare an EFI partition before using this mode.")?;
         let space = efi.space.as_ref().map_err(Clone::clone)?;
         let budget = BootSpace::default();
@@ -464,9 +458,9 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         let request = match kept { Some(k) => k.clone(), None => Request { before: s.layout.clone(), source: source.source.clone(), efi: efi_choice, allocation_bytes, swap_bytes } };
         let plan = request.plan().map_err(|e| e.to_string())?;
         state.set_after(segments(&s.layout, Some(&plan)));
-        state.set_allocation_summary(format!("New ZFS pool: {:.1} GiB · Swap: {} GiB{}", (plan.swap_start.unwrap_or(plan.end) - plan.zfs_start) as f64 * s.layout.sectorsize as f64 / GIB as f64, swap_bytes / GIB, if plan.efi_start.is_some() { " · New EFI: 512 MiB" } else { " · Existing EFI reused" }).into());
+        state.set_allocation_summary(format!("New ZFS pool: {:.1} GiB · Swap: {} GiB{}", sectors_gib(plan.swap_start.unwrap_or(plan.end) - plan.zfs_start, s.layout.sectorsize), swap_bytes / GIB, if plan.efi_start.is_some() { " · New EFI: 512 MiB" } else { " · Existing EFI reused" }).into());
         if let Some((old, size)) = &plan.shrink {
-            state.set_details(format!("{}: {:.0} → {:.0} GiB. Its start and existing data are preserved.", old.node.display(), old.size as f64 * s.layout.sectorsize as f64 / GIB as f64, *size as f64 * s.layout.sectorsize as f64 / GIB as f64).into());
+            state.set_details(format!("{}: {:.0} → {:.0} GiB. Its start and existing data are preserved.", old.node.display(), sectors_gib(old.size, s.layout.sectorsize), sectors_gib(*size, s.layout.sectorsize)).into());
         }
         Ok(request)
     });

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -508,13 +508,13 @@ fn planned_swap_bytes(
 
 /// How much of the existing ESP the boot files need, and what reusing it means.
 fn efi_details(space: &EfiSpace, budget: BootSpace, insufficient: bool) -> Result<String, String> {
-    let required = budget
-        .required_bytes()
-        .map_err(|e| e.to_string())?
-        .div_ceil(MIB);
+    let required_bytes = budget.required_bytes().map_err(|e| e.to_string())?;
+    let required = required_bytes.div_ceil(MIB);
     let consequence = if insufficient {
         "It cannot be reused; select a separate EFI partition to continue."
-    } else if space.free_bytes < required + budget.image_bytes {
+    } else if space.free_bytes < required_bytes + budget.image_bytes {
+        // Updates stage a second copy only when a whole image fits next to
+        // the installed one.
         "Later ZFSBootMenu updates replace the image in place instead of writing a second copy first."
     } else {
         "Reusing it formats nothing and keeps the existing loaders."

--- a/slint-ui/src/busy.rs
+++ b/slint-ui/src/busy.rs
@@ -1,0 +1,49 @@
+//! One round trip for the storage and alongside surveys: a request bumps the
+//! state's generation and marks it busy; the result is applied only when no
+//! newer request (or a cancel, which also bumps the generation) started since.
+
+use crate::ui::App;
+use slint::{ComponentHandle, SharedString};
+use std::future::Future;
+
+/// A Slint global with `generation`, `busy` and `error` properties.
+pub trait Guarded {
+    fn generation(app: &App) -> i32;
+    fn set_generation(app: &App, generation: i32);
+    fn set_busy(app: &App, busy: bool);
+    fn set_error(app: &App, error: SharedString);
+}
+
+/// Starts a request: bumps the generation, marks the state busy and clears
+/// the previous error. Returns the generation identifying this request.
+pub fn begin<G: Guarded>(app: &App) -> i32 {
+    let generation = G::generation(app) + 1;
+    G::set_generation(app, generation);
+    G::set_busy(app, true);
+    G::set_error(app, "".into());
+    generation
+}
+
+/// Runs `work` on the runtime and hands its result to `apply` on the UI
+/// thread, unless the request is no longer current. Busy is cleared first.
+pub fn spawn<G, T>(
+    app: &App,
+    generation: i32,
+    work: impl Future<Output = T> + Send + 'static,
+    apply: impl FnOnce(&App, T) + Send + 'static,
+) where
+    G: Guarded + 'static,
+    T: Send + 'static,
+{
+    let weak = app.as_weak();
+    tokio::spawn(async move {
+        let result = work.await;
+        let _ = weak.upgrade_in_event_loop(move |app| {
+            if G::generation(&app) != generation {
+                return;
+            }
+            G::set_busy(&app, false);
+            apply(&app, result);
+        });
+    });
+}

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -5,9 +5,7 @@ use slint::SharedString;
 
 use archinstall_zfs_core::config::choices::Choice;
 use archinstall_zfs_core::config::edit::{ChoiceSetting, EditorSetting, TextSetting};
-use archinstall_zfs_core::config::types::{
-    GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode,
-};
+use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode, ZfsEncryptionMode};
 
 use crate::ui::{ConfigItem, ItemType};
 #[cfg(test)]
@@ -145,12 +143,7 @@ fn storage_item(
     let choices = crate::storage::choices(role);
     let choice = selected.and_then(|p| choices.iter().find(|d| d.path == p));
     let consequence = match role {
-        "disk"
-            if matches!(
-                c.swap_mode,
-                SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-            ) =>
-        {
+        "disk" if c.swap_mode.uses_partition() => {
             "Erase all partitions; create EFI, ZFS and swap partitions"
         }
         "disk" => "Erase all partitions; create EFI and ZFS partitions",
@@ -317,10 +310,7 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
             c.swap_mode,
             "ZRAM uses compressed RAM. A swap partition uses disk space.",
         ));
-        if matches!(
-            c.swap_mode,
-            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-        ) {
+        if c.swap_mode.uses_partition() {
             if c.installation_mode == Some(InstallationMode::FullDisk) {
                 items.push(inline_text(
                     TextSetting::SwapPartitionSize,
@@ -641,10 +631,8 @@ fn build_review_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     if matches!(
         c.installation_mode,
         Some(InstallationMode::NewPool | InstallationMode::ExistingPool)
-    ) && matches!(
-        c.swap_mode,
-        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-    ) {
+    ) && c.swap_mode.uses_partition()
+    {
         let mut item = storage_item(
             "swap_partition",
             "Swap partition",

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -7,9 +7,11 @@ use archinstall_zfs_core::config::choices::Choice;
 use archinstall_zfs_core::config::edit::{ChoiceSetting, EditorSetting, TextSetting};
 use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode, ZfsEncryptionMode};
 
+use crate::format::gib;
 use crate::ui::{ConfigItem, ItemType};
 #[cfg(test)]
 use archinstall_zfs_core::config::edit::DeviceSetting;
+use archinstall_zfs_core::disk::alongside::GIB;
 
 pub const TOTAL_STEPS: usize = 7;
 
@@ -70,7 +72,7 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                     value: format!(
                         "{} — {:.0} GiB",
                         r.before.device.display(),
-                        r.allocation_bytes as f64 / 1073741824.0
+                        gib(r.allocation_bytes)
                     )
                     .into(),
                     description: {
@@ -92,7 +94,7 @@ fn build_disk_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                                     .into()
                             }
                         };
-                        format!("{source}. {efi}. {} GiB reserved for swap; the remainder is the new ZFS pool.", r.swap_bytes / 1073741824).into()
+                        format!("{source}. {efi}. {} GiB reserved for swap; the remainder is the new ZFS pool.", r.swap_bytes / GIB).into()
                     },
                     item_type: ItemType::Storage,
                     ..Default::default()
@@ -291,7 +293,7 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         let value = if let Some(r) = &c.alongside
             && r.swap_bytes > 0
         {
-            format!("{} — {} GiB", c.swap_mode, r.swap_bytes / 1073741824)
+            format!("{} — {} GiB", c.swap_mode, r.swap_bytes / GIB)
         } else {
             c.swap_mode.to_string()
         };

--- a/slint-ui/src/config_items.rs
+++ b/slint-ui/src/config_items.rs
@@ -5,7 +5,9 @@ use slint::SharedString;
 
 use archinstall_zfs_core::config::choices::Choice;
 use archinstall_zfs_core::config::edit::{ChoiceSetting, EditorSetting, TextSetting};
-use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode, ZfsEncryptionMode};
+use archinstall_zfs_core::config::types::{
+    GlobalConfig, InstallationMode, ZFS_PASSPHRASE_MIN_LENGTH, ZfsEncryptionMode,
+};
 
 use crate::format::gib;
 use crate::ui::{ConfigItem, ItemType};
@@ -283,8 +285,10 @@ fn build_zfs_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                 "Required"
             }
             .into(),
-            description:
-                "At least 8 characters. Keep a copy: a lost passphrase cannot be recovered.".into(),
+            description: format!(
+                "At least {ZFS_PASSPHRASE_MIN_LENGTH} characters. Keep a copy: a lost passphrase cannot be recovered."
+            )
+            .into(),
             item_type: ItemType::InlinePassword,
             ..Default::default()
         });
@@ -431,16 +435,7 @@ fn build_users_items(c: &GlobalConfig) -> Vec<ConfigItem> {
                 ),
                 _ => None,
             };
-            // ci_opt's None → "Not set"; users semantically wants "None".
-            // Construct directly so we keep the established label.
-            ConfigItem {
-                key: "users".into(),
-                label: "User accounts".into(),
-                value: summary.clone().unwrap_or_else(|| "None".into()).into(),
-                item_type: ItemType::Text,
-                is_empty: summary.is_none(),
-                ..Default::default()
-            }
+            ci_opt_with("users", "User accounts", summary, "None", ItemType::Text)
         },
     ]
 }
@@ -452,17 +447,13 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
     let profile_name = profile_def.as_ref().map(|p| p.display_name.to_string());
     let mut items = vec![
         section_header("Environment"),
-        ConfigItem {
-            key: "profile".into(),
-            label: "Profile".into(),
-            value: profile_name
-                .clone()
-                .unwrap_or_else(|| "Console only".into())
-                .into(),
-            item_type: ItemType::Select,
-            is_empty: profile_name.is_none(),
-            ..Default::default()
-        },
+        ci_opt_with(
+            "profile",
+            "Profile",
+            profile_name,
+            "Console only",
+            ItemType::Select,
+        ),
     ];
 
     // ── Profile configuration: only when a desktop profile is active ──
@@ -530,17 +521,13 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         .as_ref()
         .is_some_and(|p| p.supports_gfx_driver())
     {
-        items.push({
-            let driver = c.gfx_driver.map(|d| d.to_string());
-            ConfigItem {
-                key: "gpu_driver".into(),
-                label: "GPU driver".into(),
-                value: driver.clone().unwrap_or_else(|| "None".into()).into(),
-                item_type: ItemType::Select,
-                is_empty: driver.is_none(),
-                ..Default::default()
-            }
-        });
+        items.push(ci_opt_with(
+            "gpu_driver",
+            "GPU driver",
+            c.gfx_driver.map(|d| d.to_string()),
+            "None",
+            ItemType::Select,
+        ));
 
         // Inline warning when the proprietary NVIDIA driver is paired with
         // a Wayland-only compositor. The TUI shows a confirmation dialog;
@@ -573,14 +560,7 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         } else {
             Some(parts.join(", "))
         };
-        ConfigItem {
-            key: "packages".into(),
-            label: "Extra packages".into(),
-            value: joined.clone().unwrap_or_else(|| "None".into()).into(),
-            item_type: ItemType::Text,
-            is_empty: joined.is_none(),
-            ..Default::default()
-        }
+        ci_opt_with("packages", "Extra packages", joined, "None", ItemType::Text)
     });
     items.push({
         let joined = if c.extra_services.is_empty() {
@@ -588,14 +568,13 @@ fn build_desktop_items(c: &GlobalConfig) -> Vec<ConfigItem> {
         } else {
             Some(c.extra_services.join(", "))
         };
-        ConfigItem {
-            key: "extra_services".into(),
-            label: "Extra services".into(),
-            value: joined.clone().unwrap_or_else(|| "None".into()).into(),
-            item_type: ItemType::Text,
-            is_empty: joined.is_none(),
-            ..Default::default()
-        }
+        ci_opt_with(
+            "extra_services",
+            "Extra services",
+            joined,
+            "None",
+            ItemType::Text,
+        )
     });
     items.push(ci_toggle("zrepl", "zrepl (snapshots)", c.zrepl_enabled));
 
@@ -769,14 +748,23 @@ fn ci(key: &str, label: &str, value: &str, item_type: ItemType) -> ConfigItem {
 /// "Not set" with `is_empty: true` so the Slint side colors the value muted
 /// without string-matching the sentinel.
 fn ci_opt(key: &str, label: &str, value: Option<&str>, item_type: ItemType) -> ConfigItem {
-    let (display, is_empty) = match value {
-        Some(v) => (v, false),
-        None => ("Not set", true),
-    };
+    ci_opt_with(key, label, value.map(str::to_owned), "Not set", item_type)
+}
+
+/// [`ci_opt`] with the placeholder shown for `None` chosen by the caller;
+/// `is_empty` still marks the row as unset.
+fn ci_opt_with(
+    key: &str,
+    label: &str,
+    value: Option<String>,
+    placeholder: &str,
+    item_type: ItemType,
+) -> ConfigItem {
+    let is_empty = value.is_none();
     ConfigItem {
         key: key.into(),
         label: label.into(),
-        value: display.into(),
+        value: value.unwrap_or_else(|| placeholder.into()).into(),
         item_type,
         is_empty,
         ..Default::default()

--- a/slint-ui/src/format.rs
+++ b/slint-ui/src/format.rs
@@ -1,4 +1,7 @@
-//! Tiny formatting helpers used by the install progress display.
+//! Tiny formatting helpers used by the install progress display and the
+//! storage pages.
+
+use archinstall_zfs_core::disk::alongside::{GIB, MIB};
 
 pub fn format_speed(bps: u64) -> String {
     if bps >= 1_000_000 {
@@ -32,4 +35,19 @@ pub fn truncate_str(s: &str, max: usize) -> &str {
             None => s,
         }
     }
+}
+
+/// Bytes as fractional GiB for `{:.0}`/`{:.1}` display.
+pub fn gib(bytes: u64) -> f64 {
+    bytes as f64 / GIB as f64
+}
+
+/// A sector count as fractional GiB for display.
+pub fn sectors_gib(sectors: u64, sectorsize: u64) -> f64 {
+    sectors as f64 * sectorsize as f64 / GIB as f64
+}
+
+/// A sector count as fractional MiB for display.
+pub fn sectors_mib(sectors: u64, sectorsize: u64) -> f64 {
+    sectors as f64 * sectorsize as f64 / MIB as f64
 }

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -1,4 +1,5 @@
 mod alongside;
+mod busy;
 mod completion;
 mod config_items;
 #[cfg(feature = "linuxkms")]

--- a/slint-ui/src/preview.rs
+++ b/slint-ui/src/preview.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use archinstall_zfs_core::config::types::{
     GlobalConfig, InstallationMode, ProfileSelection, UserConfig,
 };
+use archinstall_zfs_core::disk::alongside::GIB;
 use archinstall_zfs_core::disk::device::{
     BlockDevice, BlockPartition, DeviceChoice, DevicePath, DevicePathKind,
 };
@@ -115,7 +116,7 @@ fn devices() -> Vec<BlockDevice> {
         }],
         model: Some(model.into()),
         serial: Some(serial.into()),
-        size_bytes: Some(size * 1024 * 1024 * 1024),
+        size_bytes: Some(size * GIB),
         transport: Some(bus.into()),
         rotational: Some(false),
         removable,
@@ -172,9 +173,9 @@ pub fn partitions() -> Vec<DeviceChoice> {
                     model: disk.model.clone(),
                     serial: disk.serial.clone(),
                     size_bytes: Some(if number == 1 {
-                        1024 * 1024 * 1024
+                        GIB
                     } else {
-                        (disk.size_bytes.unwrap() - 1024 * 1024 * 1024) / (count - 1)
+                        (disk.size_bytes.unwrap() - GIB) / (count - 1)
                     }),
                     parent_size_bytes: disk.size_bytes,
                     transport: disk.transport.clone(),

--- a/slint-ui/src/storage.rs
+++ b/slint-ui/src/storage.rs
@@ -461,7 +461,7 @@ async fn pool_inventory() -> Result<(Vec<PoolRow>, Vec<String>), String> {
             .properties
             .get("free")
             .and_then(|p| p.value.parse::<u64>().ok())
-            .map(|bytes| format!("{:.1} GiB", bytes as f64 / 1073741824.0))
+            .map(|bytes| format!("{:.1} GiB", crate::format::gib(bytes)))
             .unwrap_or_else(|| "Unknown".into());
         rows.push((
             p.name.clone(),

--- a/slint-ui/src/storage.rs
+++ b/slint-ui/src/storage.rs
@@ -21,6 +21,38 @@ struct Inventory {
     datasets: Vec<String>,
 }
 thread_local! { static INVENTORY: RefCell<Inventory> = RefCell::default(); }
+impl Inventory {
+    fn with<R>(f: impl FnOnce(&Inventory) -> R) -> R {
+        INVENTORY.with_borrow(f)
+    }
+    fn update<R>(f: impl FnOnce(&mut Inventory) -> R) -> R {
+        INVENTORY.with_borrow_mut(f)
+    }
+    fn devices(role: &str) -> Vec<DeviceChoice> {
+        Self::with(|i| {
+            if role == "disk" {
+                i.disks.clone()
+            } else {
+                i.partitions.clone()
+            }
+        })
+    }
+    fn set_devices(disks: Vec<DeviceChoice>, partitions: Vec<DeviceChoice>) {
+        Self::update(|i| {
+            i.disks = disks;
+            i.partitions = partitions;
+        });
+    }
+    fn pools() -> Vec<StorageCandidate> {
+        Self::with(|i| i.pools.clone())
+    }
+    fn set_pools(pools: Vec<StorageCandidate>, datasets: Vec<String>) {
+        Self::update(|i| {
+            i.pools = pools;
+            i.datasets = datasets;
+        });
+    }
+}
 
 pub fn choices(role: &str) -> Vec<DeviceChoice> {
     if crate::preview::enabled() {
@@ -30,13 +62,7 @@ pub fn choices(role: &str) -> Vec<DeviceChoice> {
             crate::preview::partitions()
         };
     }
-    INVENTORY.with_borrow(|i| {
-        if role == "disk" {
-            i.disks.clone()
-        } else {
-            i.partitions.clone()
-        }
-    })
+    Inventory::devices(role)
 }
 fn same_device(a: &Path, b: &Path) -> bool {
     std::fs::canonicalize(a).unwrap_or_else(|_| a.into())
@@ -163,7 +189,7 @@ fn populate(app: &App, c: &GlobalConfig) {
     let role = state.get_role();
     let filter = state.get_filter().to_lowercase();
     let rows: Vec<_> = if role == "pool" {
-        INVENTORY.with_borrow(|i| i.pools.clone())
+        Inventory::pools()
     } else {
         choices(&role)
             .into_iter()
@@ -370,36 +396,29 @@ fn scan(app: &App, pools: bool) {
             }
             state.set_busy(false);
             match result {
-                Ok((disks, parts, found, datasets)) => INVENTORY.with_borrow_mut(|i| {
-                    if pools {
-                        i.datasets = datasets;
-                        i.pools = found
-                            .into_iter()
-                            .map(|(name, status, details, blocked)| StorageCandidate {
-                                key: name.clone().into(),
-                                name: name.into(),
-                                group: "ZFS pools".into(),
-                                label: status.into(),
-                                details: details.into(),
-                                unavailable: blocked.into(),
-                                ..Default::default()
-                            })
-                            .collect();
-                    } else {
-                        i.disks = disks;
-                        i.partitions = parts;
-                    }
-                }),
+                Ok((_, _, found, datasets)) if pools => Inventory::set_pools(
+                    found
+                        .into_iter()
+                        .map(|(name, status, details, blocked)| StorageCandidate {
+                            key: name.clone().into(),
+                            name: name.into(),
+                            group: "ZFS pools".into(),
+                            label: status.into(),
+                            details: details.into(),
+                            unavailable: blocked.into(),
+                            ..Default::default()
+                        })
+                        .collect(),
+                    datasets,
+                ),
+                Ok((disks, parts, _, _)) => Inventory::set_devices(disks, parts),
                 Err(e) => {
                     state.set_error(e.into());
-                    INVENTORY.with_borrow_mut(|i| {
-                        if pools {
-                            i.pools.clear()
-                        } else {
-                            i.disks.clear();
-                            i.partitions.clear();
-                        }
-                    });
+                    if pools {
+                        Inventory::update(|i| i.pools.clear());
+                    } else {
+                        Inventory::set_devices(Vec::new(), Vec::new());
+                    }
                 }
             }
             state.invoke_inventory_changed();
@@ -545,7 +564,7 @@ pub fn issues(c: &GlobalConfig) -> Vec<String> {
     if c.installation_mode == Some(InstallationMode::ExistingPool)
         && let Some(name) = &c.pool_name
     {
-        INVENTORY.with_borrow(|i| {
+        Inventory::with(|i| {
             match i.pools.iter().find(|p| p.name.as_str() == name) {
                 None => issues.push("Choose or refresh the existing pool before installing".into()),
                 Some(p) if !p.unavailable.is_empty() => issues.push(p.unavailable.to_string()),

--- a/slint-ui/src/storage.rs
+++ b/slint-ui/src/storage.rs
@@ -6,7 +6,7 @@ use crate::{
 use archinstall_zfs_core::{
     config::{
         edit::{DeviceSetting, apply_device},
-        types::{GlobalConfig, InstallationMode, SwapMode},
+        types::{GlobalConfig, InstallationMode},
     },
     disk::device::{self, DeviceChoice},
 };
@@ -63,10 +63,7 @@ pub fn unavailable(choice: &DeviceChoice, role: &str, c: &GlobalConfig) -> Strin
         (
             "swap_partition",
             c.swap_partition.as_ref(),
-            matches!(
-                c.swap_mode,
-                SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-            ),
+            c.swap_mode.uses_partition(),
         ),
     ] {
         if active && role != other && selected.is_some_and(|p| same_device(p, &choice.path)) {
@@ -520,10 +517,7 @@ pub fn issues(c: &GlobalConfig) -> Vec<String> {
         if c.installation_mode == Some(InstallationMode::NewPool) {
             roles.push(("zfs_partition", c.zfs_partition.as_deref()));
         }
-        if matches!(
-            c.swap_mode,
-            SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-        ) {
+        if c.swap_mode.uses_partition() {
             roles.push(("swap_partition", c.swap_partition.as_deref()));
         }
         roles

--- a/slint-ui/src/storage.rs
+++ b/slint-ui/src/storage.rs
@@ -1,5 +1,6 @@
 //! Read-only storage discovery and identity-based selection for the graphical wizard.
 use crate::{
+    busy::{self, Guarded},
     refresh::refresh_items,
     ui::{App, StorageCandidate, StorageState},
 };
@@ -354,16 +355,25 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
         scan(app, false);
     }
 }
+impl Guarded for StorageState<'_> {
+    fn generation(app: &App) -> i32 {
+        app.global::<StorageState>().get_generation()
+    }
+    fn set_generation(app: &App, generation: i32) {
+        app.global::<StorageState>().set_generation(generation);
+    }
+    fn set_busy(app: &App, busy: bool) {
+        app.global::<StorageState>().set_busy(busy);
+    }
+    fn set_error(app: &App, error: slint::SharedString) {
+        app.global::<StorageState>().set_error(error);
+    }
+}
 fn scan(app: &App, pools: bool) {
-    let state = app.global::<StorageState>();
-    let generation = state.get_generation() + 1;
-    state.set_generation(generation);
-    state.set_busy(true);
-    state.set_error("".into());
-    let weak = app.as_weak();
-    tokio::spawn(async move {
-        // Only plain owned Rust data crosses the worker/event-loop boundary.
-        let result = tokio::time::timeout(std::time::Duration::from_secs(20), async {
+    let generation = busy::begin::<StorageState>(app);
+    // Only plain owned Rust data crosses the worker/event-loop boundary.
+    let work = async move {
+        tokio::time::timeout(std::time::Duration::from_secs(20), async {
             if pools {
                 let (pools, datasets) = pool_inventory().await?;
                 Ok::<_, String>((Vec::new(), Vec::new(), pools, datasets))
@@ -386,43 +396,37 @@ fn scan(app: &App, pools: bool) {
             }
         })
         .await
-        .unwrap_or_else(|_| {
-            Err("Storage discovery timed out. Check the devices and retry.".into())
-        });
-        let _ = weak.upgrade_in_event_loop(move |app| {
-            let state = app.global::<StorageState>();
-            if state.get_generation() != generation {
-                return;
-            }
-            state.set_busy(false);
-            match result {
-                Ok((_, _, found, datasets)) if pools => Inventory::set_pools(
-                    found
-                        .into_iter()
-                        .map(|(name, status, details, blocked)| StorageCandidate {
-                            key: name.clone().into(),
-                            name: name.into(),
-                            group: "ZFS pools".into(),
-                            label: status.into(),
-                            details: details.into(),
-                            unavailable: blocked.into(),
-                            ..Default::default()
-                        })
-                        .collect(),
-                    datasets,
-                ),
-                Ok((disks, parts, _, _)) => Inventory::set_devices(disks, parts),
-                Err(e) => {
-                    state.set_error(e.into());
-                    if pools {
-                        Inventory::update(|i| i.pools.clear());
-                    } else {
-                        Inventory::set_devices(Vec::new(), Vec::new());
-                    }
+        .unwrap_or_else(|_| Err("Storage discovery timed out. Check the devices and retry.".into()))
+    };
+    busy::spawn::<StorageState, _>(app, generation, work, move |app, result| {
+        let state = app.global::<StorageState>();
+        match result {
+            Ok((_, _, found, datasets)) if pools => Inventory::set_pools(
+                found
+                    .into_iter()
+                    .map(|(name, status, details, blocked)| StorageCandidate {
+                        key: name.clone().into(),
+                        name: name.into(),
+                        group: "ZFS pools".into(),
+                        label: status.into(),
+                        details: details.into(),
+                        unavailable: blocked.into(),
+                        ..Default::default()
+                    })
+                    .collect(),
+                datasets,
+            ),
+            Ok((disks, parts, _, _)) => Inventory::set_devices(disks, parts),
+            Err(e) => {
+                state.set_error(e.into());
+                if pools {
+                    Inventory::update(|i| i.pools.clear());
+                } else {
+                    Inventory::set_devices(Vec::new(), Vec::new());
                 }
             }
-            state.invoke_inventory_changed();
-        });
+        }
+        state.invoke_inventory_changed();
     });
 }
 type PoolRow = (String, String, String, String);

--- a/slint-ui/ui/components/alongside-panel.slint
+++ b/slint-ui/ui/components/alongside-panel.slint
@@ -3,8 +3,7 @@ import { AlongsideState, DiskSegment } from "../state/alongside-state.slint";
 import { Theme } from "../styling.slint";
 import { StyledButton } from "styled-button.slint";
 import { StyledTextInput } from "styled-text-input.slint";
-import { RadioDot } from "radio-dot.slint";
-import { FocusTouchArea } from "internal/state-layer.slint";
+import { RadioCard } from "radio-card.slint";
 
 component DiskMap inherits Rectangle {
     in property <[DiskSegment]> segments;
@@ -130,38 +129,15 @@ export component AlongsidePanel inherits Rectangle {
             Text { text: AlongsideState.efi-details; color: Theme.c.subtext1; wrap: word-wrap; }
             HorizontalLayout {
                 spacing: 12px;
-                for option[index] in ["Reuse the selected EFI partition", "Create a separate 512 MiB EFI partition"]: Rectangle {
-                    property <bool> selected: (index == 1) == AlongsideState.additional-efi;
-                    property <bool> available: index == 1 || !AlongsideState.insufficient;
-                    horizontal-stretch: 1;
-                    background: selected ? Theme.c.blue.with-alpha(0.16) : Theme.c.surface0.with-alpha(0.55);
-                    border-radius: 8px;
-                    border-width: touch.has-focus ? 2px : 1px;
-                    border-color: touch.has-focus || selected ? Theme.c.blue : Theme.c.surface1;
-                    opacity: available ? 1 : 0.5;
-                    HorizontalLayout {
-                        padding: 10px;
-                        spacing: 8px;
-                        RadioDot { filled: selected; dot-color: Theme.c.blue; }
-                        VerticalLayout {
-                            spacing: 3px;
-                            horizontal-stretch: 1;
-                            Text { text: option + (index == 0 ? " (recommended)" : ""); color: Theme.c.text; font-weight: 600; wrap: word-wrap; }
-                            Text { text: index == 0 ? "Boot files go next to the existing loaders; nothing is formatted." : "Takes 512 MiB from the allocation; firmware and the other system then see two EFI partitions."; color: Theme.c.subtext1; font-size: 12px; wrap: word-wrap; }
-                        }
-                    }
-                    touch := FocusTouchArea {
-                        width: 100%;
-                        height: 100%;
-                        enabled: available && !AlongsideState.busy;
-                        accessible-role: radio-button;
-                        accessible-label: option;
-                        accessible-checked: selected;
-                        accessible-enabled: available && !AlongsideState.busy;
-                        accessible-action-default => { AlongsideState.additional(index == 1); }
-                        clicked => { AlongsideState.additional(index == 1); }
-                        changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); }
-                    }
+                for option[index] in ["Reuse the selected EFI partition", "Create a separate 512 MiB EFI partition"]: RadioCard {
+                    title: option + (index == 0 ? " (recommended)" : "");
+                    label: option;
+                    description: index == 0 ? "Boot files go next to the existing loaders; nothing is formatted." : "Takes 512 MiB from the allocation; firmware and the other system then see two EFI partitions.";
+                    selected: (index == 1) == AlongsideState.additional-efi;
+                    available: index == 1 || !AlongsideState.insufficient;
+                    enabled: !AlongsideState.busy;
+                    activated => { AlongsideState.additional(index == 1); }
+                    reveal(y, h) => { root.reveal(y, h); }
                 }
             }
         }

--- a/slint-ui/ui/components/alongside-panel.slint
+++ b/slint-ui/ui/components/alongside-panel.slint
@@ -35,6 +35,8 @@ component DiskMap inherits Rectangle {
 
 export component AlongsidePanel inherits Rectangle {
     callback reveal(length, length);
+    // Scroll a control into view when it gains keyboard focus.
+    function reveal-if(focused: bool, y: length, h: length) { if focused { root.reveal(y, h); } }
     background: transparent;
     vertical-stretch: 0;
     init => { if AlongsideState.disks.length == 0 { AlongsideState.reload(); } else { AlongsideState.rebuild(); } }
@@ -43,7 +45,7 @@ export component AlongsidePanel inherits Rectangle {
         HorizontalLayout {
             spacing: 12px;
             disk-choice := ComboBox {
-                changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } }
+                changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); }
                 accessible-label: "Installation disk";
                 model: AlongsideState.disks;
                 current-index: AlongsideState.disk-index;
@@ -65,13 +67,13 @@ export component AlongsidePanel inherits Rectangle {
         if AlongsideState.sources.length > 0: VerticalLayout {
             spacing: 8px;
             Text { text: "Where to make space"; font-weight: 600; color: Theme.c.text; }
-            source-choice := ComboBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "Space source"; model: AlongsideState.sources; current-index <=> AlongsideState.source-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-source(self.current-index); } }
+            source-choice := ComboBox { changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } accessible-label: "Space source"; model: AlongsideState.sources; current-index <=> AlongsideState.source-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-source(self.current-index); } }
             Text { text: AlongsideState.details; color: Theme.c.subtext1; wrap: word-wrap; }
-            CheckBox { text: "Use all available space"; checked: AlongsideState.use-all; enabled: !AlongsideState.busy; toggled => { AlongsideState.all-space(self.checked); } changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } }
+            CheckBox { text: "Use all available space"; checked: AlongsideState.use-all; enabled: !AlongsideState.busy; toggled => { AlongsideState.all-space(self.checked); } changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } }
             HorizontalLayout {
                 spacing: 16px;
                 Text { text: "Allocate to this installation"; color: Theme.c.text; }
-                allocation-slider := Slider { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "Space for installation"; minimum: AlongsideState.minimum; maximum: max(AlongsideState.minimum, AlongsideState.maximum); value <=> AlongsideState.allocation; enabled: !AlongsideState.busy && AlongsideState.maximum >= AlongsideState.minimum; changed(value) => { AlongsideState.allocate(round(value)); } }
+                allocation-slider := Slider { changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } accessible-label: "Space for installation"; minimum: AlongsideState.minimum; maximum: max(AlongsideState.minimum, AlongsideState.maximum); value <=> AlongsideState.allocation; enabled: !AlongsideState.busy && AlongsideState.maximum >= AlongsideState.minimum; changed(value) => { AlongsideState.allocate(round(value)); } }
                 allocation-input := StyledTextInput {
                     property <bool> dirty: false;
                     // Typing replaces the `text` binding; follow later state
@@ -80,8 +82,8 @@ export component AlongsidePanel inherits Rectangle {
                     property <float> bound: AlongsideState.allocation;
                     changed bound => { if !self.dirty { self.text = "\{self.bound}"; } }
                     changed has-focus => {
-                        if self.has-focus { root.reveal(self.absolute-position.y, self.height); }
-                        else if self.dirty { self.dirty = false; if self.text.is-float() { AlongsideState.allocate(self.text.to-float()); } self.text = "\{AlongsideState.allocation}"; }
+                        root.reveal-if(self.has-focus, self.absolute-position.y, self.height);
+                        if !self.has-focus && self.dirty { self.dirty = false; if self.text.is-float() { AlongsideState.allocate(self.text.to-float()); } self.text = "\{AlongsideState.allocation}"; }
                     }
                     edited(value) => { self.dirty = true; } accessible-label: "Allocation in GiB"; width: 80px; text: "\{AlongsideState.allocation}"; enabled: !AlongsideState.busy; accepted(value) => { self.dirty = false; if value.is-float() { AlongsideState.allocate(value.to-float()); } self.text = "\{AlongsideState.allocation}"; } }
                 Text { text: "GiB"; color: Theme.c.subtext1; }
@@ -97,7 +99,7 @@ export component AlongsidePanel inherits Rectangle {
                 current-index <=> AlongsideState.swap-mode;
                 enabled: !AlongsideState.busy;
                 selected(value) => { AlongsideState.select-swap(self.current-index); }
-                changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } }
+                changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); }
             }
             if AlongsideState.swap-mode >= 2: HorizontalLayout {
                 spacing: 12px;
@@ -112,8 +114,8 @@ export component AlongsidePanel inherits Rectangle {
                     edited(value) => { self.dirty = true; }
                     accepted(value) => { self.dirty = false; if value.is-float() { AlongsideState.size-swap(value.to-float()); } self.text = "\{AlongsideState.swap-size}"; }
                     changed has-focus => {
-                        if self.has-focus { root.reveal(self.absolute-position.y, self.height); }
-                        else if self.dirty { self.dirty = false; if self.text.is-float() { AlongsideState.size-swap(self.text.to-float()); } self.text = "\{AlongsideState.swap-size}"; }
+                        root.reveal-if(self.has-focus, self.absolute-position.y, self.height);
+                        if !self.has-focus && self.dirty { self.dirty = false; if self.text.is-float() { AlongsideState.size-swap(self.text.to-float()); } self.text = "\{AlongsideState.swap-size}"; }
                     }
                 }
                 Text { text: "Taken from the allocation above; the remainder goes to ZFS."; horizontal-stretch: 1; color: Theme.c.subtext1; wrap: word-wrap; }
@@ -124,7 +126,7 @@ export component AlongsidePanel inherits Rectangle {
         if AlongsideState.efi-partitions.length > 0: VerticalLayout {
             spacing: 8px;
             Text { text: "EFI boot files"; font-weight: 600; color: Theme.c.text; }
-            efi-choice := ComboBox { changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } } accessible-label: "EFI partition"; model: AlongsideState.efi-partitions; current-index <=> AlongsideState.efi-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-efi(self.current-index); } }
+            efi-choice := ComboBox { changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } accessible-label: "EFI partition"; model: AlongsideState.efi-partitions; current-index <=> AlongsideState.efi-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-efi(self.current-index); } }
             Text { text: AlongsideState.efi-details; color: Theme.c.subtext1; wrap: word-wrap; }
             HorizontalLayout {
                 spacing: 12px;
@@ -158,7 +160,7 @@ export component AlongsidePanel inherits Rectangle {
                         accessible-enabled: available && !AlongsideState.busy;
                         accessible-action-default => { AlongsideState.additional(index == 1); }
                         clicked => { AlongsideState.additional(index == 1); }
-                        changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } }
+                        changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); }
                     }
                 }
             }

--- a/slint-ui/ui/components/radio-card.slint
+++ b/slint-ui/ui/components/radio-card.slint
@@ -1,0 +1,78 @@
+import { Theme } from "../styling.slint";
+import { RadioDot } from "radio-dot.slint";
+import { FocusTouchArea } from "internal/state-layer.slint";
+
+// One option in a row of mutually exclusive cards: a title, a short
+// description and a selection dot. `activated` reports a click or keyboard
+// activation; `reveal` reports the card's position when it gains focus so a
+// scrolling parent can bring it into view.
+//
+// The body is one unconditional layout: a layout wrapped in `if` does not
+// contribute its size to the card, which would collapse the row.
+export component RadioCard inherits Rectangle {
+    in property <string> title;
+    in property <string> description;
+    in property <bool> selected;
+    // Whether the option can be chosen at all; an unavailable card is dimmed.
+    in property <bool> available: true;
+    // Whether input is accepted right now (cleared while a survey runs).
+    in property <bool> enabled: true;
+    // Screen-reader and review-script name; the title by default.
+    in property <string> label: root.title;
+    // Compact rows draw the dot as a glyph in front of a larger title instead
+    // of a RadioDot column beside the body.
+    in property <bool> text-dot: false;
+    callback activated();
+    callback reveal(length, length);
+
+    horizontal-stretch: 1;
+    background: root.selected ? Theme.c.blue.with-alpha(0.16) : Theme.c.surface0.with-alpha(0.55);
+    border-radius: 8px;
+    border-width: touch.has-focus ? 2px : 1px;
+    border-color: touch.has-focus || root.selected ? Theme.c.blue : Theme.c.surface1;
+    opacity: root.available ? 1 : 0.5;
+
+    HorizontalLayout {
+        padding: root.text-dot ? 12px : 10px;
+        spacing: root.text-dot ? 0px : 8px;
+        RadioDot {
+            width: root.text-dot ? 0px : 18px;
+            visible: !root.text-dot;
+            filled: root.selected;
+            dot-color: Theme.c.blue;
+        }
+
+        VerticalLayout {
+            spacing: root.text-dot ? 5px : 3px;
+            alignment: root.text-dot ? LayoutAlignment.center : LayoutAlignment.stretch;
+            horizontal-stretch: 1;
+            Text {
+                text: (root.text-dot ? (root.selected ? "●  " : "○  ") : "") + root.title;
+                color: Theme.c.text;
+                font-size: root.text-dot ? 15px : 14px;
+                font-weight: 600;
+                wrap: word-wrap;
+            }
+
+            Text {
+                text: root.description;
+                color: Theme.c.subtext1;
+                font-size: 12px;
+                wrap: word-wrap;
+            }
+        }
+    }
+
+    touch := FocusTouchArea {
+        width: 100%;
+        height: 100%;
+        enabled: root.available && root.enabled;
+        accessible-role: radio-button;
+        accessible-label: root.label;
+        accessible-checked: root.selected;
+        accessible-enabled: root.available && root.enabled;
+        accessible-action-default => { root.activated(); }
+        clicked => { root.activated(); }
+        changed has-focus => { if self.has-focus { root.reveal(self.absolute-position.y, self.height); } }
+    }
+}

--- a/slint-ui/ui/components/storage-mode.slint
+++ b/slint-ui/ui/components/storage-mode.slint
@@ -1,6 +1,5 @@
-import { Theme } from "../styling.slint";
 import { WizardState } from "../state/wizard-state.slint";
-import { FocusTouchArea } from "internal/state-layer.slint";
+import { RadioCard } from "radio-card.slint";
 export component StorageMode inherits Rectangle {
     callback activated(string);
     height: 106px;
@@ -8,41 +7,12 @@ export component StorageMode inherits Rectangle {
         spacing: 12px;
         padding-top: 8px;
         padding-bottom: 14px;
-        for label[index] in ["Erase a disk", "Use existing partitions", "Use an existing pool", "Install alongside"]: Rectangle {
-            horizontal-stretch: 1;
-            background: WizardState.storage-mode == index ? Theme.c.blue.with-alpha(0.16) : Theme.c.surface0.with-alpha(0.55);
-            border-radius: 8px;
-            border-width: touch.has-focus ? 2px : 1px;
-            border-color: touch.has-focus || WizardState.storage-mode == index ? Theme.c.blue : Theme.c.surface1;
-            VerticalLayout {
-                padding: 12px;
-                spacing: 5px;
-                alignment: center;
-                Text {
-                    text: (WizardState.storage-mode == index ? "●  " : "○  ") + label;
-                    color: Theme.c.text;
-                    font-size: 15px;
-                    font-weight: 600;
-                    wrap: word-wrap;
-                }
-
-                Text {
-                    text: index == 0 ? "Create a new partition layout" : index == 1 ? "Create a new ZFS pool" : index == 2 ? "Create a new boot environment" : "Keep another operating system";
-                    color: Theme.c.subtext1;
-                    font-size: 12px;
-                    wrap: word-wrap;
-                }
-            }
-
-            touch := FocusTouchArea {
-                width: 100%;
-                height: 100%;
-                accessible-role: radio-button;
-                accessible-label: label;
-                accessible-checked: WizardState.storage-mode == index;
-                accessible-action-default => { root.activated("radio:installation_mode:" + index); }
-                clicked => { root.activated("radio:installation_mode:" + index); }
-            }
+        for label[index] in ["Erase a disk", "Use existing partitions", "Use an existing pool", "Install alongside"]: RadioCard {
+            title: label;
+            description: index == 0 ? "Create a new partition layout" : index == 1 ? "Create a new ZFS pool" : index == 2 ? "Create a new boot environment" : "Keep another operating system";
+            selected: WizardState.storage-mode == index;
+            text-dot: true;
+            activated => { root.activated("radio:installation_mode:" + index); }
         }
     }
 }

--- a/slint-ui/ui/popups/user-manage-popup.slint
+++ b/slint-ui/ui/popups/user-manage-popup.slint
@@ -60,6 +60,8 @@ export component UserManagePopup inherits Rectangle {
                             if y + self.content-y < 0px { self.content-y = -y; }
                             else if y + h + self.content-y > self.height { self.content-y = self.height - y - h; }
                         }
+                        // Scroll a control into view when it gains keyboard focus.
+                        function reveal-if(focused: bool, y: length, h: length) { if focused { self.reveal(y, h); } }
                         preferred-height: body.preferred-height;
                         body := VerticalLayout {
                             spacing: 12px;
@@ -99,7 +101,7 @@ export component UserManagePopup inherits Rectangle {
                                         width: 156px;
                                         accessible-label: "Administrator " + user.username;
                                         checked: user.has-sudo;
-                                        changed has-focus => { if self.has-focus { form-scroll.reveal(user-row.y, user-row.height); } }
+                                        changed has-focus => { form-scroll.reveal-if(self.has-focus, user-row.y, user-row.height); }
                                         toggled => { root.user-sudo-toggled(index); }
                                     }
 
@@ -108,7 +110,7 @@ export component UserManagePopup inherits Rectangle {
                                         height: 40px;
                                         outlined: true;
                                         accessible-label: "Remove user " + user.username;
-                                        changed has-focus => { if self.has-focus { form-scroll.reveal(user-row.y, user-row.height); } }
+                                        changed has-focus => { form-scroll.reveal-if(self.has-focus, user-row.y, user-row.height); }
                                         clicked => { root.user-removed(index); }
                                     }
                                 }
@@ -136,7 +138,7 @@ export component UserManagePopup inherits Rectangle {
                                 placeholder: "e.g. alex";
                                 accessible-label: "Username";
                                 edited(_) => { EditingState.user-error = ""; }
-                                changed has-focus => { if self.has-focus { form-scroll.reveal(self.y, self.height); } }
+                                changed has-focus => { form-scroll.reveal-if(self.has-focus, self.y, self.height); }
                             }
 
                             Text {
@@ -150,7 +152,7 @@ export component UserManagePopup inherits Rectangle {
                                 placeholder: "Set a sign-in password";
                                 accessible-label: "Account password";
                                 is-password: true;
-                                changed has-focus => { if self.has-focus { form-scroll.reveal(self.y, self.height); } }
+                                changed has-focus => { form-scroll.reveal-if(self.has-focus, self.y, self.height); }
                                 edited(val) => { root.password-edited(val); }
                             }
 
@@ -186,7 +188,7 @@ export component UserManagePopup inherits Rectangle {
                                 label: "Administrator (sudo)";
                                 height: 40px;
                                 checked: true;
-                                changed has-focus => { if self.has-focus { form-scroll.reveal(self.y, self.height); } }
+                                changed has-focus => { form-scroll.reveal-if(self.has-focus, self.y, self.height); }
                             }
                         }
                     }

--- a/tui/src/tui/screens/steps/desktop.rs
+++ b/tui/src/tui/screens/steps/desktop.rs
@@ -1,31 +1,28 @@
 use archinstall_zfs_core::config::edit::{ChoiceSetting, TextSetting};
 use archinstall_zfs_core::config::types::GlobalConfig;
 
-use super::{MenuItem, MenuKind, choice_group};
+use super::{MenuItem, choice_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let sel = config.profile_selection.as_ref();
     let profile_def = sel.and_then(|s| s.profile_def());
 
     let mut items = vec![
-        MenuItem {
-            key: "profile",
-            label: "Profile",
-            value: profile_def
+        MenuItem::custom(
+            "profile",
+            "Profile",
+            profile_def
                 .as_ref()
                 .map(|p| p.display_name.to_string())
                 .unwrap_or_else(|| "Not set".into()),
-            kind: MenuKind::Custom,
-        },
-        MenuItem {
-            key: "display_manager",
-            label: "Display manager",
-            value: sel
-                .and_then(|s| s.effective_display_manager())
+        ),
+        MenuItem::custom(
+            "display_manager",
+            "Display manager",
+            sel.and_then(|s| s.effective_display_manager())
                 .map(|d| d.display_name().to_string())
                 .unwrap_or_else(|| "Profile default".into()),
-            kind: MenuKind::Custom,
-        },
+        ),
     ];
 
     items.extend(choice_group(
@@ -40,71 +37,44 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         .as_ref()
         .is_some_and(|p| p.supports_gfx_driver())
     {
-        items.push(MenuItem {
-            key: "gpu_driver",
-            label: "GPU driver",
-            value: config
+        items.push(MenuItem::custom(
+            "gpu_driver",
+            "GPU driver",
+            config
                 .gfx_driver
                 .map(|d| d.to_string())
                 .unwrap_or("None".into()),
-            kind: MenuKind::Custom,
-        });
+        ));
     }
 
     items.extend(choice_group(ChoiceSetting::Audio, "Audio", config.audio));
 
     items.extend([
-        MenuItem {
-            key: "bluetooth",
-            label: "Bluetooth",
-            value: if config.bluetooth {
-                "Enabled"
+        MenuItem::toggle("bluetooth", "Bluetooth", config.bluetooth),
+        MenuItem::custom("packages", "Extra packages", {
+            let total = config.additional_packages.len() + config.aur_packages.len();
+            if total == 0 {
+                "None".into()
             } else {
-                "Disabled"
+                let mut parts: Vec<&str> = config
+                    .additional_packages
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect();
+                parts.extend(config.aur_packages.iter().map(|s| s.as_str()));
+                parts.join(", ")
             }
-            .into(),
-            kind: MenuKind::Toggle,
-        },
-        MenuItem {
-            key: "packages",
-            label: "Extra packages",
-            value: {
-                let total = config.additional_packages.len() + config.aur_packages.len();
-                if total == 0 {
-                    "None".into()
-                } else {
-                    let mut parts: Vec<&str> = config
-                        .additional_packages
-                        .iter()
-                        .map(|s| s.as_str())
-                        .collect();
-                    parts.extend(config.aur_packages.iter().map(|s| s.as_str()));
-                    parts.join(", ")
-                }
-            },
-            kind: MenuKind::Custom,
-        },
-        MenuItem {
-            key: TextSetting::ExtraServices.as_str(),
-            label: "Extra services",
-            value: if config.extra_services.is_empty() {
+        }),
+        MenuItem::text(
+            TextSetting::ExtraServices.as_str(),
+            "Extra services",
+            if config.extra_services.is_empty() {
                 "None".into()
             } else {
                 config.extra_services.join(", ")
             },
-            kind: MenuKind::Text,
-        },
-        MenuItem {
-            key: "zrepl",
-            label: "zrepl (snapshots)",
-            value: if config.zrepl_enabled {
-                "Enabled"
-            } else {
-                "Disabled"
-            }
-            .into(),
-            kind: MenuKind::Toggle,
-        },
+        ),
+        MenuItem::toggle("zrepl", "zrepl (snapshots)", config.zrepl_enabled),
     ]);
 
     items

--- a/tui/src/tui/screens/steps/disk.rs
+++ b/tui/src/tui/screens/steps/disk.rs
@@ -1,7 +1,18 @@
+use std::path::Path;
+
 use archinstall_zfs_core::config::edit::DeviceSetting;
 use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode};
 
-use super::{MenuItem, MenuKind};
+use super::MenuItem;
+
+fn device_row(setting: DeviceSetting, label: &'static str, path: Option<&Path>) -> MenuItem {
+    MenuItem::custom(
+        setting.as_str(),
+        label,
+        path.map(|p| p.display().to_string())
+            .unwrap_or("Not set".into()),
+    )
+}
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let mode = config.installation_mode;
@@ -9,16 +20,11 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
 
     // Show disk picker for FullDisk mode
     if matches!(mode, Some(InstallationMode::FullDisk) | None) {
-        items.push(MenuItem {
-            key: DeviceSetting::Disk.as_str(),
-            label: "Disk",
-            value: config
-                .disk
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or("Not set".into()),
-            kind: MenuKind::Custom,
-        });
+        items.push(device_row(
+            DeviceSetting::Disk,
+            "Disk",
+            config.disk.as_deref(),
+        ));
     }
 
     // Show partition pickers for NewPool/ExistingPool
@@ -26,44 +32,33 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         mode,
         Some(InstallationMode::NewPool) | Some(InstallationMode::ExistingPool)
     ) {
-        items.push(MenuItem {
-            key: DeviceSetting::EfiPartition.as_str(),
-            label: "EFI partition",
-            value: config
-                .efi_partition
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or("Not set".into()),
-            kind: MenuKind::Custom,
-        });
+        items.push(device_row(
+            DeviceSetting::EfiPartition,
+            "EFI partition",
+            config.efi_partition.as_deref(),
+        ));
     }
     if matches!(mode, Some(InstallationMode::NewPool)) {
-        items.push(MenuItem {
-            key: DeviceSetting::ZfsPartition.as_str(),
-            label: "ZFS partition",
-            value: config
-                .zfs_partition
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or("Not set".into()),
-            kind: MenuKind::Custom,
-        });
+        items.push(device_row(
+            DeviceSetting::ZfsPartition,
+            "ZFS partition",
+            config.zfs_partition.as_deref(),
+        ));
     }
 
     // The graphical installer owns alongside planning. A plan loaded from a
     // configuration file is shown so the page is not blank; it cannot be
     // edited here.
     if matches!(mode, Some(InstallationMode::Alongside)) {
-        items.push(MenuItem {
-            key: "",
-            label: "Alongside plan",
-            value: config
+        items.push(MenuItem::header(
+            "",
+            "Alongside plan",
+            config
                 .alongside
                 .as_ref()
                 .map(alongside_summary)
                 .unwrap_or_else(|| "Missing; create it with the graphical installer (azfs)".into()),
-            kind: MenuKind::SectionHeader,
-        });
+        ));
     }
 
     items

--- a/tui/src/tui/screens/steps/mod.rs
+++ b/tui/src/tui/screens/steps/mod.rs
@@ -8,6 +8,7 @@ pub mod zfs;
 
 use archinstall_zfs_core::config::choices::Choice;
 use archinstall_zfs_core::config::edit::ChoiceSetting;
+use archinstall_zfs_core::config::types::GlobalConfig;
 
 // ── Shared types for all wizard steps ──────────────────
 
@@ -105,8 +106,67 @@ pub struct MenuItem {
 }
 
 impl MenuItem {
+    pub fn new(
+        key: &'static str,
+        label: &'static str,
+        value: impl Into<String>,
+        kind: MenuKind,
+    ) -> Self {
+        Self {
+            key,
+            label,
+            value: value.into(),
+            kind,
+        }
+    }
+
+    /// Row edited through a custom handler; shows `value`.
+    pub fn custom(key: &'static str, label: &'static str, value: impl Into<String>) -> Self {
+        Self::new(key, label, value, MenuKind::Custom)
+    }
+
+    /// Free-form text input row.
+    pub fn text(key: &'static str, label: &'static str, value: impl Into<String>) -> Self {
+        Self::new(key, label, value, MenuKind::Text)
+    }
+
+    /// Boolean toggle row, rendered as `Enabled` / `Disabled`.
+    pub fn toggle(key: &'static str, label: &'static str, enabled: bool) -> Self {
+        let value = if enabled { "Enabled" } else { "Disabled" };
+        Self::new(key, label, value, MenuKind::Toggle)
+    }
+
+    /// Masked input row that only reveals whether a value is present.
+    pub fn secret(key: &'static str, label: &'static str, is_set: bool) -> Self {
+        let value = if is_set { "Set" } else { "Not set" };
+        Self::new(key, label, value, MenuKind::Password)
+    }
+
+    /// Non-selectable header, separator or read-only summary line.
+    pub fn header(key: &'static str, label: &'static str, value: impl Into<String>) -> Self {
+        Self::new(key, label, value, MenuKind::SectionHeader)
+    }
+
+    /// Action button without a value.
+    pub fn action(key: &'static str, label: &'static str) -> Self {
+        Self::new(key, label, String::new(), MenuKind::Action)
+    }
+
     pub fn is_selectable(&self) -> bool {
         !matches!(self.kind, MenuKind::SectionHeader | MenuKind::RadioHeader)
+    }
+}
+
+/// Menu rows for one wizard step.
+pub fn items_for(step: StepId, config: &GlobalConfig) -> Vec<MenuItem> {
+    match step {
+        StepId::Welcome => welcome::items(config),
+        StepId::Disk => disk::items(config),
+        StepId::Zfs => zfs::items(config),
+        StepId::System => system::items(config),
+        StepId::Users => users::items(config),
+        StepId::Desktop => desktop::items(config),
+        StepId::Review => review::items(config),
     }
 }
 
@@ -128,23 +188,23 @@ pub fn radio_group(
     options: &[&'static str],
     current: usize,
 ) -> Vec<MenuItem> {
-    let mut items = vec![MenuItem {
+    let mut items = vec![MenuItem::new(
         key,
         label,
-        value: String::new(),
-        kind: MenuKind::RadioHeader,
-    }];
+        String::new(),
+        MenuKind::RadioHeader,
+    )];
     for (i, &opt) in options.iter().enumerate() {
-        items.push(MenuItem {
+        items.push(MenuItem::new(
             key,
-            label: opt,
-            value: String::new(),
-            kind: MenuKind::RadioOption {
+            opt,
+            String::new(),
+            MenuKind::RadioOption {
                 group_key: key,
                 index: i,
                 selected: i == current,
             },
-        });
+        ));
     }
     items
 }

--- a/tui/src/tui/screens/steps/review.rs
+++ b/tui/src/tui/screens/steps/review.rs
@@ -1,28 +1,15 @@
 use archinstall_zfs_core::config::types::GlobalConfig;
 
-use super::{MenuItem, MenuKind, StepId};
+use super::{MenuItem, MenuKind, StepId, items_for};
 
 /// Build a read-only summary of all steps plus validation errors and action buttons.
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let mut items = Vec::new();
 
     for step in &StepId::ALL[..6] {
-        items.push(MenuItem {
-            key: "section",
-            label: step.label(),
-            value: String::new(),
-            kind: MenuKind::SectionHeader,
-        });
+        items.push(MenuItem::header("section", step.label(), String::new()));
 
-        let step_items = match step {
-            StepId::Welcome => super::welcome::items(config),
-            StepId::Disk => super::disk::items(config),
-            StepId::Zfs => super::zfs::items(config),
-            StepId::System => super::system::items(config),
-            StepId::Users => super::users::items(config),
-            StepId::Desktop => super::desktop::items(config),
-            StepId::Review => unreachable!(),
-        };
+        let step_items = items_for(*step, config);
 
         // Flatten radio groups: show "Header: Selected option" as one summary line
         let mut i = 0;
@@ -43,20 +30,14 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
                             break;
                         }
                     }
-                    items.push(MenuItem {
-                        key: "summary",
-                        label: header_label,
-                        value: selected_label.to_string(),
-                        kind: MenuKind::SectionHeader,
-                    });
+                    items.push(MenuItem::header(
+                        "summary",
+                        header_label,
+                        selected_label.to_string(),
+                    ));
                 }
                 _ => {
-                    items.push(MenuItem {
-                        key: item.key,
-                        label: item.label,
-                        value: item.value.clone(),
-                        kind: MenuKind::SectionHeader,
-                    });
+                    items.push(MenuItem::header(item.key, item.label, item.value.clone()));
                     i += 1;
                 }
             }
@@ -66,54 +47,23 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     // Validation errors
     let errors = config.validate_for_install();
     if !errors.is_empty() {
-        items.push(MenuItem {
-            key: "sep_errors",
-            label: "",
-            value: String::new(),
-            kind: MenuKind::SectionHeader,
-        });
-        items.push(MenuItem {
-            key: "errors_header",
-            label: "Validation Errors",
-            value: String::new(),
-            kind: MenuKind::SectionHeader,
-        });
+        items.push(MenuItem::header("sep_errors", "", String::new()));
+        items.push(MenuItem::header(
+            "errors_header",
+            "Validation Errors",
+            String::new(),
+        ));
         for error in &errors {
-            items.push(MenuItem {
-                key: "error",
-                label: "",
-                value: error.to_string(),
-                kind: MenuKind::SectionHeader,
-            });
+            items.push(MenuItem::header("error", "", error.to_string()));
         }
     }
 
-    items.push(MenuItem {
-        key: "sep_actions",
-        label: "",
-        value: String::new(),
-        kind: MenuKind::SectionHeader,
-    });
+    items.push(MenuItem::header("sep_actions", "", String::new()));
 
     items.extend([
-        MenuItem {
-            key: "save",
-            label: "Save configuration",
-            value: String::new(),
-            kind: MenuKind::Action,
-        },
-        MenuItem {
-            key: "install",
-            label: "Install",
-            value: String::new(),
-            kind: MenuKind::Action,
-        },
-        MenuItem {
-            key: "quit",
-            label: "Quit",
-            value: String::new(),
-            kind: MenuKind::Action,
-        },
+        MenuItem::action("save", "Save configuration"),
+        MenuItem::action("install", "Install"),
+        MenuItem::action("quit", "Quit"),
     ]);
 
     items

--- a/tui/src/tui/screens/steps/system.rs
+++ b/tui/src/tui/screens/steps/system.rs
@@ -1,21 +1,20 @@
 use archinstall_zfs_core::config::edit::{ChoiceSetting, EditorSetting, TextSetting};
 use archinstall_zfs_core::config::types::GlobalConfig;
 
-use super::{MenuItem, MenuKind, radio_group};
+use super::{MenuItem, radio_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let mut items = vec![
         // Before the kernel: which kernels exist depends on the answer here.
-        MenuItem {
-            key: EditorSetting::Distribution.as_str(),
-            label: "Distribution",
-            value: config.distribution().display_name.to_string(),
-            kind: MenuKind::Custom,
-        },
-        MenuItem {
-            key: EditorSetting::Kernel.as_str(),
-            label: "Kernel",
-            value: format!(
+        MenuItem::custom(
+            EditorSetting::Distribution.as_str(),
+            "Distribution",
+            config.distribution().display_name.to_string(),
+        ),
+        MenuItem::custom(
+            EditorSetting::Kernel.as_str(),
+            "Kernel",
+            format!(
                 "{} [{}]",
                 config
                     .kernels
@@ -24,38 +23,28 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
                     .unwrap_or_else(|| config.primary_kernel().to_string()),
                 config.zfs_module_mode
             ),
-            kind: MenuKind::Custom,
-        },
-        MenuItem {
-            key: TextSetting::Hostname.as_str(),
-            label: "Hostname",
-            value: config.hostname.clone().unwrap_or("Not set".into()),
-            kind: MenuKind::Text,
-        },
-        MenuItem {
-            key: EditorSetting::Locale.as_str(),
-            label: "Locale",
-            value: config.locale.clone().unwrap_or("Not set".into()),
-            kind: MenuKind::Custom,
-        },
-        MenuItem {
-            key: EditorSetting::Timezone.as_str(),
-            label: "Timezone",
-            value: config.timezone.clone().unwrap_or("Not set".into()),
-            kind: MenuKind::Custom,
-        },
-        MenuItem {
-            key: EditorSetting::Keyboard.as_str(),
-            label: "Keyboard layout",
-            value: config.keyboard_layout.clone(),
-            kind: MenuKind::Custom,
-        },
-        MenuItem {
-            key: "ntp",
-            label: "NTP (time sync)",
-            value: if config.ntp { "Enabled" } else { "Disabled" }.into(),
-            kind: MenuKind::Toggle,
-        },
+        ),
+        MenuItem::text(
+            TextSetting::Hostname.as_str(),
+            "Hostname",
+            config.hostname.clone().unwrap_or("Not set".into()),
+        ),
+        MenuItem::custom(
+            EditorSetting::Locale.as_str(),
+            "Locale",
+            config.locale.clone().unwrap_or("Not set".into()),
+        ),
+        MenuItem::custom(
+            EditorSetting::Timezone.as_str(),
+            "Timezone",
+            config.timezone.clone().unwrap_or("Not set".into()),
+        ),
+        MenuItem::custom(
+            EditorSetting::Keyboard.as_str(),
+            "Keyboard layout",
+            config.keyboard_layout.clone(),
+        ),
+        MenuItem::toggle("ntp", "NTP (time sync)", config.ntp),
     ];
 
     items.extend(radio_group(
@@ -65,12 +54,11 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
         if config.network_copy_iso { 0 } else { 1 },
     ));
 
-    items.push(MenuItem {
-        key: TextSetting::ParallelDownloads.as_str(),
-        label: "Parallel downloads",
-        value: config.parallel_downloads.to_string(),
-        kind: MenuKind::Text,
-    });
+    items.push(MenuItem::text(
+        TextSetting::ParallelDownloads.as_str(),
+        "Parallel downloads",
+        config.parallel_downloads.to_string(),
+    ));
 
     items
 }

--- a/tui/src/tui/screens/steps/users.rs
+++ b/tui/src/tui/screens/steps/users.rs
@@ -1,31 +1,25 @@
 use archinstall_zfs_core::config::edit::TextSetting;
 use archinstall_zfs_core::config::types::GlobalConfig;
 
-use super::{MenuItem, MenuKind};
+use super::MenuItem;
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     vec![
-        MenuItem {
-            key: TextSetting::RootPassword.as_str(),
-            label: "Root password",
-            value: if config.root_password.is_some() {
-                "Set".into()
-            } else {
-                "Not set".into()
-            },
-            kind: MenuKind::Password,
-        },
-        MenuItem {
-            key: "users",
-            label: "User accounts",
-            value: match &config.users {
+        MenuItem::secret(
+            TextSetting::RootPassword.as_str(),
+            "Root password",
+            config.root_password.is_some(),
+        ),
+        MenuItem::custom(
+            "users",
+            "User accounts",
+            match &config.users {
                 Some(users) if !users.is_empty() => {
                     let names: Vec<&str> = users.iter().map(|u| u.username.as_str()).collect();
                     names.join(", ")
                 }
                 _ => "None".into(),
             },
-            kind: MenuKind::Custom,
-        },
+        ),
     ]
 }

--- a/tui/src/tui/screens/steps/welcome.rs
+++ b/tui/src/tui/screens/steps/welcome.rs
@@ -15,11 +15,10 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     // The graphical allocation editor owns alongside plan construction. Do not
     // expose an option that this frontend cannot configure.
     items.retain(|item| !matches!(item.kind, MenuKind::RadioOption { index, .. } if index == InstallationMode::Alongside.index()));
-    items.push(MenuItem {
-        key: "",
-        label: "For installation alongside another OS, use the graphical installer (azfs).",
-        value: String::new(),
-        kind: MenuKind::SectionHeader,
-    });
+    items.push(MenuItem::header(
+        "",
+        "For installation alongside another OS, use the graphical installer (azfs).",
+        String::new(),
+    ));
     items
 }

--- a/tui/src/tui/screens/steps/zfs.rs
+++ b/tui/src/tui/screens/steps/zfs.rs
@@ -1,16 +1,11 @@
 use archinstall_zfs_core::config::edit::{ChoiceSetting, DeviceSetting, TextSetting};
-use archinstall_zfs_core::config::types::{
-    GlobalConfig, InstallationMode, SwapMode, ZfsEncryptionMode,
-};
+use archinstall_zfs_core::config::types::{GlobalConfig, InstallationMode, ZfsEncryptionMode};
 
 use super::{MenuItem, MenuKind, choice_group};
 
 pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let mode = config.installation_mode;
-    let has_swap_partition = matches!(
-        config.swap_mode,
-        SwapMode::ZswapPartition | SwapMode::ZswapPartitionEncrypted
-    );
+    let has_swap_partition = config.swap_mode.uses_partition();
 
     let mut items = vec![
         MenuItem {

--- a/tui/src/tui/screens/steps/zfs.rs
+++ b/tui/src/tui/screens/steps/zfs.rs
@@ -8,22 +8,21 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     let has_swap_partition = config.swap_mode.uses_partition();
 
     let mut items = vec![
-        MenuItem {
-            key: TextSetting::PoolName.as_str(),
-            label: "Pool name",
-            value: config.pool_name.clone().unwrap_or("Not set".into()),
-            kind: if matches!(mode, Some(InstallationMode::ExistingPool)) {
+        MenuItem::new(
+            TextSetting::PoolName.as_str(),
+            "Pool name",
+            config.pool_name.clone().unwrap_or("Not set".into()),
+            if matches!(mode, Some(InstallationMode::ExistingPool)) {
                 MenuKind::Custom
             } else {
                 MenuKind::Text
             },
-        },
-        MenuItem {
-            key: TextSetting::DatasetPrefix.as_str(),
-            label: "Dataset prefix",
-            value: config.dataset_prefix.clone(),
-            kind: MenuKind::Text,
-        },
+        ),
+        MenuItem::text(
+            TextSetting::DatasetPrefix.as_str(),
+            "Dataset prefix",
+            config.dataset_prefix.clone(),
+        ),
     ];
 
     items.extend(choice_group(
@@ -39,16 +38,11 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     ));
 
     if config.zfs_encryption_mode != ZfsEncryptionMode::None {
-        items.push(MenuItem {
-            key: TextSetting::EncryptionPassword.as_str(),
-            label: "Encryption password",
-            value: if config.zfs_encryption_password.is_some() {
-                "Set".into()
-            } else {
-                "Not set".into()
-            },
-            kind: MenuKind::Password,
-        });
+        items.push(MenuItem::secret(
+            TextSetting::EncryptionPassword.as_str(),
+            "Encryption password",
+            config.zfs_encryption_password.is_some(),
+        ));
     }
 
     items.extend(choice_group(
@@ -58,27 +52,25 @@ pub fn items(config: &GlobalConfig) -> Vec<MenuItem> {
     ));
 
     if matches!(mode, Some(InstallationMode::FullDisk)) && has_swap_partition {
-        items.push(MenuItem {
-            key: TextSetting::SwapPartitionSize.as_str(),
-            label: "Swap size",
-            value: config
+        items.push(MenuItem::text(
+            TextSetting::SwapPartitionSize.as_str(),
+            "Swap size",
+            config
                 .swap_partition_size
                 .clone()
                 .unwrap_or("Not set".into()),
-            kind: MenuKind::Text,
-        });
+        ));
     }
     if !matches!(mode, Some(InstallationMode::FullDisk) | None) && has_swap_partition {
-        items.push(MenuItem {
-            key: DeviceSetting::SwapPartition.as_str(),
-            label: "Swap partition",
-            value: config
+        items.push(MenuItem::custom(
+            DeviceSetting::SwapPartition.as_str(),
+            "Swap partition",
+            config
                 .swap_partition
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or("Not set".into()),
-            kind: MenuKind::Custom,
-        });
+        ));
     }
 
     items.extend(choice_group(

--- a/tui/src/tui/screens/wizard.rs
+++ b/tui/src/tui/screens/wizard.rs
@@ -50,15 +50,7 @@ impl Wizard {
     }
 
     fn items(&self) -> Vec<MenuItem> {
-        match self.current_step {
-            StepId::Welcome => super::steps::welcome::items(&self.config),
-            StepId::Disk => super::steps::disk::items(&self.config),
-            StepId::Zfs => super::steps::zfs::items(&self.config),
-            StepId::System => super::steps::system::items(&self.config),
-            StepId::Users => super::steps::users::items(&self.config),
-            StepId::Desktop => super::steps::desktop::items(&self.config),
-            StepId::Review => super::steps::review::items(&self.config),
-        }
+        super::steps::items_for(self.current_step, &self.config)
     }
 
     fn selectable_indices(&self) -> Vec<usize> {

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -1,0 +1,398 @@
+//! Download benchmark: repeated installs at several concurrency levels and
+//! the analysis of the metrics they leave behind.
+
+use std::path::{Path, PathBuf};
+
+use crate::{TestOpts, check_prerequisites, cmd_test_install};
+
+// ── bench-downloads ────────────────────────────────────
+
+/// Patch `parallel_downloads` in a JSON config and write to a temp file.
+fn patch_config_concurrency(
+    config_path: &Path,
+    concurrency: usize,
+    dest: &Path,
+) -> Result<(), String> {
+    let content = std::fs::read_to_string(config_path).map_err(|e| format!("read config: {e}"))?;
+    let mut v: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| format!("parse config: {e}"))?;
+    v["parallel_downloads"] = serde_json::json!(concurrency);
+    let patched = serde_json::to_string_pretty(&v).map_err(|e| format!("serialize config: {e}"))?;
+    std::fs::write(dest, patched).map_err(|e| format!("write patched config: {e}"))?;
+    Ok(())
+}
+
+pub fn cmd_bench_downloads(
+    opts: TestOpts,
+    concurrency_spec: &str,
+    out_dir: &Path,
+    samples: usize,
+) -> Result<(), String> {
+    check_prerequisites(&opts)?;
+    std::fs::create_dir_all(out_dir).map_err(|e| format!("create out_dir: {e}"))?;
+
+    let samples = samples.max(1);
+
+    // Parse comma-separated concurrency values
+    let concurrencies: Vec<usize> = concurrency_spec
+        .split(',')
+        .map(|s| {
+            s.trim()
+                .parse::<usize>()
+                .map_err(|_| format!("invalid concurrency value: '{s}'"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    eprintln!(
+        "=== bench-downloads: {} concurrency levels × {} sample(s): {:?} ===",
+        concurrencies.len(),
+        samples,
+        concurrencies
+    );
+
+    for &conc in &concurrencies {
+        eprintln!("\n--- concurrency={conc} ({samples} sample(s)) ---");
+
+        // Write patched config to a temp file (shared across all samples)
+        let patched_config = out_dir.join(format!("config_conc{conc}.json"));
+        patch_config_concurrency(&opts.paths.config, conc, &patched_config)?;
+
+        // Track phase4 wall time for each sample to pick the median
+        let mut sample_files: Vec<PathBuf> = Vec::new();
+        let mut phase4_times: Vec<u64> = Vec::new();
+
+        for s in 1..=samples {
+            eprintln!("  sample {s}/{samples}");
+
+            let mut run_opts = opts.clone();
+            run_opts.paths.config = patched_config.clone();
+            cmd_test_install(run_opts)?;
+
+            let local_metrics = PathBuf::from("/tmp/archinstall-metrics.jsonl");
+            let sample_dest = out_dir.join(format!("conc_{conc}_s{s}.jsonl"));
+            if local_metrics.exists() {
+                std::fs::copy(&local_metrics, &sample_dest)
+                    .map_err(|e| format!("copy metrics sample: {e}"))?;
+                eprintln!("    saved {}", sample_dest.display());
+
+                // Extract phase 4 wall time from this sample
+                let content = std::fs::read_to_string(&sample_dest).unwrap_or_default();
+                let ph4_time = phase4_wall_ms_from_jsonl(&content);
+                eprintln!("    phase4 wall: {:.1}s", ph4_time as f64 / 1000.0);
+                phase4_times.push(ph4_time);
+                sample_files.push(sample_dest);
+            } else {
+                eprintln!("    Warning: metrics file not found");
+                phase4_times.push(u64::MAX);
+                sample_files.push(PathBuf::new());
+            }
+        }
+
+        // Pick the median sample (by phase 4 wall time) as the canonical result
+        let median_idx = median_index(&phase4_times);
+        let canonical = out_dir.join(format!("conc_{conc}.jsonl"));
+        if sample_files[median_idx].exists() {
+            std::fs::copy(&sample_files[median_idx], &canonical)
+                .map_err(|e| format!("copy median sample: {e}"))?;
+            eprintln!(
+                "  Median sample: s{} ({:.1}s) → {}",
+                median_idx + 1,
+                phase4_times[median_idx] as f64 / 1000.0,
+                canonical.display()
+            );
+        }
+        if samples > 1 {
+            let mut sorted = phase4_times.clone();
+            sorted.retain(|&t| t != u64::MAX);
+            sorted.sort_unstable();
+            let min_s = sorted.first().copied().unwrap_or(0) as f64 / 1000.0;
+            let max_s = sorted.last().copied().unwrap_or(0) as f64 / 1000.0;
+            eprintln!("  Phase4 range: {min_s:.1}s – {max_s:.1}s");
+        }
+    }
+
+    eprintln!("\n=== bench-downloads: complete ===");
+    eprintln!(
+        "Run 'cargo xtask analyze-metrics --dir {}' to see results.",
+        out_dir.display()
+    );
+    Ok(())
+}
+
+/// Extract the phase-4 wall-clock time (ms) from a JSONL string.
+/// Returns phase_5.ts_ms - phase_4.ts_ms, or 0 if either is missing.
+fn phase4_wall_ms_from_jsonl(content: &str) -> u64 {
+    let mut ts4 = None;
+    let mut ts5 = None;
+    for line in content.lines() {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if v.get("event").and_then(|e| e.as_str()) == Some("phase_start") {
+            let num = v.get("num").and_then(|n| n.as_u64()).unwrap_or(0);
+            let ts = v.get("ts_ms").and_then(|t| t.as_u64()).unwrap_or(0);
+            match num {
+                4 => ts4 = Some(ts),
+                5 => ts5 = Some(ts),
+                _ => {}
+            }
+        }
+    }
+    match (ts4, ts5) {
+        (Some(t4), Some(t5)) if t5 > t4 => t5 - t4,
+        _ => 0,
+    }
+}
+
+/// Return the index of the median value in a slice.
+fn median_index(values: &[u64]) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    let mut indexed: Vec<(usize, u64)> = values.iter().copied().enumerate().collect();
+    indexed.sort_by_key(|&(_, v)| v);
+    indexed[indexed.len() / 2].0
+}
+
+// ── analyze-metrics ────────────────────────────────────
+
+#[derive(Default)]
+struct RunStats {
+    concurrency: usize,
+    pkg_count: u64,
+    total_bytes: u64,
+    total_dl_ms: u64,
+    max_speed_bps: u64,
+    avg_speed_bps: u64,
+    batch_install_ms: u64,
+    phases: Vec<(u32, String, u64)>, // (num, name, ts_ms)
+}
+
+pub fn cmd_analyze_metrics(dir: &Path) -> Result<(), String> {
+    if !dir.exists() {
+        return Err(format!("directory not found: {}", dir.display()));
+    }
+
+    // Collect canonical conc_N.jsonl files, sorted by N
+    let mut entries: Vec<(usize, PathBuf)> = std::fs::read_dir(dir)
+        .map_err(|e| format!("read dir: {e}"))?
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().into_string().ok()?;
+            let stem = name.strip_suffix(".jsonl")?;
+            // Only canonical files (conc_N, not conc_N_sM)
+            let n = stem.strip_prefix("conc_")?;
+            if n.contains('_') {
+                return None;
+            }
+            let n = n.parse::<usize>().ok()?;
+            Some((n, e.path()))
+        })
+        .collect();
+    entries.sort_by_key(|(n, _)| *n);
+
+    if entries.is_empty() {
+        return Err(format!("no conc_N.jsonl files found in {}", dir.display()));
+    }
+
+    // Also check for per-sample files to compute scatter
+    let mut sample_map: std::collections::HashMap<usize, Vec<u64>> = Default::default();
+    for e in std::fs::read_dir(dir)
+        .map_err(|e| format!("read dir: {e}"))?
+        .filter_map(|e| e.ok())
+    {
+        let name = e.file_name().into_string().unwrap_or_default();
+        let stem = name.strip_suffix(".jsonl").unwrap_or("");
+        // matches conc_N_sM
+        if let Some(rest) = stem.strip_prefix("conc_") {
+            let parts: Vec<&str> = rest.splitn(2, '_').collect();
+            if parts.len() == 2
+                && let (Ok(n), Some(_s)) = (parts[0].parse::<usize>(), parts[1].strip_prefix('s'))
+                && let Ok(content) = std::fs::read_to_string(e.path())
+            {
+                let t = phase4_wall_ms_from_jsonl(&content);
+                sample_map.entry(n).or_default().push(t);
+            }
+        }
+    }
+
+    let mut rows: Vec<RunStats> = Vec::new();
+
+    for (conc, path) in &entries {
+        let content =
+            std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+
+        let mut stats = RunStats {
+            concurrency: *conc,
+            ..Default::default()
+        };
+
+        let mut phase_ts: Vec<(u32, String, u64)> = Vec::new();
+        let mut dl_speeds: Vec<u64> = Vec::new();
+
+        for line in content.lines() {
+            let v: serde_json::Value = match serde_json::from_str(line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let event = v.get("event").and_then(|e| e.as_str()).unwrap_or("");
+            let ts_ms = v.get("ts_ms").and_then(|t| t.as_u64()).unwrap_or(0);
+
+            match event {
+                "pkg_download" => {
+                    let bytes = v.get("bytes").and_then(|b| b.as_u64()).unwrap_or(0);
+                    let speed_bps = v.get("speed_bps").and_then(|s| s.as_u64()).unwrap_or(0);
+                    stats.pkg_count += 1;
+                    stats.total_bytes += bytes;
+                    dl_speeds.push(speed_bps);
+                    if speed_bps > stats.max_speed_bps {
+                        stats.max_speed_bps = speed_bps;
+                    }
+                }
+                "batch_install" => {
+                    stats.batch_install_ms +=
+                        v.get("duration_ms").and_then(|d| d.as_u64()).unwrap_or(0);
+                }
+                "phase_start" => {
+                    let num = v.get("num").and_then(|n| n.as_u64()).unwrap_or(0) as u32;
+                    let name = v
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    phase_ts.push((num, name, ts_ms));
+                }
+                _ => {}
+            }
+        }
+
+        if !dl_speeds.is_empty() {
+            stats.avg_speed_bps = dl_speeds.iter().sum::<u64>() / dl_speeds.len() as u64;
+        }
+
+        // Use phase4→phase5 timestamps for wall-clock download time
+        if let Some((_, _, ts4)) = phase_ts.iter().find(|(n, _, _)| *n == 4)
+            && let Some((_, _, ts5)) = phase_ts.iter().find(|(n, _, _)| *n == 5)
+        {
+            stats.total_dl_ms = ts5 - ts4;
+        }
+        // total_bytes must be measured from pkg_download events (set above, but reset by wall logic)
+        // re-sum bytes properly
+        stats.total_bytes = 0;
+        for line in content.lines() {
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+                continue;
+            };
+            if v.get("event").and_then(|e| e.as_str()) == Some("pkg_download") {
+                stats.total_bytes += v.get("bytes").and_then(|b| b.as_u64()).unwrap_or(0);
+            }
+        }
+
+        stats.phases = phase_ts;
+        rows.push(stats);
+    }
+
+    // Print markdown table
+    println!("## Download Benchmark Results\n");
+
+    // Check if we have multi-sample scatter
+    let has_scatter = sample_map.values().any(|v| v.len() > 1);
+
+    if has_scatter {
+        println!(
+            "| conc | pkgs | total_MB | dl_med_s | dl_min_s | dl_max_s | avg_MBps | max_MBps | install_s |"
+        );
+        println!(
+            "|-----:|-----:|---------:|---------:|---------:|---------:|---------:|---------:|----------:|"
+        );
+    } else {
+        println!("| conc | pkgs | total_MB | dl_wall_s | avg_MBps | max_MBps | install_s |");
+        println!("|-----:|-----:|---------:|----------:|---------:|---------:|----------:|");
+    }
+
+    for r in &rows {
+        let total_mb = r.total_bytes as f64 / 1_048_576.0;
+        let dl_wall_s = r.total_dl_ms as f64 / 1000.0;
+        let avg_mbps = r.avg_speed_bps as f64 / 1_048_576.0;
+        let max_mbps = r.max_speed_bps as f64 / 1_048_576.0;
+        let install_s = r.batch_install_ms as f64 / 1000.0;
+
+        if has_scatter {
+            let mut samples = sample_map.get(&r.concurrency).cloned().unwrap_or_default();
+            samples.sort_unstable();
+            let min_s = samples.first().copied().unwrap_or(0) as f64 / 1000.0;
+            let max_s = samples.last().copied().unwrap_or(0) as f64 / 1000.0;
+            println!(
+                "| {:>4} | {:>4} | {:>8.1} | {:>8.1} | {:>8.1} | {:>8.1} | {:>8.2} | {:>8.2} | {:>9.1} |",
+                r.concurrency,
+                r.pkg_count,
+                total_mb,
+                dl_wall_s,
+                min_s,
+                max_s,
+                avg_mbps,
+                max_mbps,
+                install_s
+            );
+        } else {
+            println!(
+                "| {:>4} | {:>4} | {:>8.1} | {:>9.1} | {:>8.2} | {:>8.2} | {:>9.1} |",
+                r.concurrency, r.pkg_count, total_mb, dl_wall_s, avg_mbps, max_mbps, install_s
+            );
+        }
+    }
+
+    // Per-phase breakdown for each run
+    println!("\n## Phase Timings (seconds)\n");
+    let all_phases: Vec<u32> = {
+        let mut nums: Vec<u32> = rows
+            .iter()
+            .flat_map(|r| r.phases.iter().map(|(n, _, _)| *n))
+            .collect();
+        nums.sort_unstable();
+        nums.dedup();
+        nums
+    };
+
+    if !all_phases.is_empty() {
+        let header_phases: String = all_phases
+            .iter()
+            .map(|n| format!("| Ph{n:>2} "))
+            .collect::<Vec<_>>()
+            .join("");
+        println!("| conc {header_phases}|");
+        let sep: String = all_phases
+            .iter()
+            .map(|_| "|-----:")
+            .collect::<Vec<_>>()
+            .join("");
+        println!("|-----:{sep}|");
+
+        for r in &rows {
+            let phase_map: std::collections::HashMap<u32, u64> = r
+                .phases
+                .windows(2)
+                .map(|w| {
+                    let (n1, _, ts1) = &w[0];
+                    let (_, _, ts2) = &w[1];
+                    (*n1, ts2 - ts1)
+                })
+                .collect();
+
+            let cells: String = all_phases
+                .iter()
+                .map(|n| {
+                    if let Some(&dur) = phase_map.get(n) {
+                        format!("| {:>4.1}s", dur as f64 / 1000.0)
+                    } else {
+                        "|    - ".to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            println!("| {:>4} {cells} |", r.concurrency);
+        }
+    }
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,14 +1,16 @@
 mod alongside;
+mod bench;
 mod iso;
 mod qemu;
+mod verify;
 
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 use std::time::Duration;
 
-use clap::{Parser, Subcommand, ValueEnum};
-use serde_json::{Value, json};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use serde_json::{Map, Value, json};
 
 use qemu::QemuVm;
 
@@ -18,6 +20,15 @@ enum ZfsModeOpt {
     Dkms,
 }
 
+impl ZfsModeOpt {
+    fn as_str(self) -> &'static str {
+        match self {
+            ZfsModeOpt::Precompiled => "precompiled",
+            ZfsModeOpt::Dkms => "dkms",
+        }
+    }
+}
+
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 enum EncryptionOpt {
     None,
@@ -25,10 +36,29 @@ enum EncryptionOpt {
     Dataset,
 }
 
+impl EncryptionOpt {
+    fn as_str(self) -> &'static str {
+        match self {
+            EncryptionOpt::None => "none",
+            EncryptionOpt::Pool => "pool",
+            EncryptionOpt::Dataset => "dataset",
+        }
+    }
+}
+
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 enum InitOpt {
     Dracut,
     Mkinitcpio,
+}
+
+impl InitOpt {
+    fn as_str(self) -> &'static str {
+        match self {
+            InitOpt::Dracut => "dracut",
+            InitOpt::Mkinitcpio => "mkinitcpio",
+        }
+    }
 }
 
 #[derive(Parser)]
@@ -112,11 +142,28 @@ enum Commands {
     },
 }
 
-#[derive(Parser, Clone)]
+#[derive(Args, Clone)]
 struct TestOpts {
     /// Install by shrinking an ext4 fixture in the disposable VM; verify retained files.
     #[arg(long)]
     alongside: bool,
+
+    #[command(flatten)]
+    paths: PathOpts,
+
+    #[command(flatten)]
+    cache: CacheOpts,
+
+    #[command(flatten)]
+    ssh: SshOpts,
+
+    #[command(flatten)]
+    overrides: OverrideOpts,
+}
+
+/// Inputs of a run and the scratch files it writes.
+#[derive(Args, Clone)]
+struct PathOpts {
     /// Testing ISO to boot. By default, use the newest *-testing-*.iso.
     /// Custom images must allow passwordless root SSH on the ISO VM.
     #[arg(long)]
@@ -141,7 +188,11 @@ struct TestOpts {
     /// Place disk image and UEFI vars in /tmp (tmpfs) for faster I/O
     #[arg(long)]
     tmpfs: bool,
+}
 
+/// Host-side package and source cache shared into the guest.
+#[derive(Args, Clone)]
+struct CacheOpts {
     /// Directory on the host holding downloaded packages and sources, reused
     /// across runs. Created if missing; --no-cache turns it off.
     #[arg(long, default_value = "/var/tmp/archinstall-zfs-cache")]
@@ -150,7 +201,11 @@ struct TestOpts {
     /// Download everything again instead of reusing the host cache.
     #[arg(long)]
     no_cache: bool,
+}
 
+/// How the VMs are reached.
+#[derive(Args, Clone)]
+struct SshOpts {
     /// SSH port for ISO VM
     #[arg(long, default_value_t = 2222)]
     iso_port: u16,
@@ -166,8 +221,11 @@ struct TestOpts {
     /// SSH/boot timeout in seconds
     #[arg(long, default_value_t = 120)]
     timeout: u64,
+}
 
-    // ── Config overrides (layered on --config) ──────────
+/// Config overrides (layered on --config).
+#[derive(Args, Clone)]
+struct OverrideOpts {
     /// Override zfs_module_mode
     #[arg(long, value_enum)]
     zfs_mode: Option<ZfsModeOpt>,
@@ -194,88 +252,92 @@ struct TestOpts {
 }
 
 fn apply_tmpfs(mut opts: TestOpts) -> TestOpts {
-    if opts.tmpfs {
-        opts.disk = PathBuf::from("/tmp/archzfs-test.qcow2");
-        opts.vars = PathBuf::from("/tmp/archzfs-test-vars.fd");
+    if opts.paths.tmpfs {
+        opts.paths.disk = PathBuf::from("/tmp/archzfs-test.qcow2");
+        opts.paths.vars = PathBuf::from("/tmp/archzfs-test-vars.fd");
         eprintln!(
             "Using tmpfs: disk={}, vars={}",
-            opts.disk.display(),
-            opts.vars.display()
+            opts.paths.disk.display(),
+            opts.paths.vars.display()
         );
     }
     opts
+}
+
+/// Insert `key` when a value is given and remember that the config changed.
+fn set_if_some(obj: &mut Map<String, Value>, changed: &mut bool, key: &str, value: Option<Value>) {
+    if let Some(value) = value {
+        obj.insert(key.into(), value);
+        *changed = true;
+    }
 }
 
 /// Apply CLI overrides to the base config, write the merged JSON to a temp
 /// file, and point opts.config at it. Downstream code then reads the merged
 /// config transparently (including detect_init_system and scp_to).
 fn materialize_config(mut opts: TestOpts) -> Result<TestOpts, String> {
-    let content = fs::read_to_string(&opts.config)
-        .map_err(|e| format!("read {}: {e}", opts.config.display()))?;
+    let content = fs::read_to_string(&opts.paths.config)
+        .map_err(|e| format!("read {}: {e}", opts.paths.config.display()))?;
     let mut json: Value = serde_json::from_str(&content)
-        .map_err(|e| format!("parse {}: {e}", opts.config.display()))?;
+        .map_err(|e| format!("parse {}: {e}", opts.paths.config.display()))?;
     let obj = json
         .as_object_mut()
         .ok_or_else(|| "config JSON must be an object".to_string())?;
+    let overrides = &opts.overrides;
 
     let mut changed = false;
-    if let Some(m) = opts.zfs_mode {
-        obj.insert(
-            "zfs_module_mode".into(),
-            json!(match m {
-                ZfsModeOpt::Precompiled => "precompiled",
-                ZfsModeOpt::Dkms => "dkms",
-            }),
-        );
-        changed = true;
-    }
-    if let Some(e) = opts.encryption {
-        let mode = match e {
-            EncryptionOpt::None => "none",
-            EncryptionOpt::Pool => "pool",
-            EncryptionOpt::Dataset => "dataset",
-        };
-        obj.insert("zfs_encryption_mode".into(), json!(mode));
-        if e != EncryptionOpt::None {
-            obj.insert(
-                "zfs_encryption_password".into(),
-                json!(opts.encryption_password),
-            );
-        }
-        changed = true;
-    }
-    if let Some(i) = opts.init_system {
-        obj.insert(
-            "init_system".into(),
-            json!(match i {
-                InitOpt::Dracut => "dracut",
-                InitOpt::Mkinitcpio => "mkinitcpio",
-            }),
-        );
-        changed = true;
-    }
-    if let Some(ref pkgs) = opts.aur_packages {
-        obj.insert("aur_packages".into(), json!(pkgs));
-        changed = true;
-    }
-    if let Some(ref p) = opts.profile {
-        obj.insert(
-            "profile_selection".into(),
+    set_if_some(
+        obj,
+        &mut changed,
+        "zfs_module_mode",
+        overrides.zfs_mode.map(|m| json!(m.as_str())),
+    );
+    set_if_some(
+        obj,
+        &mut changed,
+        "zfs_encryption_mode",
+        overrides.encryption.map(|e| json!(e.as_str())),
+    );
+    set_if_some(
+        obj,
+        &mut changed,
+        "zfs_encryption_password",
+        overrides
+            .encryption
+            .filter(|e| *e != EncryptionOpt::None)
+            .map(|_| json!(overrides.encryption_password)),
+    );
+    set_if_some(
+        obj,
+        &mut changed,
+        "init_system",
+        overrides.init_system.map(|i| json!(i.as_str())),
+    );
+    set_if_some(
+        obj,
+        &mut changed,
+        "aur_packages",
+        overrides.aur_packages.as_ref().map(|pkgs| json!(pkgs)),
+    );
+    set_if_some(
+        obj,
+        &mut changed,
+        "profile_selection",
+        overrides.profile.as_ref().map(|p| {
             json!({
                 "profile": p,
                 "optional_packages": [],
                 "display_manager_override": null,
-            }),
-        );
-        changed = true;
-    }
+            })
+        }),
+    );
 
     if changed {
         let tmp = std::env::temp_dir().join("archzfs-xtask-merged.json");
         fs::write(&tmp, serde_json::to_string_pretty(&json).unwrap())
             .map_err(|e| format!("write merged config: {e}"))?;
         eprintln!("Merged config written to {}", tmp.display());
-        opts.config = tmp;
+        opts.paths.config = tmp;
     }
 
     Ok(opts)
@@ -297,8 +359,8 @@ fn main() -> ExitCode {
             out_dir,
             samples,
         } => materialize_config(apply_tmpfs(opts))
-            .and_then(|o| cmd_bench_downloads(o, &concurrency, &out_dir, samples)),
-        Commands::AnalyzeMetrics { dir } => cmd_analyze_metrics(&dir),
+            .and_then(|o| bench::cmd_bench_downloads(o, &concurrency, &out_dir, samples)),
+        Commands::AnalyzeMetrics { dir } => bench::cmd_analyze_metrics(&dir),
         Commands::RenderProfile {
             profile_dir,
             out_dir,
@@ -328,22 +390,12 @@ fn cmd_test_vm(opts: TestOpts) -> Result<(), String> {
     Ok(())
 }
 
-/// Detect the init system from the JSON config file.
-fn detect_init_system(config: &Path) -> String {
-    let content = std::fs::read_to_string(config).unwrap_or_default();
-    if content.contains("\"mkinitcpio\"") {
-        "mkinitcpio".to_string()
-    } else {
-        "dracut".to_string()
-    }
-}
-
 /// Prepare the directory shared into the guest, or `None` when caching is off.
 ///
 /// Holds two things: the packages the installer downloads, which is the
 /// gigabyte that would otherwise be fetched again on every run, and the
 /// sources makepkg needs for the AUR builds.
-fn prepare_cache(opts: &TestOpts) -> Result<Option<PathBuf>, String> {
+fn prepare_cache(opts: &CacheOpts) -> Result<Option<PathBuf>, String> {
     if opts.no_cache {
         return Ok(None);
     }
@@ -423,8 +475,9 @@ fn seed_aur_sources(dir: &Path) {
 
 fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
     check_prerequisites(&opts)?;
-    let timeout = Duration::from_secs(opts.timeout);
-    let iso = match &opts.iso {
+    let paths = &opts.paths;
+    let timeout = Duration::from_secs(opts.ssh.timeout);
+    let iso = match &paths.iso {
         Some(path) if path.is_file() => path.clone(),
         Some(path) => return Err(format!("ISO not found: {}", path.display())),
         None => qemu::find_latest_testing_iso()?,
@@ -435,11 +488,11 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
 
     // Fresh environment
     eprintln!("[1/4] Creating fresh disk and UEFI vars");
-    qemu::create_fresh_disk(&opts.disk);
+    qemu::create_fresh_disk(&paths.disk);
     if opts.alongside {
         let status = Command::new("qemu-img")
             .args(["resize"])
-            .arg(&opts.disk)
+            .arg(&paths.disk)
             .arg("80G")
             .status()
             .map_err(|e| e.to_string())?;
@@ -447,16 +500,16 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
             return Err("Cannot enlarge alongside fixture disk".into());
         }
     }
-    qemu::reset_uefi_vars(&opts.vars);
+    qemu::reset_uefi_vars(&paths.vars);
 
     // Boot ISO
-    eprintln!("[2/4] Booting ISO VM on port {}", opts.iso_port);
-    let cache = prepare_cache(&opts)?;
+    eprintln!("[2/4] Booting ISO VM on port {}", opts.ssh.iso_port);
+    let cache = prepare_cache(&opts.cache)?;
     let mut vm = QemuVm::boot_iso(
-        &opts.disk,
-        &opts.vars,
+        &paths.disk,
+        &paths.vars,
         &iso,
-        opts.iso_port,
+        opts.ssh.iso_port,
         cache.as_deref(),
     );
     if !vm.wait_for_ssh(timeout) {
@@ -465,10 +518,10 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
 
     // Upload and run installer
     eprintln!("[3/4] Running installer");
-    vm.scp_to(&opts.binary, "/root/archinstall-zfs-rs");
-    vm.scp_to(&opts.config, "/root/config.json");
+    vm.scp_to(&paths.binary, "/root/archinstall-zfs-rs");
+    vm.scp_to(&paths.config, "/root/config.json");
     if opts.alongside {
-        alongside::prepare(&vm, &opts.config)?;
+        alongside::prepare(&vm, &paths.config)?;
     }
     vm.ssh_run("chmod +x /root/archinstall-zfs-rs")
         .map_err(|e| format!("chmod failed: {e}"))?;
@@ -477,7 +530,10 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
         Some(_) => {
             let tag = qemu::CACHE_MOUNT_TAG;
             let dir = qemu::CACHE_GUEST_DIR;
-            eprintln!("  Reusing the host cache at {}", opts.cache_dir.display());
+            eprintln!(
+                "  Reusing the host cache at {}",
+                opts.cache.cache_dir.display()
+            );
             format!(
                 "mkdir -p {dir} && \
                  mount -t 9p -o trans=virtio,version=9p2000.L {tag} {dir} && \
@@ -532,12 +588,13 @@ fn cmd_test_install(opts: TestOpts) -> Result<(), String> {
 }
 
 fn cmd_test_boot(opts: TestOpts) -> Result<(), String> {
-    let timeout = Duration::from_secs(opts.timeout);
+    let paths = &opts.paths;
+    let timeout = Duration::from_secs(opts.ssh.timeout);
 
-    if !opts.disk.exists() {
+    if !paths.disk.exists() {
         return Err(format!(
             "Disk {} not found. Run 'cargo xtask test-install' first.",
-            opts.disk.display()
+            paths.disk.display()
         ));
     }
 
@@ -545,12 +602,15 @@ fn cmd_test_boot(opts: TestOpts) -> Result<(), String> {
 
     // Reset UEFI vars (clean slate, uses EFI/BOOT/BOOTX64.EFI fallback)
     eprintln!("[1/3] Resetting UEFI vars for clean boot");
-    qemu::reset_uefi_vars(&opts.vars);
+    qemu::reset_uefi_vars(&paths.vars);
 
     // Boot from disk
-    eprintln!("[2/3] Booting installed system on port {}", opts.boot_port);
-    let vm =
-        QemuVm::boot_disk(&opts.disk, &opts.vars, opts.boot_port).with_password(&opts.password);
+    eprintln!(
+        "[2/3] Booting installed system on port {}",
+        opts.ssh.boot_port
+    );
+    let vm = QemuVm::boot_disk(&paths.disk, &paths.vars, opts.ssh.boot_port)
+        .with_password(&opts.ssh.password);
 
     if !vm.wait_for_ssh(timeout) {
         return Err(format!(
@@ -561,207 +621,23 @@ fn cmd_test_boot(opts: TestOpts) -> Result<(), String> {
 
     // Verify
     eprintln!("[3/3] Verifying system health");
-    verify_system(&vm, &opts.config)?;
+    verify::verify_system(&vm, &paths.config)?;
 
     eprintln!("=== test-boot: PASSED ===\n");
     Ok(())
 }
 
-// ── Verification ───────────────────────────────────────
-
-fn verify_system(vm: &QemuVm, config_path: &Path) -> Result<(), String> {
-    let init_system = detect_init_system(config_path);
-    let mut passed = 0;
-    let mut checks = Vec::new();
-
-    // Kernel
-    let kernel = vm.ssh_stdout("uname -r");
-    if kernel.contains("lts") {
-        checks.push(format!("  kernel: {kernel}"));
-        passed += 1;
-    } else {
-        checks.push(format!("  kernel: FAIL (expected lts, got '{kernel}')"));
-    }
-
-    // ZFS pool
-    let pool = vm.ssh_stdout("zpool status testpool 2>&1");
-    if pool.contains("ONLINE") {
-        checks.push("  zpool: ONLINE".to_string());
-        passed += 1;
-    } else {
-        checks.push(format!("  zpool: FAIL\n{pool}"));
-    }
-
-    // sshd
-    let sshd = vm.ssh_stdout("systemctl is-active sshd");
-    if sshd == "active" {
-        checks.push("  sshd: active".to_string());
-        passed += 1;
-    } else {
-        checks.push(format!("  sshd: FAIL ({sshd})"));
-    }
-
-    // fstab
-    let fstab = vm.ssh_stdout("cat /etc/fstab");
-    if fstab.contains("testpool/arch0/root") {
-        checks.push("  fstab: OK (has root dataset)".to_string());
-        passed += 1;
-    } else {
-        checks.push(format!("  fstab: FAIL\n{fstab}"));
-    }
-
-    // initramfs config
-    if init_system == "mkinitcpio" {
-        let mkinitcpio = vm.ssh_stdout("cat /etc/mkinitcpio.conf 2>/dev/null || echo missing");
-        if mkinitcpio.contains("zfs") {
-            checks.push("  mkinitcpio: configured (has zfs)".to_string());
-            passed += 1;
-        } else {
-            checks.push(format!("  mkinitcpio: FAIL\n{mkinitcpio}"));
-        }
-    } else {
-        let dracut = vm.ssh_stdout("cat /etc/dracut.conf.d/zfs.conf 2>/dev/null || echo missing");
-        if dracut.contains("hostonly") {
-            checks.push("  dracut: configured".to_string());
-            passed += 1;
-        } else {
-            checks.push(format!("  dracut: FAIL ({dracut})"));
-        }
-    }
-
-    // Verify the configured swap path, including activation after boot.
-    let config: Value = serde_json::from_slice(&fs::read(config_path).map_err(|e| e.to_string())?)
-        .map_err(|e| e.to_string())?;
-    let swap = vm.ssh_stdout("swapon --show=NAME --noheadings");
-    let swap_ok = match config["swap_mode"].as_str().unwrap_or("none") {
-        "none" => swap.trim().is_empty(),
-        "zram" => swap.contains("/dev/zram"),
-        "zswap_partition" => !swap.trim().is_empty() && !swap.contains("zram"),
-        "zswap_partition_encrypted" => swap.contains("cryptswap") || swap.contains("/dev/dm-"),
-        _ => false,
-    };
-    if swap_ok {
-        checks.push("  swap: configured and active as requested".into());
-        passed += 1;
-    } else {
-        checks.push(format!("  swap: FAIL ({swap})"));
-    }
-
-    // ZFS mounts
-    let mounts = vm.ssh_stdout("zfs list -o name,mountpoint 2>&1");
-    if mounts.contains("/home") && mounts.contains("/root") {
-        checks.push("  ZFS mounts: OK (/home, /root)".to_string());
-        passed += 1;
-    } else {
-        checks.push(format!("  ZFS mounts: FAIL\n{mounts}"));
-    }
-
-    // hostid
-    let hostid = vm.ssh_stdout("od -A n -t x1 /etc/hostid 2>/dev/null | tr -d ' \\n'");
-    if hostid == "0cb1ba00" {
-        checks.push("  hostid: 0x00bab10c".to_string());
-        passed += 1;
-    } else {
-        checks.push(format!("  hostid: FAIL (got '{hostid}')"));
-    }
-
-    // ZED cache hook (boot-environment aware)
-    let zed_hook = vm.ssh_stdout(
-        "cat /etc/zfs/zed.d/history_event-zfs-list-cacher.sh 2>/dev/null || echo missing",
-    );
-    if zed_hook.contains("boot environment aware") {
-        checks.push("  ZED hook: installed".to_string());
-        passed += 1;
-    } else {
-        checks.push("  ZED hook: FAIL (custom hook not found)".to_string());
-    }
-
-    // bootfs (needed for zbm.timeout auto-boot; users can still select other BEs)
-    let bootfs = vm.ssh_stdout("zpool get -H -o value bootfs testpool 2>/dev/null");
-    if bootfs == "testpool/arch0/root" {
-        checks.push("  bootfs: testpool/arch0/root".to_string());
-        passed += 1;
-    } else {
-        checks.push(format!(
-            "  bootfs: FAIL (expected testpool/arch0/root, got '{bootfs}')"
-        ));
-    }
-
-    // ZBM rootprefix property
-    let rootprefix = vm.ssh_stdout(
-        "zfs get -H -o value org.zfsbootmenu:rootprefix testpool/arch0/root 2>/dev/null",
-    );
-    let expected_prefix = if init_system == "dracut" {
-        "root=ZFS="
-    } else {
-        "zfs="
-    };
-    if rootprefix == expected_prefix {
-        checks.push(format!("  rootprefix: {rootprefix}").to_string());
-        passed += 1;
-    } else {
-        checks.push(format!(
-            "  rootprefix: FAIL (expected '{expected_prefix}', got '{rootprefix}')"
-        ));
-    }
-
-    // ZBM locally built (generate-zbm available + config present)
-    let zbm_config = vm.ssh_stdout("cat /etc/zfsbootmenu/config.yaml 2>/dev/null || echo missing");
-    let zbm_bin = vm.ssh_stdout("which generate-zbm 2>/dev/null || echo missing");
-    if zbm_config.contains("ManageImages: true") && !zbm_bin.contains("missing") {
-        checks.push("  ZBM local build: OK".to_string());
-        passed += 1;
-    } else {
-        checks.push(format!(
-            "  ZBM local build: FAIL (config={}, bin={})",
-            if zbm_config.contains("ManageImages") {
-                "ok"
-            } else {
-                "missing"
-            },
-            if zbm_bin.contains("missing") {
-                "missing"
-            } else {
-                "ok"
-            }
-        ));
-    }
-
-    // ZBM pacman hook
-    let zbm_hook =
-        vm.ssh_stdout("cat /etc/pacman.d/hooks/95-zfsbootmenu.hook 2>/dev/null || echo missing");
-    if zbm_hook.contains("Exec = /usr/local/sbin/azfs-update-zbm")
-        && vm.ssh_stdout("test -x /usr/local/sbin/azfs-update-zbm && test -x /usr/local/libexec/azfs-install-zbm && echo ready").trim() == "ready" {
-        checks.push("  ZBM pacman hook: installed".to_string());
-        passed += 1;
-    } else {
-        checks.push("  ZBM pacman hook: FAIL".to_string());
-    }
-
-    let total = 13;
-    for line in &checks {
-        eprintln!("{line}");
-    }
-    eprintln!("  --- {passed}/{total} checks passed ---");
-
-    if passed == total {
-        Ok(())
-    } else {
-        Err(format!("{}/{total} checks failed", total - passed))
-    }
-}
-
 // ── Helpers ────────────────────────────────────────────
 
 fn check_prerequisites(opts: &TestOpts) -> Result<(), String> {
-    if !opts.binary.exists() {
+    if !opts.paths.binary.exists() {
         return Err(format!(
             "Binary not found: {}. Run 'cargo build --release' first.",
-            opts.binary.display()
+            opts.paths.binary.display()
         ));
     }
-    if !opts.config.exists() {
-        return Err(format!("Config not found: {}", opts.config.display()));
+    if !opts.paths.config.exists() {
+        return Err(format!("Config not found: {}", opts.paths.config.display()));
     }
     // Check KVM
     if !std::path::Path::new("/dev/kvm").exists() {
@@ -775,399 +651,5 @@ fn check_prerequisites(opts: &TestOpts) -> Result<(), String> {
     if !sshpass.is_ok_and(|s| s.success()) {
         return Err("sshpass not found. Install it: pacman -S sshpass".to_string());
     }
-    Ok(())
-}
-
-// ── bench-downloads ────────────────────────────────────
-
-/// Patch `parallel_downloads` in a JSON config and write to a temp file.
-fn patch_config_concurrency(
-    config_path: &Path,
-    concurrency: usize,
-    dest: &Path,
-) -> Result<(), String> {
-    let content = std::fs::read_to_string(config_path).map_err(|e| format!("read config: {e}"))?;
-    let mut v: serde_json::Value =
-        serde_json::from_str(&content).map_err(|e| format!("parse config: {e}"))?;
-    v["parallel_downloads"] = serde_json::json!(concurrency);
-    let patched = serde_json::to_string_pretty(&v).map_err(|e| format!("serialize config: {e}"))?;
-    std::fs::write(dest, patched).map_err(|e| format!("write patched config: {e}"))?;
-    Ok(())
-}
-
-fn cmd_bench_downloads(
-    opts: TestOpts,
-    concurrency_spec: &str,
-    out_dir: &Path,
-    samples: usize,
-) -> Result<(), String> {
-    check_prerequisites(&opts)?;
-    std::fs::create_dir_all(out_dir).map_err(|e| format!("create out_dir: {e}"))?;
-
-    let samples = samples.max(1);
-
-    // Parse comma-separated concurrency values
-    let concurrencies: Vec<usize> = concurrency_spec
-        .split(',')
-        .map(|s| {
-            s.trim()
-                .parse::<usize>()
-                .map_err(|_| format!("invalid concurrency value: '{s}'"))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    eprintln!(
-        "=== bench-downloads: {} concurrency levels × {} sample(s): {:?} ===",
-        concurrencies.len(),
-        samples,
-        concurrencies
-    );
-
-    for &conc in &concurrencies {
-        eprintln!("\n--- concurrency={conc} ({samples} sample(s)) ---");
-
-        // Write patched config to a temp file (shared across all samples)
-        let patched_config = out_dir.join(format!("config_conc{conc}.json"));
-        patch_config_concurrency(&opts.config, conc, &patched_config)?;
-
-        // Track phase4 wall time for each sample to pick the median
-        let mut sample_files: Vec<PathBuf> = Vec::new();
-        let mut phase4_times: Vec<u64> = Vec::new();
-
-        for s in 1..=samples {
-            eprintln!("  sample {s}/{samples}");
-
-            let run_opts = TestOpts {
-                config: patched_config.clone(),
-                ..opts.clone()
-            };
-            cmd_test_install(run_opts)?;
-
-            let local_metrics = PathBuf::from("/tmp/archinstall-metrics.jsonl");
-            let sample_dest = out_dir.join(format!("conc_{conc}_s{s}.jsonl"));
-            if local_metrics.exists() {
-                std::fs::copy(&local_metrics, &sample_dest)
-                    .map_err(|e| format!("copy metrics sample: {e}"))?;
-                eprintln!("    saved {}", sample_dest.display());
-
-                // Extract phase 4 wall time from this sample
-                let content = std::fs::read_to_string(&sample_dest).unwrap_or_default();
-                let ph4_time = phase4_wall_ms_from_jsonl(&content);
-                eprintln!("    phase4 wall: {:.1}s", ph4_time as f64 / 1000.0);
-                phase4_times.push(ph4_time);
-                sample_files.push(sample_dest);
-            } else {
-                eprintln!("    Warning: metrics file not found");
-                phase4_times.push(u64::MAX);
-                sample_files.push(PathBuf::new());
-            }
-        }
-
-        // Pick the median sample (by phase 4 wall time) as the canonical result
-        let median_idx = median_index(&phase4_times);
-        let canonical = out_dir.join(format!("conc_{conc}.jsonl"));
-        if sample_files[median_idx].exists() {
-            std::fs::copy(&sample_files[median_idx], &canonical)
-                .map_err(|e| format!("copy median sample: {e}"))?;
-            eprintln!(
-                "  Median sample: s{} ({:.1}s) → {}",
-                median_idx + 1,
-                phase4_times[median_idx] as f64 / 1000.0,
-                canonical.display()
-            );
-        }
-        if samples > 1 {
-            let mut sorted = phase4_times.clone();
-            sorted.retain(|&t| t != u64::MAX);
-            sorted.sort_unstable();
-            let min_s = sorted.first().copied().unwrap_or(0) as f64 / 1000.0;
-            let max_s = sorted.last().copied().unwrap_or(0) as f64 / 1000.0;
-            eprintln!("  Phase4 range: {min_s:.1}s – {max_s:.1}s");
-        }
-    }
-
-    eprintln!("\n=== bench-downloads: complete ===");
-    eprintln!(
-        "Run 'cargo xtask analyze-metrics --dir {}' to see results.",
-        out_dir.display()
-    );
-    Ok(())
-}
-
-/// Extract the phase-4 wall-clock time (ms) from a JSONL string.
-/// Returns phase_5.ts_ms - phase_4.ts_ms, or 0 if either is missing.
-fn phase4_wall_ms_from_jsonl(content: &str) -> u64 {
-    let mut ts4 = None;
-    let mut ts5 = None;
-    for line in content.lines() {
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        if v.get("event").and_then(|e| e.as_str()) == Some("phase_start") {
-            let num = v.get("num").and_then(|n| n.as_u64()).unwrap_or(0);
-            let ts = v.get("ts_ms").and_then(|t| t.as_u64()).unwrap_or(0);
-            match num {
-                4 => ts4 = Some(ts),
-                5 => ts5 = Some(ts),
-                _ => {}
-            }
-        }
-    }
-    match (ts4, ts5) {
-        (Some(t4), Some(t5)) if t5 > t4 => t5 - t4,
-        _ => 0,
-    }
-}
-
-/// Return the index of the median value in a slice.
-fn median_index(values: &[u64]) -> usize {
-    if values.is_empty() {
-        return 0;
-    }
-    let mut indexed: Vec<(usize, u64)> = values.iter().copied().enumerate().collect();
-    indexed.sort_by_key(|&(_, v)| v);
-    indexed[indexed.len() / 2].0
-}
-
-// ── analyze-metrics ────────────────────────────────────
-
-#[derive(Default)]
-struct RunStats {
-    concurrency: usize,
-    pkg_count: u64,
-    total_bytes: u64,
-    total_dl_ms: u64,
-    max_speed_bps: u64,
-    avg_speed_bps: u64,
-    batch_install_ms: u64,
-    phases: Vec<(u32, String, u64)>, // (num, name, ts_ms)
-}
-
-fn cmd_analyze_metrics(dir: &Path) -> Result<(), String> {
-    if !dir.exists() {
-        return Err(format!("directory not found: {}", dir.display()));
-    }
-
-    // Collect canonical conc_N.jsonl files, sorted by N
-    let mut entries: Vec<(usize, PathBuf)> = std::fs::read_dir(dir)
-        .map_err(|e| format!("read dir: {e}"))?
-        .filter_map(|e| e.ok())
-        .filter_map(|e| {
-            let name = e.file_name().into_string().ok()?;
-            let stem = name.strip_suffix(".jsonl")?;
-            // Only canonical files (conc_N, not conc_N_sM)
-            let n = stem.strip_prefix("conc_")?;
-            if n.contains('_') {
-                return None;
-            }
-            let n = n.parse::<usize>().ok()?;
-            Some((n, e.path()))
-        })
-        .collect();
-    entries.sort_by_key(|(n, _)| *n);
-
-    if entries.is_empty() {
-        return Err(format!("no conc_N.jsonl files found in {}", dir.display()));
-    }
-
-    // Also check for per-sample files to compute scatter
-    let mut sample_map: std::collections::HashMap<usize, Vec<u64>> = Default::default();
-    for e in std::fs::read_dir(dir)
-        .map_err(|e| format!("read dir: {e}"))?
-        .filter_map(|e| e.ok())
-    {
-        let name = e.file_name().into_string().unwrap_or_default();
-        let stem = name.strip_suffix(".jsonl").unwrap_or("");
-        // matches conc_N_sM
-        if let Some(rest) = stem.strip_prefix("conc_") {
-            let parts: Vec<&str> = rest.splitn(2, '_').collect();
-            if parts.len() == 2
-                && let (Ok(n), Some(_s)) = (parts[0].parse::<usize>(), parts[1].strip_prefix('s'))
-                && let Ok(content) = std::fs::read_to_string(e.path())
-            {
-                let t = phase4_wall_ms_from_jsonl(&content);
-                sample_map.entry(n).or_default().push(t);
-            }
-        }
-    }
-
-    let mut rows: Vec<RunStats> = Vec::new();
-
-    for (conc, path) in &entries {
-        let content =
-            std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
-
-        let mut stats = RunStats {
-            concurrency: *conc,
-            ..Default::default()
-        };
-
-        let mut phase_ts: Vec<(u32, String, u64)> = Vec::new();
-        let mut dl_speeds: Vec<u64> = Vec::new();
-
-        for line in content.lines() {
-            let v: serde_json::Value = match serde_json::from_str(line) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let event = v.get("event").and_then(|e| e.as_str()).unwrap_or("");
-            let ts_ms = v.get("ts_ms").and_then(|t| t.as_u64()).unwrap_or(0);
-
-            match event {
-                "pkg_download" => {
-                    let bytes = v.get("bytes").and_then(|b| b.as_u64()).unwrap_or(0);
-                    let speed_bps = v.get("speed_bps").and_then(|s| s.as_u64()).unwrap_or(0);
-                    stats.pkg_count += 1;
-                    stats.total_bytes += bytes;
-                    dl_speeds.push(speed_bps);
-                    if speed_bps > stats.max_speed_bps {
-                        stats.max_speed_bps = speed_bps;
-                    }
-                }
-                "batch_install" => {
-                    stats.batch_install_ms +=
-                        v.get("duration_ms").and_then(|d| d.as_u64()).unwrap_or(0);
-                }
-                "phase_start" => {
-                    let num = v.get("num").and_then(|n| n.as_u64()).unwrap_or(0) as u32;
-                    let name = v
-                        .get("name")
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    phase_ts.push((num, name, ts_ms));
-                }
-                _ => {}
-            }
-        }
-
-        if !dl_speeds.is_empty() {
-            stats.avg_speed_bps = dl_speeds.iter().sum::<u64>() / dl_speeds.len() as u64;
-        }
-
-        // Use phase4→phase5 timestamps for wall-clock download time
-        if let Some((_, _, ts4)) = phase_ts.iter().find(|(n, _, _)| *n == 4)
-            && let Some((_, _, ts5)) = phase_ts.iter().find(|(n, _, _)| *n == 5)
-        {
-            stats.total_dl_ms = ts5 - ts4;
-        }
-        // total_bytes must be measured from pkg_download events (set above, but reset by wall logic)
-        // re-sum bytes properly
-        stats.total_bytes = 0;
-        for line in content.lines() {
-            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
-                continue;
-            };
-            if v.get("event").and_then(|e| e.as_str()) == Some("pkg_download") {
-                stats.total_bytes += v.get("bytes").and_then(|b| b.as_u64()).unwrap_or(0);
-            }
-        }
-
-        stats.phases = phase_ts;
-        rows.push(stats);
-    }
-
-    // Print markdown table
-    println!("## Download Benchmark Results\n");
-
-    // Check if we have multi-sample scatter
-    let has_scatter = sample_map.values().any(|v| v.len() > 1);
-
-    if has_scatter {
-        println!(
-            "| conc | pkgs | total_MB | dl_med_s | dl_min_s | dl_max_s | avg_MBps | max_MBps | install_s |"
-        );
-        println!(
-            "|-----:|-----:|---------:|---------:|---------:|---------:|---------:|---------:|----------:|"
-        );
-    } else {
-        println!("| conc | pkgs | total_MB | dl_wall_s | avg_MBps | max_MBps | install_s |");
-        println!("|-----:|-----:|---------:|----------:|---------:|---------:|----------:|");
-    }
-
-    for r in &rows {
-        let total_mb = r.total_bytes as f64 / 1_048_576.0;
-        let dl_wall_s = r.total_dl_ms as f64 / 1000.0;
-        let avg_mbps = r.avg_speed_bps as f64 / 1_048_576.0;
-        let max_mbps = r.max_speed_bps as f64 / 1_048_576.0;
-        let install_s = r.batch_install_ms as f64 / 1000.0;
-
-        if has_scatter {
-            let mut samples = sample_map.get(&r.concurrency).cloned().unwrap_or_default();
-            samples.sort_unstable();
-            let min_s = samples.first().copied().unwrap_or(0) as f64 / 1000.0;
-            let max_s = samples.last().copied().unwrap_or(0) as f64 / 1000.0;
-            println!(
-                "| {:>4} | {:>4} | {:>8.1} | {:>8.1} | {:>8.1} | {:>8.1} | {:>8.2} | {:>8.2} | {:>9.1} |",
-                r.concurrency,
-                r.pkg_count,
-                total_mb,
-                dl_wall_s,
-                min_s,
-                max_s,
-                avg_mbps,
-                max_mbps,
-                install_s
-            );
-        } else {
-            println!(
-                "| {:>4} | {:>4} | {:>8.1} | {:>9.1} | {:>8.2} | {:>8.2} | {:>9.1} |",
-                r.concurrency, r.pkg_count, total_mb, dl_wall_s, avg_mbps, max_mbps, install_s
-            );
-        }
-    }
-
-    // Per-phase breakdown for each run
-    println!("\n## Phase Timings (seconds)\n");
-    let all_phases: Vec<u32> = {
-        let mut nums: Vec<u32> = rows
-            .iter()
-            .flat_map(|r| r.phases.iter().map(|(n, _, _)| *n))
-            .collect();
-        nums.sort_unstable();
-        nums.dedup();
-        nums
-    };
-
-    if !all_phases.is_empty() {
-        let header_phases: String = all_phases
-            .iter()
-            .map(|n| format!("| Ph{n:>2} "))
-            .collect::<Vec<_>>()
-            .join("");
-        println!("| conc {header_phases}|");
-        let sep: String = all_phases
-            .iter()
-            .map(|_| "|-----:")
-            .collect::<Vec<_>>()
-            .join("");
-        println!("|-----:{sep}|");
-
-        for r in &rows {
-            let phase_map: std::collections::HashMap<u32, u64> = r
-                .phases
-                .windows(2)
-                .map(|w| {
-                    let (n1, _, ts1) = &w[0];
-                    let (_, _, ts2) = &w[1];
-                    (*n1, ts2 - ts1)
-                })
-                .collect();
-
-            let cells: String = all_phases
-                .iter()
-                .map(|n| {
-                    if let Some(&dur) = phase_map.get(n) {
-                        format!("| {:>4.1}s", dur as f64 / 1000.0)
-                    } else {
-                        "|    - ".to_string()
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join(" ");
-            println!("| {:>4} {cells} |", r.concurrency);
-        }
-    }
-
     Ok(())
 }

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -270,6 +270,12 @@ impl Drop for QemuVm {
 
 /// Locate an OVMF firmware file by trying distro-specific layouts.
 /// Arch ships `<name>.4m.fd`; Fedora/Debian ship `<name>.fd` (no 4m).
+///
+/// The justfile (`qemu-setup-uefi`) and `gen_iso/run-qemu.sh`
+/// (`find_ovmf_file`) keep their own lists: the justfile searches the
+/// `/usr/share/{edk2,edk2-ovmf,OVMF}` roots recursively and skips secboot
+/// images, run-qemu.sh probes the x64 subdirectories without
+/// `/usr/share/edk2/ovmf`. Update all three together.
 fn find_ovmf(base: &str) -> PathBuf {
     let dirs = [
         "/usr/share/edk2/x64",

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -18,6 +18,13 @@ pub struct QemuVm {
     password: Option<String>,
 }
 
+/// OpenSSH client the VM is reached with; `scp` spells the port flag `-P`.
+#[derive(Clone, Copy)]
+enum RemoteTool {
+    Ssh,
+    Scp,
+}
+
 impl QemuVm {
     /// Boot the installation medium, with `cache` shared into the guest when
     /// one is given.
@@ -167,48 +174,42 @@ impl QemuVm {
         false
     }
 
-    pub fn ssh_run(&self, cmd: &str) -> std::io::Result<Output> {
-        let port_str = self.port.to_string();
-        let timeout_str = format!("ConnectTimeout={SSH_TIMEOUT_SECS}");
+    /// Build an `ssh`/`scp` command for the guest.
+    ///
+    /// Wraps the tool in `sshpass` when a password is set, disables host key
+    /// checks and appends the port; `opts` go between the shared options and
+    /// the port, so the caller adds only its own `-o` flags and operands.
+    fn remote_cmd(&self, tool: RemoteTool, opts: &[&str]) -> Command {
+        let (name, port_flag) = match tool {
+            RemoteTool::Ssh => ("ssh", "-p"),
+            RemoteTool::Scp => ("scp", "-P"),
+        };
+        let mut cmd = match &self.password {
+            Some(pw) => {
+                let mut cmd = Command::new("sshpass");
+                cmd.args(["-p", pw, name]);
+                cmd
+            }
+            None => Command::new(name),
+        };
+        cmd.args([
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+        ])
+        .args(opts)
+        .args([port_flag, &self.port.to_string()]);
+        cmd
+    }
 
-        if let Some(ref pw) = self.password {
-            Command::new("sshpass")
-                .args([
-                    "-p",
-                    pw,
-                    "ssh",
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "UserKnownHostsFile=/dev/null",
-                    "-o",
-                    &timeout_str,
-                    "-p",
-                    &port_str,
-                    "root@localhost",
-                    cmd,
-                ])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output()
-        } else {
-            Command::new("ssh")
-                .args([
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "UserKnownHostsFile=/dev/null",
-                    "-o",
-                    &timeout_str,
-                    "-p",
-                    &port_str,
-                    "root@localhost",
-                    cmd,
-                ])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output()
-        }
+    pub fn ssh_run(&self, cmd: &str) -> std::io::Result<Output> {
+        let timeout_str = format!("ConnectTimeout={SSH_TIMEOUT_SECS}");
+        self.remote_cmd(RemoteTool::Ssh, &["-o", &timeout_str])
+            .args(["root@localhost", cmd])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
     }
 
     pub fn ssh_stdout(&self, cmd: &str) -> String {
@@ -217,72 +218,28 @@ impl QemuVm {
     }
 
     pub fn scp_to(&self, local: &Path, remote: &str) {
-        let port_str = self.port.to_string();
-        let mut args = vec![
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-P",
-            &port_str,
-        ];
         let local_str = local.to_str().unwrap();
         let remote_dest = format!("root@localhost:{remote}");
-
-        if let Some(ref pw) = self.password {
-            let status = Command::new("sshpass")
-                .args(["-p", pw, "scp"])
-                .args(&args)
-                .args([local_str, remote_dest.as_str()])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-                .expect("scp failed to execute");
-            assert!(status.success(), "scp to {remote} failed");
-        } else {
-            args.push(local_str);
-            args.push(remote_dest.as_str());
-            let status = Command::new("scp")
-                .args(&args)
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-                .expect("scp failed to execute");
-            assert!(status.success(), "scp to {remote} failed");
-        }
+        let status = self
+            .remote_cmd(RemoteTool::Scp, &[])
+            .args([local_str, remote_dest.as_str()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("scp failed to execute");
+        assert!(status.success(), "scp to {remote} failed");
     }
 
     /// Copy a file from the VM to a local path. Returns true on success.
     pub fn scp_from(&self, remote: &str, local: &Path) -> bool {
-        let port_str = self.port.to_string();
         let remote_src = format!("root@localhost:{remote}");
         let local_str = local.to_str().unwrap();
-        let base_args = [
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-P",
-            &port_str,
-        ];
-
-        let status = if let Some(pw) = &self.password {
-            Command::new("sshpass")
-                .args(["-p", pw, "scp"])
-                .args(base_args)
-                .args([remote_src.as_str(), local_str])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-        } else {
-            Command::new("scp")
-                .args(base_args)
-                .args([remote_src.as_str(), local_str])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-        };
-
+        let status = self
+            .remote_cmd(RemoteTool::Scp, &[])
+            .args([remote_src.as_str(), local_str])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
         status.is_ok_and(|s| s.success())
     }
 
@@ -390,8 +347,68 @@ pub fn reset_uefi_vars(path: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::is_testing_iso;
+    use super::{QemuVm, RemoteTool, is_testing_iso};
     use std::path::Path;
+    use std::process::Command;
+
+    fn argv(cmd: &Command) -> Vec<String> {
+        std::iter::once(cmd.get_program())
+            .chain(cmd.get_args())
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn remote_commands_keep_their_argv() {
+        let vm = QemuVm {
+            pid: None,
+            port: 2222,
+            password: None,
+        };
+        assert_eq!(
+            argv(&vm.remote_cmd(RemoteTool::Ssh, &["-o", "ConnectTimeout=10"])),
+            [
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "ConnectTimeout=10",
+                "-p",
+                "2222",
+            ]
+        );
+        assert_eq!(
+            argv(&vm.remote_cmd(RemoteTool::Scp, &[])),
+            [
+                "scp",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-P",
+                "2222",
+            ]
+        );
+
+        let vm = vm.with_password("test");
+        assert_eq!(
+            argv(&vm.remote_cmd(RemoteTool::Scp, &[])),
+            [
+                "sshpass",
+                "-p",
+                "test",
+                "scp",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-P",
+                "2222",
+            ]
+        );
+    }
 
     #[test]
     fn integration_harness_accepts_only_testing_isos() {

--- a/xtask/src/verify.rs
+++ b/xtask/src/verify.rs
@@ -1,0 +1,187 @@
+//! Health checks run over SSH against the freshly booted installation.
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::qemu::QemuVm;
+
+/// Detect the init system from the JSON config file.
+pub fn detect_init_system(config: &Path) -> String {
+    let content = std::fs::read_to_string(config).unwrap_or_default();
+    if content.contains("\"mkinitcpio\"") {
+        "mkinitcpio".to_string()
+    } else {
+        "dracut".to_string()
+    }
+}
+
+/// One remote command and the condition its trimmed stdout must satisfy.
+struct Check {
+    label: &'static str,
+    command: String,
+    /// What a passing output looks like; shown next to the verdict.
+    expect: String,
+    predicate: Box<dyn Fn(&str) -> bool>,
+}
+
+impl Check {
+    fn new(
+        label: &'static str,
+        command: impl Into<String>,
+        expect: impl Into<String>,
+        predicate: impl Fn(&str) -> bool + 'static,
+    ) -> Self {
+        Self {
+            label,
+            command: command.into(),
+            expect: expect.into(),
+            predicate: Box::new(predicate),
+        }
+    }
+}
+
+fn checks(config_path: &Path) -> Result<Vec<Check>, String> {
+    let init_system = detect_init_system(config_path);
+    let config: Value = serde_json::from_slice(&fs::read(config_path).map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())?;
+    let swap_mode = config["swap_mode"].as_str().unwrap_or("none").to_string();
+
+    let initramfs = if init_system == "mkinitcpio" {
+        Check::new(
+            "mkinitcpio",
+            "cat /etc/mkinitcpio.conf 2>/dev/null || echo missing",
+            "configured (has zfs)",
+            |out| out.contains("zfs"),
+        )
+    } else {
+        Check::new(
+            "dracut",
+            "cat /etc/dracut.conf.d/zfs.conf 2>/dev/null || echo missing",
+            "configured (hostonly)",
+            |out| out.contains("hostonly"),
+        )
+    };
+    // ZBM rootprefix property
+    let expected_prefix = if init_system == "dracut" {
+        "root=ZFS="
+    } else {
+        "zfs="
+    };
+
+    Ok(vec![
+        Check::new("kernel", "uname -r", "lts", |out| out.contains("lts")),
+        Check::new("zpool", "zpool status testpool 2>&1", "ONLINE", |out| {
+            out.contains("ONLINE")
+        }),
+        Check::new("sshd", "systemctl is-active sshd", "active", |out| {
+            out == "active"
+        }),
+        Check::new("fstab", "cat /etc/fstab", "has root dataset", |out| {
+            out.contains("testpool/arch0/root")
+        }),
+        initramfs,
+        // The configured swap path, including activation after boot.
+        Check::new(
+            "swap",
+            "swapon --show=NAME --noheadings",
+            format!("configured and active as requested ({swap_mode})"),
+            move |out| match swap_mode.as_str() {
+                "none" => out.trim().is_empty(),
+                "zram" => out.contains("/dev/zram"),
+                "zswap_partition" => !out.trim().is_empty() && !out.contains("zram"),
+                "zswap_partition_encrypted" => {
+                    out.contains("cryptswap") || out.contains("/dev/dm-")
+                }
+                _ => false,
+            },
+        ),
+        Check::new(
+            "ZFS mounts",
+            "zfs list -o name,mountpoint 2>&1",
+            "/home, /root",
+            |out| out.contains("/home") && out.contains("/root"),
+        ),
+        Check::new(
+            "hostid",
+            "od -A n -t x1 /etc/hostid 2>/dev/null | tr -d ' \\n'",
+            "0x00bab10c",
+            |out| out == "0cb1ba00",
+        ),
+        // ZED cache hook (boot-environment aware)
+        Check::new(
+            "ZED hook",
+            "cat /etc/zfs/zed.d/history_event-zfs-list-cacher.sh 2>/dev/null || echo missing",
+            "installed (boot environment aware)",
+            |out| out.contains("boot environment aware"),
+        ),
+        // bootfs (needed for zbm.timeout auto-boot; users can still select other BEs)
+        Check::new(
+            "bootfs",
+            "zpool get -H -o value bootfs testpool 2>/dev/null",
+            "testpool/arch0/root",
+            |out| out == "testpool/arch0/root",
+        ),
+        Check::new(
+            "rootprefix",
+            "zfs get -H -o value org.zfsbootmenu:rootprefix testpool/arch0/root 2>/dev/null",
+            expected_prefix,
+            move |out| out == expected_prefix,
+        ),
+        // ZBM locally built (generate-zbm available + config present)
+        Check::new(
+            "ZBM local build",
+            "echo config=$(grep -q 'ManageImages: true' /etc/zfsbootmenu/config.yaml 2>/dev/null \
+             && echo ok || echo missing) \
+             bin=$(which generate-zbm >/dev/null 2>&1 && echo ok || echo missing)",
+            "config=ok bin=ok",
+            |out| out == "config=ok bin=ok",
+        ),
+        Check::new(
+            "ZBM pacman hook",
+            "grep -qF 'Exec = /usr/local/sbin/azfs-update-zbm' /etc/pacman.d/hooks/95-zfsbootmenu.hook 2>/dev/null \
+             && test -x /usr/local/sbin/azfs-update-zbm \
+             && test -x /usr/local/libexec/azfs-install-zbm \
+             && echo ready",
+            "installed",
+            |out| out == "ready",
+        ),
+    ])
+}
+
+pub fn verify_system(vm: &QemuVm, config_path: &Path) -> Result<(), String> {
+    let checks = checks(config_path)?;
+    let total = checks.len();
+    let mut passed = 0;
+    let mut lines = Vec::new();
+
+    for check in &checks {
+        let output = vm.ssh_stdout(&check.command);
+        if (check.predicate)(&output) {
+            lines.push(format!("  {}: OK ({})", check.label, check.expect));
+            passed += 1;
+        } else if output.contains('\n') {
+            lines.push(format!(
+                "  {}: FAIL (expected {})\n{output}",
+                check.label, check.expect
+            ));
+        } else {
+            lines.push(format!(
+                "  {}: FAIL (expected {}, got '{output}')",
+                check.label, check.expect
+            ));
+        }
+    }
+
+    for line in &lines {
+        eprintln!("{line}");
+    }
+    eprintln!("  --- {passed}/{total} checks passed ---");
+
+    if passed == total {
+        Ok(())
+    } else {
+        Err(format!("{}/{total} checks failed", total - passed))
+    }
+}


### PR DESCRIPTION
Behaviour-preserving cleanup following the dual-boot work: the same predicates, constants, command plumbing and UI patterns had been written out several times across core, the Slint UI, the TUI, xtask and the shell scripts. Each commit is one item and keeps command lines, messages, accessible labels and rendered pixels identical; one real fix (mixed byte/MiB units in the ESP in-place update note) is in its own commit.

- `SwapMode::uses_partition()` replaces nine copies of the partition predicate
- GPT type GUIDs, sgdisk codes, the GPT margin and the ESP slack are named once
- Dead public API removed (`umount_efi`, `get_zfs_packages`, `supports_precompiled`, `query_package_version`, alpm `handle`/`handle_mut`, `install_network_manager`, `dataset_encryption_properties`); `create_efi_entries` drops its unused `target`
- `probe::run_with_stdin`, `GlobalConfig::download_config`, `alpm_pacman::open_target_alpm`, `users::add_to_group`, `cmd::chroot_checked`, `prepare::create_boot_environment`, `packages::best_matches`
- Configuration line editors moved to `system::conf`; ESP location parsing split from lsblk
- Slint: shared GiB formatting, `rebuild()` split into named helpers, `Session`/`Inventory` accessors, one edit factory for the alongside handlers, `ci_opt_with`, `reveal-if`, a shared `RadioCard`, a shared busy generation guard
- Review scripts share `reveal_by_tab`, `wait_value`, `properties`, `select`, `fill_labeled` on `Preview`
- TUI `MenuItem` constructors and one step item dispatcher
- xtask: one remote command builder for ssh/scp, table-driven `verify_system` in `verify.rs`, benchmarks in `bench.rs`, flattened `TestOpts` (CLI surface unchanged)
- `azfs-install-zbm` publishes through one verified copy helper; gen_iso deploy/update scripts share `zfs-be-common.sh`
- justfile private helpers for the paired ISO and QEMU recipes; `build.yml` builds both ISO kernels from one matrix job
- ESP in-place update note compared bytes with a MiB count

Testing

- `sudo target/debug/examples/alongside_fixture` in all five modes and `sudo bash core/tests/zbm-update-fixture.sh`: PASS
- `alongside_review.py` (all four display configurations), `storage_review.py`, `review.py`, `interactions.py`, `design_review.py` on the preview build: passed; disk, new-pool, existing-pool and alongside pages pixel-identical to the pre-refactor baseline
- `xtask --help` for every subcommand byte-identical before and after; `just --summary` and dry-runs of the folded recipes unchanged; gen_iso scripts compared on 20 non-root invocations each
