### PR TITLE
Drop the mtools dependency from the alongside ESP check and its fixture

### DIFF
--- a/core/src/disk/alongside/efi.rs
+++ b/core/src/disk/alongside/efi.rs
@@ -92,14 +92,15 @@ impl EfiSpace {
 }
 
 /// Inspect FAT without mounting or repairing it. A failed consistency or
-/// capacity check is not a low-space result.
+/// capacity check is not a low-space result. Free space comes from the same
+/// `fsck.fat -n -v` run: dosfstools is on every live medium, mtools is not.
 pub fn inspect_efi(
     runner: &dyn CommandRunner,
     layout: &Layout,
     number: u32,
     filesystems: &[Filesystem],
 ) -> Result<EfiSpace> {
-    check_tools(&[("fsck.fat", "dosfstools"), ("mdir", "mtools")])?;
+    check_tools(&[("fsck.fat", "dosfstools")])?;
     let p = layout
         .partitions
         .iter()
@@ -115,8 +116,7 @@ pub fn inspect_efi(
             .any(|f| f.path == p.node && f.fstype.as_deref() == Some("vfat")),
         "The existing ESP must contain a FAT filesystem"
     );
-    probe::run(runner, "fsck.fat", &["-n", &p.node.to_string_lossy()]).wrap_err("The existing EFI filesystem needs maintenance. No additional ESP is offered for a failed filesystem check")?;
-    let output = probe::run(runner, "mdir", &["-i", &p.node.to_string_lossy(), "::"])?;
+    let output = probe::run(runner, "fsck.fat", &["-n", "-v", &p.node.to_string_lossy()]).wrap_err("The existing EFI filesystem needs maintenance. No additional ESP is offered for a failed filesystem check")?;
     let free_bytes = parse_free_bytes(&output)?;
     ensure!(
         free_bytes <= p.size * layout.sectorsize,
@@ -128,17 +128,33 @@ pub fn inspect_efi(
     })
 }
 
+/// Free bytes from `fsck.fat -v` output: the boot-sector dump gives the
+/// cluster size and the summary line gives `used/total clusters`.
 fn parse_free_bytes(output: &str) -> Result<u64> {
-    let lines: Vec<_> = output
+    const UNREADABLE: &str =
+        "Cannot determine free space on the existing ESP; refresh after checking the filesystem";
+    let cluster_bytes: Vec<u64> = output
         .lines()
-        .filter_map(|l| l.trim().strip_suffix("bytes free"))
+        .filter_map(|l| l.trim().strip_suffix(" bytes per cluster"))
+        .filter_map(|n| n.trim().parse().ok())
         .collect();
-    ensure!(
-        lines.len() == 1,
-        "Cannot determine free space on the existing ESP; refresh after checking the filesystem"
-    );
-    let digits: String = lines[0].chars().filter(|c| !c.is_whitespace()).collect();
-    Ok(digits.parse()?)
+    let clusters: Vec<(u64, u64)> = output
+        .lines()
+        .filter_map(|l| l.trim().strip_suffix(" clusters"))
+        .filter_map(|l| l.rsplit(' ').next())
+        .filter_map(|pair| {
+            let (used, total) = pair.split_once('/')?;
+            Some((used.parse().ok()?, total.parse().ok()?))
+        })
+        .collect();
+    let (&[cluster], &[(used, total)]) = (cluster_bytes.as_slice(), clusters.as_slice()) else {
+        bail!(UNREADABLE);
+    };
+    ensure!(cluster > 0 && used <= total, UNREADABLE);
+    total
+        .checked_sub(used)
+        .and_then(|free| free.checked_mul(cluster))
+        .ok_or_else(|| eyre!(UNREADABLE))
 }
 
 #[cfg(test)]
@@ -229,11 +245,13 @@ mod tests {
     }
     #[test]
     fn unreadable_capacity_is_not_zero_space() {
-        assert_eq!(
-            parse_free_bytes("  123 456 789 bytes free\n").unwrap(),
-            123456789
-        );
+        let verbose = "fsck.fat 4.2 (2021-01-31)\nBoot sector contents:\n       512 bytes per logical sector\n      4096 bytes per cluster\n    201616 data clusters (825819136 bytes)\nChecking free cluster summary.\n/dev/sda1: 12 files, 8451/201616 clusters\n";
+        assert_eq!(parse_free_bytes(verbose).unwrap(), (201616 - 8451) * 4096);
         assert!(parse_free_bytes("Device unavailable").is_err());
-        assert!(parse_free_bytes("12 bytes free\n34 bytes free").is_err());
+        // The summary alone, without the cluster size, is not a measurement.
+        assert!(parse_free_bytes("/dev/sda1: 12 files, 8451/201616 clusters\n").is_err());
+        assert!(
+            parse_free_bytes("4096 bytes per cluster\n/dev/sda1: 1 files, 5/4 clusters\n").is_err()
+        );
     }
 }

--- a/xtask/src/alongside.rs
+++ b/xtask/src/alongside.rs
@@ -5,7 +5,6 @@ use std::{fs, io::Write, os::unix::fs::OpenOptionsExt, path::Path};
 pub fn prepare(vm: &QemuVm, config: &Path) -> Result<(), String> {
     let output = vm.ssh_run(r#"set -euo pipefail
 [ "$(readlink -f /dev/disk/by-id/virtio-archzfs-test-disk)" = /dev/vda ]
-command -v mmd >/dev/null || pacman -Sy --noconfirm --needed mtools
 sgdisk --zap-all --new=1:2048:+500M --typecode=1:ef00 --new=2:0:+50G --typecode=2:8300 --new=3:0:+1G --typecode=3:8300 /dev/vda
 udevadm settle
 mkfs.fat -F32 /dev/vda1
@@ -14,9 +13,12 @@ mkdir -p /run/preserved
 mount /dev/vda2 /run/preserved
 printf 'preserved filesystem payload\n' > /run/preserved/KEEP.txt
 umount /run/preserved
-printf 'foreign EFI payload\n' > /run/KEEP.EFI
-mmd -i /dev/vda1 ::/EFI ::/EFI/FOREIGN
-mcopy -i /dev/vda1 /run/KEEP.EFI ::/EFI/FOREIGN/KEEP.EFI
+# Write through a normal mount: the live medium need not carry mtools or a
+# usable pacman keyring for the fixture.
+mount /dev/vda1 /run/preserved
+mkdir -p /run/preserved/EFI/FOREIGN
+printf 'foreign EFI payload\n' > /run/preserved/EFI/FOREIGN/KEEP.EFI
+umount /run/preserved
 "#).map_err(|e| e.to_string())?;
     if !output.status.success() {
         return Err(format!(
@@ -72,8 +74,11 @@ mount -o ro /dev/vda2 /run/preserved
 value=$(cat /run/preserved/KEEP.txt)
 umount /run/preserved
 [ "$value" = 'preserved filesystem payload' ]
-[ "$(mtype -i /dev/vda1 ::/EFI/FOREIGN/KEEP.EFI)" = 'foreign EFI payload' ]
-mtype -i /dev/vda1 ::/EFI/zbm/vmlinuz.EFI > /run/installed-zbm.EFI
+mount -o ro /dev/vda1 /run/preserved
+value=$(cat /run/preserved/EFI/FOREIGN/KEEP.EFI)
+cp /run/preserved/EFI/zbm/vmlinuz.EFI /run/installed-zbm.EFI
+umount /run/preserved
+[ "$value" = 'foreign EFI payload' ]
 [ "$(od -An -tx1 -N2 /run/installed-zbm.EFI | tr -d ' \n')" = 4d5a ]
 "#,
         )

--- a/xtask/src/alongside.rs
+++ b/xtask/src/alongside.rs
@@ -74,10 +74,13 @@ mount -o ro /dev/vda2 /run/preserved
 value=$(cat /run/preserved/KEEP.txt)
 umount /run/preserved
 [ "$value" = 'preserved filesystem payload' ]
-mount -o ro /dev/vda1 /run/preserved
-value=$(cat /run/preserved/EFI/FOREIGN/KEEP.EFI)
-cp /run/preserved/EFI/zbm/vmlinuz.EFI /run/installed-zbm.EFI
-umount /run/preserved
+# The installer leaves the ESP mounted under the target; FAT cannot be
+# mounted a second time, so read it where it is.
+esp=$(findmnt -n -o TARGET --source /dev/vda1 | head -n 1)
+if [ -z "$esp" ]; then mount -o ro /dev/vda1 /run/preserved; esp=/run/preserved; fi
+value=$(cat "$esp/EFI/FOREIGN/KEEP.EFI")
+cp "$esp/EFI/zbm/vmlinuz.EFI" /run/installed-zbm.EFI
+[ "$esp" != /run/preserved ] || umount /run/preserved
 [ "$value" = 'foreign EFI payload' ]
 [ "$(od -An -tx1 -N2 /run/installed-zbm.EFI | tr -d ' \n')" = 4d5a ]
 "#,


### PR DESCRIPTION
The alongside planner read the ESP's free space with mdir, so the live medium had to carry mtools. Neither testing ISO does; the VM harness happened to install mtools with pacman before running the installer, which hid the dependency until an ISO without a usable live keyring broke that step. The consistency check already runs fsck.fat, and its verbose output has the cluster size and used/total cluster counts, so the measurement now comes from there and mtools is no longer needed anywhere.

- Measure ESP free space from `fsck.fat -n -v` instead of `mdir`; parser unit tests cover the verbose format and malformed output
- The harness writes the foreign ESP payload through a plain mount instead of `mmd`/`mcopy` and no longer runs pacman in the live medium
- The harness reads the ESP through the installer's remaining mount after installation, since FAT cannot be mounted twice

Testing

- `sudo target/debug/examples/alongside_fixture` in ext4 and new-esp modes: PASS
- `xtask test-vm --alongside --zfs-mode dkms` with `alongside-swap.json` on the 2026-09-09 testing ISO: install, preserved-payload verification and boot passed, 13/13 checks
