### PR TITLE
Propose half of the free space when shrinking another system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -197,7 +197,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset"
 version = "0.2.1"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset-macro"
 version = "0.2.1"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1678,7 +1678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-linuxkms"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "calloop 0.14.4",
  "cfg_aliases",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-selector"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "cfg-if",
  "cfg_aliases",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-testing"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "cfg_aliases",
  "i-slint-common",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-winit"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "arboard",
  "block2 0.6.2",
@@ -2574,7 +2574,7 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "derive_more",
  "fontique",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "i-slint-compiler"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "annotate-snippets",
  "by_address",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core-macros"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "quote",
  "serde_json",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-skia"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-software"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "bytemuck",
  "clru",
@@ -3563,7 +3563,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3719,7 +3719,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4197,7 +4197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4732,7 +4732,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5198,7 +5198,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5255,7 +5255,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5618,7 +5618,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slint"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "const-field-offset",
  "i-slint-backend-linuxkms",
@@ -5639,7 +5639,7 @@ dependencies = [
 [[package]]
 name = "slint-build"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "derive_more",
  "fontique",
@@ -5651,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "slint-macros"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -5746,7 +5746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6026,7 +6026,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6039,7 +6039,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6592,7 +6592,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6759,7 +6759,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vtable"
 version = "0.5.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -6770,7 +6770,7 @@ dependencies = [
 [[package]]
 name = "vtable-macro"
 version = "0.5.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#313b4667c10844224667aa7db424606539f81961"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7288,7 +7288,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset"
 version = "0.2.1"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset-macro"
 version = "0.2.1"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-linuxkms"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "calloop 0.14.4",
  "cfg_aliases",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-selector"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "cfg-if",
  "cfg_aliases",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-testing"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "cfg_aliases",
  "i-slint-common",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-winit"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "arboard",
  "block2 0.6.2",
@@ -2574,7 +2574,7 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "derive_more",
  "fontique",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "i-slint-compiler"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "annotate-snippets",
  "by_address",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core-macros"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "quote",
  "serde_json",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-skia"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "ash",
  "bytemuck",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-software"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "bytemuck",
  "clru",
@@ -5618,7 +5618,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slint"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "const-field-offset",
  "i-slint-backend-linuxkms",
@@ -5639,7 +5639,7 @@ dependencies = [
 [[package]]
 name = "slint-build"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "derive_more",
  "fontique",
@@ -5651,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "slint-macros"
 version = "1.18.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -6759,7 +6759,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vtable"
 version = "0.5.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -6770,7 +6770,7 @@ dependencies = [
 [[package]]
 name = "vtable-macro"
 version = "0.5.0"
-source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#0b52d7c741743ad55d69ec2e7845dc4a3f339669"
+source = "git+https://github.com/okhsunrog/slint.git?branch=feat%2Flinuxkms-integration#744a3cfaf72d10bc792261189187e24486f634b3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/src/disk/alongside.rs
+++ b/core/src/disk/alongside.rs
@@ -15,7 +15,7 @@ mod execute;
 pub use execute::execute;
 mod probe;
 pub use efi::{BootSpace, EfiChoice, EfiSpace, inspect_efi};
-pub use probe::{Filesystem, inspect, minimum_size};
+pub use probe::{Filesystem, ShrinkLimits, inspect, minimum_size, shrink_limits};
 
 pub const MIB: u64 = 1024 * 1024;
 pub const GIB: u64 = 1024 * MIB;
@@ -27,6 +27,64 @@ pub const ESP_BYTES: u64 = 512 * MIB;
 /// added to the boot image budget, and reserved again when checking that the
 /// budget fits a newly created ESP.
 pub const ESP_SLACK_BYTES: u64 = 8 * MIB;
+/// Free space the retained system keeps by default: this share of its
+/// partition, but at least [`KEEP_FREE_MIN_BYTES`].
+pub const KEEP_FREE_FRACTION: u64 = 5;
+pub const KEEP_FREE_MIN_BYTES: u64 = 20 * GIB;
+/// Below this share of free space the retained system is warned about.
+pub const WARN_FREE_PERCENT: u64 = 15;
+
+/// How much of a shrinkable partition to propose for the new system. Space
+/// that belongs to nobody (an unallocated extent) is taken whole; space that
+/// another operating system is using is shared: half of what it has free,
+/// leaving it a working margin, and never more than the resizer allows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShrinkDefaults {
+    /// What the resizer allows at most, MiB-aligned.
+    pub hard_max: u64,
+    /// What can be taken while the retained system keeps its margin.
+    pub soft_max: u64,
+    /// The proposed allocation: half of the free space within `soft_max`,
+    /// or the required minimum when only the hard limit accommodates it.
+    /// `None` when even `needed` does not fit.
+    pub default: Option<u64>,
+}
+
+impl ShrinkDefaults {
+    pub fn compute(size: u64, limits: ShrinkLimits, needed: u64) -> Self {
+        let hard_max =
+            size.saturating_sub(limits.minimum_bytes.saturating_add(2 * MIB)) / MIB * MIB;
+        let free = size.saturating_sub(limits.used_bytes);
+        let keep = (size / KEEP_FREE_FRACTION).max(KEEP_FREE_MIN_BYTES);
+        let soft_max = free.saturating_sub(keep).min(hard_max) / MIB * MIB;
+        let default = if needed <= soft_max {
+            Some((free / 2 / MIB * MIB).clamp(needed, soft_max))
+        } else if needed <= hard_max {
+            Some(needed)
+        } else {
+            None
+        };
+        Self {
+            hard_max,
+            soft_max,
+            default,
+        }
+    }
+
+    /// Whether `default` had to go beyond the margin the retained system
+    /// keeps by default.
+    pub fn cramped(&self) -> bool {
+        self.default.is_some_and(|d| d > self.soft_max)
+    }
+}
+
+/// Free space the retained system has left after giving `allocation` away,
+/// and whether that is below the warning threshold.
+pub fn retained_free(size: u64, used: u64, allocation: u64) -> (u64, bool) {
+    let free_after = size.saturating_sub(used).saturating_sub(allocation);
+    (free_after, free_after * 100 < size * WARN_FREE_PERCENT)
+}
+
 pub const EFI_TYPE: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
 pub const BASIC_TYPE: &str = "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7";
 pub const LINUX_TYPE: &str = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
@@ -347,6 +405,52 @@ pub fn check_tools(tools: &[(&str, &str)]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn limits(used: u64) -> ShrinkLimits {
+        ShrinkLimits {
+            used_bytes: used,
+            minimum_bytes: used + (used / 10).max(GIB),
+        }
+    }
+
+    #[test]
+    fn shrinking_proposes_half_of_the_free_space_and_keeps_a_margin() {
+        // 450 GiB with 170 GiB used: free 280, half 140, margin 90 GiB.
+        let d = ShrinkDefaults::compute(450 * GIB, limits(170 * GIB), MIN_LINUX_BYTES);
+        assert_eq!(d.default, Some(140 * GIB));
+        assert_eq!(d.soft_max, 190 * GIB);
+        assert_eq!(d.hard_max, 450 * GIB - 187 * GIB - 2 * MIB);
+        assert!(!d.cramped());
+        // Nearly empty 450 GiB: the old rule left it 37 GiB; now 240 GiB.
+        let d = ShrinkDefaults::compute(450 * GIB, limits(30 * GIB), MIN_LINUX_BYTES);
+        assert_eq!(d.default, Some(210 * GIB));
+        // A 256 GiB laptop disk with 90 GiB used.
+        let d = ShrinkDefaults::compute(256 * GIB, limits(90 * GIB), MIN_LINUX_BYTES);
+        assert_eq!(d.default, Some(83 * GIB));
+        // Small partitions keep at least 20 GiB free, not 20 percent.
+        let d = ShrinkDefaults::compute(80 * GIB, limits(20 * GIB), MIN_LINUX_BYTES);
+        assert_eq!(d.soft_max, 40 * GIB);
+        assert_eq!(d.default, Some(32 * GIB));
+    }
+
+    #[test]
+    fn a_cramped_partition_yields_only_the_minimum_or_nothing() {
+        // 200 GiB with 150 used: free 50, margin 40 -> soft 10 < 32 needed,
+        // but the resizer allows 200 - 166 = 34: propose the minimum, flagged.
+        let d = ShrinkDefaults::compute(200 * GIB, limits(150 * GIB), MIN_LINUX_BYTES);
+        assert_eq!(d.default, Some(MIN_LINUX_BYTES));
+        assert!(d.cramped());
+        assert!(retained_free(200 * GIB, 150 * GIB, MIN_LINUX_BYTES).1);
+        // 200 GiB with 160 used: 200 - 177 = 23 < 32: nothing to propose.
+        let d = ShrinkDefaults::compute(200 * GIB, limits(160 * GIB), MIN_LINUX_BYTES);
+        assert_eq!(d.default, None);
+        // A larger requirement (swap, separate ESP) moves the default up.
+        let d = ShrinkDefaults::compute(450 * GIB, limits(170 * GIB), 150 * GIB);
+        assert_eq!(d.default, Some(150 * GIB));
+        assert_eq!(
+            retained_free(450 * GIB, 170 * GIB, 140 * GIB),
+            (140 * GIB, false)
+        );
+    }
 
     fn layout(sectorsize: u64) -> Layout {
         Layout {

--- a/core/src/disk/alongside/probe.rs
+++ b/core/src/disk/alongside/probe.rs
@@ -137,7 +137,28 @@ pub(super) fn ext_size(runner: &dyn CommandRunner, device: &str) -> Result<(u64,
 
 /// Returns a conservative lower bound. Passing this check does not bypass the
 /// resizer's own checks. Failed or unparseable probes never enable shrinking.
+/// What a filesystem occupies and the smallest size it may be shrunk to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShrinkLimits {
+    /// Bytes the filesystem needs for its data and metadata, as reported by
+    /// the resizer. This is the basis for "free space" in the planner.
+    pub used_bytes: u64,
+    /// The hard lower bound for resizing: `used_bytes` plus a safety margin
+    /// against the resizer's estimate.
+    pub minimum_bytes: u64,
+}
+
+/// The smallest size the filesystem may safely be shrunk to. See
+/// [`shrink_limits`] for the numbers behind it.
 pub fn minimum_size(runner: &dyn CommandRunner, part: &Partition, fs: &str) -> Result<u64> {
+    Ok(shrink_limits(runner, part, fs)?.minimum_bytes)
+}
+
+pub fn shrink_limits(
+    runner: &dyn CommandRunner,
+    part: &Partition,
+    fs: &str,
+) -> Result<ShrinkLimits> {
     check_tools(required_tools(fs)?)?;
     ensure!(
         part.attrs.is_empty(),
@@ -169,11 +190,16 @@ pub fn minimum_size(runner: &dyn CommandRunner, part: &Partition, fs: &str) -> R
         }
         _ => unreachable!("required_tools rejected an unsupported filesystem"),
     };
-    // Leave working space for the retained OS, and avoid trusting a minimum
-    // estimate as an exact safe boundary (notably resize2fs with small blocks).
-    raw.checked_add(raw / 5)
-        .and_then(|n| n.checked_add(GIB))
-        .ok_or_else(|| eyre!("Minimum size overflow"))
+    // The resizer's minimum is an estimate (notably resize2fs with small
+    // blocks); keep a margin above it. Working space for the retained system
+    // is a planning default, not a resize limit: see `shrink_defaults`.
+    let minimum_bytes = raw
+        .checked_add((raw / 10).max(GIB))
+        .ok_or_else(|| eyre!("Minimum size overflow"))?;
+    Ok(ShrinkLimits {
+        used_bytes: raw,
+        minimum_bytes,
+    })
 }
 
 #[cfg(test)]

--- a/docs/dual-boot-development.md
+++ b/docs/dual-boot-development.md
@@ -149,7 +149,7 @@ including maps, the compact layout and the review summary.
 | --- | --- |
 | Reuse ESP | Select source, enter allocation, switch to unallocated space |
 | Swap | Choose disk swap on Disk; map and Review subtract its size from the pool |
-| Whole extent | Default to all MiB-aligned space; preserve fractional-GiB capacity |
+| Whole extent | Free space is taken whole by default; a shrink proposes half of the free space (140 of 280 GiB) and "take the rest" moves to the resizer's limit |
 | Insufficient ESP | Reuse option disabled with reason; select the separate ESP by keyboard |
 | Return navigation | Open Review, return to Disk, switch installation modes and return |
 | Missing NTFS tools | Select unavailable source; readable package hint; Install disabled |
@@ -163,8 +163,14 @@ can satisfy the minimum allocation. These preview results do not establish real
 filesystem safety or existing-OS bootability; use the execution tests separately.
 
 
-Allocation defaults to the entire selected free extent (or the maximum safe
-shrink allocation), aligned down to MiB without discarding a fractional GiB.
+Unallocated space is proposed whole, aligned down to MiB without discarding a
+fractional GiB. Shrinking another system's partition proposes half of that
+filesystem's free space, so that it keeps at least 20 % of its partition (or
+20 GiB) free; the slider still reaches the resizer's limit, and below 15 %
+free the details line warns. The resize limit itself is the resizer's minimum
+plus 10 % (at least 1 GiB) as a margin against the estimate. When several
+partitions qualify, the one with the roomiest proposal is preselected; free
+space always wins over shrinking. See `ShrinkDefaults` in `core`.
 The Disk page owns swap selection for alongside installs. None/ZRAM consume no
 disk space; plain/encrypted swap reserves the chosen GiB inside the allocation.
 A minimum of 32 GiB remains for ZFS after subtracting swap and an optional new

--- a/docs/dual-boot-development.md
+++ b/docs/dual-boot-development.md
@@ -149,7 +149,7 @@ including maps, the compact layout and the review summary.
 | --- | --- |
 | Reuse ESP | Select source, enter allocation, switch to unallocated space |
 | Swap | Choose disk swap on Disk; map and Review subtract its size from the pool |
-| Whole extent | Free space is taken whole by default; a shrink proposes half of the free space (140 of 280 GiB) and "take the rest" moves to the resizer's limit |
+| Whole extent | Free space is taken whole by default; a shrink proposes half of the free space (140 of 280 GiB) and the slider tops out at the resizer's limit |
 | Insufficient ESP | Reuse option disabled with reason; select the separate ESP by keyboard |
 | Return navigation | Open Review, return to Disk, switch installation modes and return |
 | Missing NTFS tools | Select unavailable source; readable package hint; Install disabled |

--- a/slint-ui/scripts/alongside_review.py
+++ b/slint-ui/scripts/alongside_review.py
@@ -16,7 +16,9 @@ def run(binary, output, size, scale, small):
         p.screenshot(prefix + '-initial')
         p.click('Combobox', 'Space source')
         p.click('ListItem', '/dev/nvme0n1p2')
-        p.reveal_by_tab('TextInput', 'Allocation in GiB')
+        # Shrinking proposes half of the free space (280 GiB free -> 140),
+        # never everything the resizer would allow.
+        p.wait_value('TextInput', 'Allocation in GiB', '140')
         p.click('TextInput', 'Allocation in GiB')
         p.fill_labeled('Allocation in GiB', '100')
         p.key('\n')
@@ -26,16 +28,17 @@ def run(binary, output, size, scale, small):
             assert not reuse.get('accessibleEnabled'), reuse
             p.click('RadioButton', 'Create a separate')
         # Widgets must follow state set by Rust after the user has touched
-        # them: "Use all" moves the slider and the input to the capacity.
-        p.reveal_by_tab('Checkbox', 'Use all available space')
-        p.click('Checkbox', 'Use all available space')
-        p.wait_value('Slider', 'Space for installation', '240')
-        p.wait_value('TextInput', 'Allocation in GiB', '240')
+        # them: taking everything moves the slider and the input to the
+        # resizer's limit (450 GiB minus the 187 GiB minimum).
+        p.reveal_by_tab('Checkbox', 'Leave the existing system')
+        p.click('Checkbox', 'Leave the existing system')
+        p.wait_value('Slider', 'Space for installation', '263')
+        p.wait_value('TextInput', 'Allocation in GiB', '263')
         # A refresh keeps the current plan while the layout is unchanged.
         p.reveal_by_tab('Button', 'Refresh disks')
         p.click('Button', 'Refresh disks')
         p.wait_value('Combobox', 'Space source', '/dev/nvme0n1p2 — NTFS — 450 GiB')
-        p.wait_value('TextInput', 'Allocation in GiB', '240')
+        p.wait_value('TextInput', 'Allocation in GiB', '263')
         assert p.wait('Combobox', 'Space source')['accessibleValue'].startswith('/dev/nvme0n1p2'), 'refresh discarded the selected source'
         p.click('TextInput', 'Allocation in GiB')
         p.fill_labeled('Allocation in GiB', '100')

--- a/slint-ui/scripts/alongside_review.py
+++ b/slint-ui/scripts/alongside_review.py
@@ -28,12 +28,19 @@ def run(binary, output, size, scale, small):
             assert not reuse.get('accessibleEnabled'), reuse
             p.click('RadioButton', 'Create a separate')
         # Widgets must follow state set by Rust after the user has touched
-        # them: taking everything moves the slider and the input to the
-        # resizer's limit (450 GiB minus the 187 GiB minimum).
-        p.reveal_by_tab('Checkbox', 'Leave the existing system')
-        p.click('Checkbox', 'Leave the existing system')
+        # them: re-selecting the source returns to the proposal, and the
+        # slider tops out at the resizer's limit (450 GiB minus the 187 GiB
+        # minimum), which is what a maximal drag reaches.
+        p.reveal_by_tab('Combobox', 'Space source')
+        p.click('Combobox', 'Space source')
+        p.click('ListItem', '/dev/nvme0n1p2')
+        p.wait_value('Slider', 'Space for installation', '140')
+        p.wait_value('TextInput', 'Allocation in GiB', '140')
+        assert abs(p.properties('Slider', 'Space for installation').get('accessibleValueMaximum', 0) - 263.0) < 0.01
+        p.click('TextInput', 'Allocation in GiB')
+        p.fill_labeled('Allocation in GiB', '263')
+        p.key('\n')
         p.wait_value('Slider', 'Space for installation', '263')
-        p.wait_value('TextInput', 'Allocation in GiB', '263')
         # A refresh keeps the current plan while the layout is unchanged.
         p.reveal_by_tab('Button', 'Refresh disks')
         p.click('Button', 'Refresh disks')

--- a/slint-ui/scripts/interactions.py
+++ b/slint-ui/scripts/interactions.py
@@ -38,6 +38,8 @@ def users(p):
     p.click('Button', 'Cancel')
     p.click('Button', 'User accounts')
     p.screenshot('users-dialog')
+    # With an account present the dialog shows cards; the form is on request.
+    p.click('Button', 'Add another user')
     p.fill(0, 'previewuser')
     p.fill(1, 'a long preview passphrase for testing')
     time.sleep(.5)

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -669,14 +669,6 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         let max = gib(source.capacity) as f32;
         state.set_minimum(min);
         state.set_maximum(max);
-        state.set_use_all_label(
-            if source.is_unallocated() {
-                "Use the whole free extent"
-            } else {
-                "Leave the existing system only its minimum and take the rest"
-            }
-            .into(),
-        );
         let all_bytes = source.capacity / MIB * MIB;
         let allocation_bytes = if let Some(k) = kept {
             k.allocation_bytes

--- a/slint-ui/src/alongside.rs
+++ b/slint-ui/src/alongside.rs
@@ -19,9 +19,41 @@ use std::{cell::RefCell, path::PathBuf, rc::Rc};
 struct Source {
     source: SpaceSource,
     label: String,
+    /// Hard maximum: the whole extent, or what the resizer allows.
     capacity: u64,
+    /// For a shrink source: partition size and the filesystem's resize limits.
+    shrink: Option<(u64, ShrinkLimits)>,
     detail: String,
     error: String,
+}
+
+impl Source {
+    fn is_unallocated(&self) -> bool {
+        matches!(self.source, SpaceSource::Unallocated { .. })
+    }
+
+    /// The allocation proposed for `needed` bytes, and whether it exceeds the
+    /// margin the retained system keeps by default.
+    fn proposal(&self, needed: u64) -> Option<(u64, bool)> {
+        match self.shrink {
+            Some((size, limits)) => {
+                let d = ShrinkDefaults::compute(size, limits, needed);
+                d.default.map(|bytes| (bytes, d.cramped()))
+            }
+            None => (self.capacity >= needed).then_some((self.capacity / MIB * MIB, false)),
+        }
+    }
+}
+
+/// What shrinking `node` leaves for its current system, for the source line.
+fn shrink_detail(node: &std::path::Path, size: u64, limits: ShrinkLimits) -> String {
+    let free = size.saturating_sub(limits.used_bytes);
+    format!(
+        "{} uses {:.0} GiB and has {:.0} GiB free. Only its end moves; the proposal shares that free space and leaves it a working margin.",
+        node.display(),
+        gib(limits.used_bytes),
+        gib(free)
+    )
 }
 #[derive(Clone)]
 struct Efi {
@@ -139,23 +171,21 @@ fn survey(disk: &std::path::Path, previous: Option<&Survey>) -> Result<Survey, S
             sources.push(cached.clone());
             continue;
         }
-        let minimum = minimum_size(&RealRunner, p, fs);
-        let (capacity, error) = match minimum {
-            Ok(min) => (
-                size.saturating_sub(min.saturating_add(2 * MIB)),
+        let (capacity, shrink, detail, error) = match shrink_limits(&RealRunner, p, fs) {
+            Ok(limits) => (
+                ShrinkDefaults::compute(size, limits, 0).hard_max,
+                Some((size, limits)),
+                shrink_detail(&p.node, size, limits),
                 String::new(),
             ),
-            Err(e) => (0, format!("{e:#}")),
+            Err(e) => (0, None, String::new(), format!("{e:#}")),
         };
         sources.push(Source {
             source: SpaceSource::Shrink { partition: number },
             label,
             capacity,
-            detail: format!(
-                "Keep {} at its current start; reduce only its end. Up to {:.0} GiB can be allocated here.",
-                p.node.display(),
-                gib(capacity)
-            ),
+            shrink,
+            detail,
             error,
         });
     }
@@ -167,6 +197,7 @@ fn survey(disk: &std::path::Path, previous: Option<&Survey>) -> Result<Survey, S
                 source: SpaceSource::Unallocated { start, end },
                 label: format!("Unallocated space — {:.1} GiB", gib(bytes)),
                 capacity: bytes,
+                shrink: None,
                 detail: "Create a ZFS partition here without shrinking an existing filesystem."
                     .into(),
                 error: String::new(),
@@ -223,12 +254,21 @@ fn fixture() -> Survey {
     let mut survey = Survey {
         layout: layout.clone(),
         sources: vec![
-            Source {
-                source: SpaceSource::Shrink { partition: 2 },
-                label: "/dev/nvme0n1p2 — NTFS — 450 GiB".into(),
-                capacity: 240 * GIB,
-                detail: "Windows keeps at least 210 GiB, including working space. Only the end of this partition will move.".into(),
-                error: String::new(),
+            {
+                // 170 GiB in use: 280 GiB free, 140 GiB proposed, 263 GiB at most.
+                let size = 450 * GIB;
+                let limits = ShrinkLimits {
+                    used_bytes: 170 * GIB,
+                    minimum_bytes: 187 * GIB,
+                };
+                Source {
+                    source: SpaceSource::Shrink { partition: 2 },
+                    label: "/dev/nvme0n1p2 — NTFS — 450 GiB".into(),
+                    capacity: ShrinkDefaults::compute(size, limits, 0).hard_max,
+                    shrink: Some((size, limits)),
+                    detail: shrink_detail(std::path::Path::new("/dev/nvme0n1p2"), size, limits),
+                    error: String::new(),
+                }
             },
             Source {
                 source: SpaceSource::Unallocated {
@@ -237,6 +277,7 @@ fn fixture() -> Survey {
                 },
                 label: "Unallocated space — 60 GiB".into(),
                 capacity: ((layout.lastlba + 1) * 512 - 452 * GIB) / MIB * MIB,
+                shrink: None,
                 detail: "Use free space without resizing Windows.".into(),
                 error: String::new(),
             },
@@ -258,6 +299,7 @@ fn fixture() -> Survey {
         }
         Ok("missing-tools") => {
             survey.sources[0].capacity = 0;
+            survey.sources[0].shrink = None;
             survey.sources[0].error =
                 "Resizing NTFS requires ntfsresize (package ntfs-3g). Install it in the live system and refresh, or use unallocated space."
                     .into();
@@ -266,6 +308,34 @@ fn fixture() -> Survey {
         _ => {}
     }
     survey
+}
+
+/// Free space that belongs to nobody comes first. Otherwise prefer the
+/// partition whose proposal stays within its system's margin, then any
+/// partition the resizer can make room on.
+fn default_source(sources: &[Source]) -> Option<usize> {
+    let usable = |s: &Source| s.error.is_empty();
+    sources
+        .iter()
+        .position(|s| usable(s) && s.is_unallocated() && s.capacity >= MIN_LINUX_BYTES)
+        .or_else(|| {
+            sources
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| usable(s))
+                .filter_map(|(i, s)| {
+                    s.proposal(MIN_LINUX_BYTES)
+                        .filter(|(_, cramped)| !cramped)
+                        .map(|(bytes, _)| (i, bytes))
+                })
+                .max_by_key(|(_, bytes)| *bytes)
+                .map(|(i, _)| i)
+        })
+        .or_else(|| {
+            sources
+                .iter()
+                .position(|s| usable(s) && s.proposal(MIN_LINUX_BYTES).is_some())
+        })
 }
 
 impl Guarded for AlongsideState<'_> {
@@ -363,6 +433,7 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                     state.set_efi_index(efi as i32);
                     state.set_additional_efi(matches!(r.efi, EfiChoice::CreateSeparate { .. }));
                     state.set_use_all(false);
+                    state.set_custom_allocation(true);
                     state.set_allocation(gib(r.allocation_bytes) as f32);
                     if r.swap_bytes > 0 {
                         state.set_swap_size((r.swap_bytes / GIB) as f32);
@@ -376,24 +447,10 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                         "The previous plan no longer matches this disk; this is a new plan built from the current layout.",
                     );
                 }
-                state.set_source_index(
-                    survey
-                        .sources
-                        .iter()
-                        .position(|s| {
-                            matches!(s.source, SpaceSource::Unallocated { .. })
-                                && s.error.is_empty()
-                                && s.capacity >= MIN_LINUX_BYTES
-                        })
-                        .or_else(|| {
-                            survey
-                                .sources
-                                .iter()
-                                .position(|s| s.error.is_empty() && s.capacity >= MIN_LINUX_BYTES)
-                        })
-                        .map(|i| i as i32)
-                        .unwrap_or(0),
-                );
+                let chosen = default_source(&survey.sources);
+                state.set_source_index(chosen.map(|i| i as i32).unwrap_or(0));
+                state.set_use_all(chosen.is_some_and(|i| survey.sources[i].is_unallocated()));
+                state.set_custom_allocation(false);
                 state.set_efi_index(
                     survey
                         .efis
@@ -406,7 +463,6 @@ fn load(app: &App, index: Option<usize>, keep: Option<Request>) {
                         .unwrap_or(0) as i32,
                 );
                 state.set_additional_efi(false);
-                state.set_use_all(true);
                 Session::set_survey(Some(survey));
                 state.invoke_rebuild();
             }
@@ -525,6 +581,34 @@ fn efi_details(space: &EfiSpace, budget: BootSpace, insufficient: bool) -> Resul
     ))
 }
 
+/// Both sides of a shrink: the new size, what the retained system keeps
+/// free, and a warning when that is little.
+fn shrink_outcome(
+    old: &Partition,
+    new_sectors: u64,
+    sectorsize: u64,
+    limits: Option<ShrinkLimits>,
+) -> String {
+    let before = sectors_gib(old.size, sectorsize);
+    let after = sectors_gib(new_sectors, sectorsize);
+    let mut text = format!(
+        "{}: {before:.0} → {after:.0} GiB. Its start and existing data are preserved.",
+        old.node.display()
+    );
+    if let Some(limits) = limits {
+        let size = old.size * sectorsize;
+        let allocation = (old.size - new_sectors) * sectorsize;
+        let (free_after, low) = retained_free(size, limits.used_bytes, allocation);
+        text.push_str(&format!(" It keeps {:.0} GiB free.", gib(free_after)));
+        if low {
+            text.push_str(&format!(
+                " That is under {WARN_FREE_PERCENT}% of the partition; updates and everyday use need room."
+            ));
+        }
+    }
+    text
+}
+
 fn allocation_summary(plan: &Plan, layout: &Layout, swap_bytes: u64) -> String {
     let zfs_sectors = plan.swap_start.unwrap_or(plan.end) - plan.zfs_start;
     let efi = if plan.efi_start.is_some() {
@@ -580,19 +664,33 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         } else {
             0
         };
-        let min = gib(MIN_LINUX_BYTES + swap_bytes + extra) as f32;
+        let needed = MIN_LINUX_BYTES + swap_bytes + extra;
+        let min = gib(needed) as f32;
         let max = gib(source.capacity) as f32;
         state.set_minimum(min);
         state.set_maximum(max);
+        state.set_use_all_label(
+            if source.is_unallocated() {
+                "Use the whole free extent"
+            } else {
+                "Leave the existing system only its minimum and take the rest"
+            }
+            .into(),
+        );
         let all_bytes = source.capacity / MIB * MIB;
         let allocation_bytes = if let Some(k) = kept {
             k.allocation_bytes
         } else if state.get_use_all() {
             all_bytes
-        } else {
+        } else if state.get_custom_allocation() {
             (state.get_allocation().round().max(min) as u64)
                 .saturating_mul(GIB)
                 .min(all_bytes)
+        } else {
+            source
+                .proposal(needed)
+                .map(|(bytes, _)| bytes)
+                .unwrap_or(all_bytes)
         };
         state.set_allocation((gib(allocation_bytes) * 10.0).round() as f32 / 10.0);
         let efi = s.efis.get(state.get_efi_index() as usize).ok_or(
@@ -638,11 +736,11 @@ fn rebuild(app: &App, config: &mut GlobalConfig) {
         state.set_allocation_summary(allocation_summary(&plan, &s.layout, swap_bytes).into());
         if let Some((old, size)) = &plan.shrink {
             state.set_details(
-                format!(
-                    "{}: {:.0} → {:.0} GiB. Its start and existing data are preserved.",
-                    old.node.display(),
-                    sectors_gib(old.size, s.layout.sectorsize),
-                    sectors_gib(*size, s.layout.sectorsize)
+                shrink_outcome(
+                    old,
+                    *size,
+                    s.layout.sectorsize,
+                    source.shrink.map(|(_, limits)| limits),
                 )
                 .into(),
             );
@@ -698,7 +796,16 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
     let state = app.global::<AlongsideState>();
     state.on_select_source(edit(app, |s, index: i32| {
         s.set_source_index(index);
-        s.set_use_all(true);
+        // Free space is taken whole; a shrink starts from the proposal.
+        let unallocated = Session::with(|session| {
+            session
+                .survey
+                .as_ref()
+                .and_then(|survey| survey.sources.get(index as usize))
+                .is_some_and(Source::is_unallocated)
+        });
+        s.set_use_all(unallocated);
+        s.set_custom_allocation(false);
         true
     }));
     state.on_select_efi(edit(app, |s, index: i32| {
@@ -711,11 +818,14 @@ pub fn setup(app: &App, config: &Rc<RefCell<GlobalConfig>>) {
             return false;
         }
         s.set_use_all(false);
+        s.set_custom_allocation(true);
         s.set_allocation(value);
         true
     }));
     state.on_all_space(edit(app, |s, value: bool| {
         s.set_use_all(value);
+        // Unticking returns to the proposal rather than a stale number.
+        s.set_custom_allocation(false);
         true
     }));
     let cfg = config.clone();

--- a/slint-ui/src/controllers/wizard.rs
+++ b/slint-ui/src/controllers/wizard.rs
@@ -430,8 +430,12 @@ fn setup_password_strength(app: &App) {
         }
         let current = generation.get().wrapping_add(1);
         generation.set(current);
-        app.global::<PopupState>().set_password_strength_score(-1);
+        // Keep the previous rating on screen until the new one arrives: a
+        // rating that vanishes and reappears on every keystroke is noise.
         if value.is_empty() {
+            let popup = app.global::<PopupState>();
+            popup.set_password_strength_score(-1);
+            popup.set_password_strength_hint(SharedString::default());
             return;
         }
 

--- a/slint-ui/ui/components/alongside-panel.slint
+++ b/slint-ui/ui/components/alongside-panel.slint
@@ -68,7 +68,7 @@ export component AlongsidePanel inherits Rectangle {
             Text { text: "Where to make space"; font-weight: 600; color: Theme.c.text; }
             source-choice := ComboBox { changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } accessible-label: "Space source"; model: AlongsideState.sources; current-index <=> AlongsideState.source-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-source(self.current-index); } }
             Text { text: AlongsideState.details; color: Theme.c.subtext1; wrap: word-wrap; }
-            CheckBox { text: "Use all available space"; checked: AlongsideState.use-all; enabled: !AlongsideState.busy; toggled => { AlongsideState.all-space(self.checked); } changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } }
+            CheckBox { text: AlongsideState.use-all-label; checked: AlongsideState.use-all; enabled: !AlongsideState.busy; toggled => { AlongsideState.all-space(self.checked); } changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } }
             HorizontalLayout {
                 spacing: 16px;
                 Text { text: "Allocate to this installation"; color: Theme.c.text; }

--- a/slint-ui/ui/components/alongside-panel.slint
+++ b/slint-ui/ui/components/alongside-panel.slint
@@ -68,7 +68,6 @@ export component AlongsidePanel inherits Rectangle {
             Text { text: "Where to make space"; font-weight: 600; color: Theme.c.text; }
             source-choice := ComboBox { changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } accessible-label: "Space source"; model: AlongsideState.sources; current-index <=> AlongsideState.source-index; enabled: !AlongsideState.busy; selected(value) => { AlongsideState.select-source(self.current-index); } }
             Text { text: AlongsideState.details; color: Theme.c.subtext1; wrap: word-wrap; }
-            CheckBox { text: AlongsideState.use-all-label; checked: AlongsideState.use-all; enabled: !AlongsideState.busy; toggled => { AlongsideState.all-space(self.checked); } changed has-focus => { root.reveal-if(self.has-focus, self.absolute-position.y, self.height); } }
             HorizontalLayout {
                 spacing: 16px;
                 Text { text: "Allocate to this installation"; color: Theme.c.text; }

--- a/slint-ui/ui/popups/text-input-popup.slint
+++ b/slint-ui/ui/popups/text-input-popup.slint
@@ -68,32 +68,35 @@ export component TextInputPopup inherits Rectangle {
 
                     init => { input.focus-input(); root.text-edited(root.input-text); }
 
-                // Password strength bar
-                if root.is-password && root.strength-score >= 0: VerticalLayout {
+                    // Password strength. The block keeps one size whatever the
+                    // rating, so the popup neither resizes nor moves while typing.
+                    if root.is-password: VerticalLayout {
                         spacing: Theme.spacing-xs;
 
                         ProgressBar {
-                            value: root.strength-score + 1;
+                            value: max(root.strength-score + 1, 0);
                             max: 5;
-                            fill-color: root.strength-color;
+                            fill-color: root.strength-score >= 0 ? root.strength-color : Theme.c.overlay0;
                         }
 
-                        VerticalLayout {
-                            spacing: Theme.spacing-md;
+                        Text {
+                            text: root.strength-score >= 0 ? root.strength-label : "Strength";
+                            color: root.strength-score >= 0 ? root.strength-color : Theme.c.overlay0;
+                            font-size: Theme.font-sm;
+                            font-weight: FontWeight.semi-bold;
+                            height: 18px;
+                            vertical-alignment: center;
+                        }
 
-                            Text {
-                                text: root.strength-label;
-                                color: root.strength-color;
-                                font-size: Theme.font-sm;
-                                font-weight: FontWeight.semi-bold;
-                            }
-
-                            if root.strength-hint != "": Text {
-                                text: root.strength-hint;
-                                color: Theme.c.subtext1;
-                                font-size: 13px;
-                                wrap: word-wrap;
-                            }
+                        // Room for two lines of advice; longer hints are elided.
+                        Text {
+                            text: root.strength-score >= 0 ? root.strength-hint : "The rating appears as you type.";
+                            color: Theme.c.subtext1;
+                            font-size: 13px;
+                            wrap: word-wrap;
+                            overflow: elide;
+                            height: 38px;
+                            vertical-alignment: top;
                         }
                     }
 

--- a/slint-ui/ui/popups/user-manage-popup.slint
+++ b/slint-ui/ui/popups/user-manage-popup.slint
@@ -16,6 +16,23 @@ export component UserManagePopup inherits Rectangle {
     callback user-sudo-toggled(int);
     callback password-edited(string);
     callback closed();
+    // The form is shown for the first account and on request; most systems
+    // have one user, so after adding one the cards are what is on screen.
+    in-out property <bool> adding;
+    // Mirrors of the form fields, so the action row outside the scrolling
+    // body can submit them; the form itself is destroyed after a submit.
+    property <string> form-username;
+    property <string> form-password;
+    property <bool> form-sudo: true;
+    property <bool> form-dirty: form-username != "" || form-password != "";
+    // Destroying the form clears its fields; the mirrors follow.
+    function reset-form() {
+        root.adding = false;
+        root.form-username = "";
+        root.form-password = "";
+        root.form-sudo = true;
+        root.password-edited("");
+    }
 
     if popup-visible: Rectangle {
         background: #00000080;
@@ -115,6 +132,16 @@ export component UserManagePopup inherits Rectangle {
                                     }
                                 }
                             }
+                            if root.users.length > 0 && !root.adding: StyledButton {
+                                label: "Add another user";
+                                height: 40px;
+                                outlined: true;
+                                changed has-focus => { form-scroll.reveal-if(self.has-focus, self.y, self.height); }
+                                clicked => { root.adding = true; EditingState.user-error = ""; }
+                            }
+                            if root.adding: VerticalLayout {
+                            spacing: 12px;
+                            init => { username-input.focus-input(); }
                             Rectangle {
                                 height: 1px;
                                 background: Theme.c.surface1;
@@ -137,7 +164,7 @@ export component UserManagePopup inherits Rectangle {
                                 height: 40px;
                                 placeholder: "e.g. alex";
                                 accessible-label: "Username";
-                                edited(_) => { EditingState.user-error = ""; }
+                                edited(val) => { EditingState.user-error = ""; root.form-username = val; }
                                 changed has-focus => { form-scroll.reveal-if(self.has-focus, self.y, self.height); }
                             }
 
@@ -153,7 +180,7 @@ export component UserManagePopup inherits Rectangle {
                                 accessible-label: "Account password";
                                 is-password: true;
                                 changed has-focus => { form-scroll.reveal-if(self.has-focus, self.y, self.height); }
-                                edited(val) => { root.password-edited(val); }
+                                edited(val) => { root.password-edited(val); root.form-password = val; }
                             }
 
                             // One fixed-size area for the rating or the no-password
@@ -193,6 +220,8 @@ export component UserManagePopup inherits Rectangle {
                                 height: 40px;
                                 checked: true;
                                 changed has-focus => { form-scroll.reveal-if(self.has-focus, self.y, self.height); }
+                                toggled => { root.form-sudo = self.checked; }
+                            }
                             }
                         }
                     }
@@ -205,21 +234,23 @@ export component UserManagePopup inherits Rectangle {
                     }
                     HorizontalLayout {
                         spacing: 12px;
-                        StyledButton {
+                        if root.adding: StyledButton {
                             label: "Add user";
                             height: 40px;
-                            style: username-input.text != "" ? Theme.button-primary : Theme.button-default;
-                            outlined: username-input.text == "";
-                            enabled: username-input.text != "";
+                            style: root.form-username != "" ? Theme.button-primary : Theme.button-default;
+                            outlined: root.form-username == "";
+                            enabled: root.form-username != "";
                             clicked => {
-                                if root.user-added(username-input.text, password-input.text, sudo-check.checked) {
-                                    username-input.text = "";
-                                    password-input.text = "";
-                                    sudo-check.checked = true;
-                                    root.password-edited("");
-                                    username-input.focus-input();
+                                if root.user-added(root.form-username, root.form-password, root.form-sudo) {
+                                    root.reset-form();
                                 }
                             }
+                        }
+                        if root.adding && root.users.length > 0: StyledButton {
+                            label: "Cancel";
+                            height: 40px;
+                            outlined: true;
+                            clicked => { EditingState.user-error = ""; root.reset-form(); }
                         }
 
                         Rectangle {
@@ -229,18 +260,18 @@ export component UserManagePopup inherits Rectangle {
                         StyledButton {
                             label: "Done";
                             height: 40px;
-                            style: username-input.text == "" ? Theme.button-primary : Theme.button-default;
-                            outlined: username-input.text != "";
+                            style: root.form-dirty ? Theme.button-default : Theme.button-primary;
+                            outlined: root.form-dirty;
                             clicked => {
-                                if username-input.text != "" || password-input.text != "" {
-                                    EditingState.user-error = "Click Add user to save this account, or clear the form to finish.";
+                                if root.adding && root.form-dirty {
+                                    EditingState.user-error = "Click Add user to save this account, or Cancel to discard it.";
                                 } else { root.closed(); }
                             }
                         }
                     }
                 }
 
-                init => { username-input.focus-input(); root.password-edited(""); EditingState.user-error = ""; }
+                init => { root.reset-form(); root.adding = root.users.length == 0; EditingState.user-error = ""; }
             }
         }
     }

--- a/slint-ui/ui/popups/user-manage-popup.slint
+++ b/slint-ui/ui/popups/user-manage-popup.slint
@@ -156,32 +156,36 @@ export component UserManagePopup inherits Rectangle {
                                 edited(val) => { root.password-edited(val); }
                             }
 
-                            if password-input.text == "": Text {
-                                text: "Without a password, password login is unavailable. Configure another sign-in method before using this account.";
-                                color: Theme.c.subtext1;
-                                font-size: 13px;
-                                wrap: word-wrap;
-                            }
-                            if password-input.text != "" && PopupState.password-strength-score >= 0: VerticalLayout {
+                            // One fixed-size area for the rating or the no-password
+                            // note, so the form does not resize on every keystroke.
+                            rating := VerticalLayout {
                                 spacing: 6px;
+                                property <bool> rated: password-input.text != "" && PopupState.password-strength-score >= 0;
                                 ProgressBar {
-                                    value: PopupState.password-strength-score + 1;
+                                    value: rating.rated ? PopupState.password-strength-score + 1 : 0;
                                     max: 5;
-                                    fill-color: PopupState.password-strength-color;
+                                    fill-color: rating.rated ? PopupState.password-strength-color : Theme.c.overlay0;
                                 }
 
                                 Text {
-                                    text: PopupState.password-strength-label;
-                                    color: PopupState.password-strength-color;
+                                    text: rating.rated ? PopupState.password-strength-label : (password-input.text == "" ? "No password" : "Strength");
+                                    color: rating.rated ? PopupState.password-strength-color : Theme.c.overlay0;
                                     font-size: 13px;
                                     font-weight: 600;
+                                    height: 18px;
+                                    vertical-alignment: center;
                                 }
 
-                                if PopupState.password-strength-hint != "": Text {
-                                    text: PopupState.password-strength-hint;
+                                Text {
+                                    text: password-input.text == ""
+                                        ? "Without a password, password login is unavailable. Configure another sign-in method before using this account."
+                                        : (rating.rated ? PopupState.password-strength-hint : "The rating appears as you type.");
                                     color: Theme.c.subtext1;
                                     font-size: 13px;
                                     wrap: word-wrap;
+                                    overflow: elide;
+                                    height: 38px;
+                                    vertical-alignment: top;
                                 }
                             }
                             sudo-check := CheckBox {

--- a/slint-ui/ui/state/alongside-state.slint
+++ b/slint-ui/ui/state/alongside-state.slint
@@ -10,11 +10,12 @@ export global AlongsideState {
     in-out property <int> generation;
     in-out property <bool> insufficient;
     in-out property <bool> additional-efi;
+    // Free space is taken whole (MiB-aligned, so a fractional GiB is kept);
+    // a shrink starts from the proposal. Set by Rust from the source kind.
     in-out property <bool> use-all: true;
     // Set when the user typed or dragged an allocation; cleared when the
     // source changes so the proposal applies again.
     in-out property <bool> custom-allocation;
-    in-out property <string> use-all-label: "Use the whole free extent";
     in-out property <int> swap-mode;
     in-out property <float> swap-size: 8;
     in-out property <float> allocation: 32;

--- a/slint-ui/ui/state/alongside-state.slint
+++ b/slint-ui/ui/state/alongside-state.slint
@@ -11,6 +11,10 @@ export global AlongsideState {
     in-out property <bool> insufficient;
     in-out property <bool> additional-efi;
     in-out property <bool> use-all: true;
+    // Set when the user typed or dragged an allocation; cleared when the
+    // source changes so the proposal applies again.
+    in-out property <bool> custom-allocation;
+    in-out property <string> use-all-label: "Use the whole free extent";
     in-out property <int> swap-mode;
     in-out property <float> swap-size: 8;
     in-out property <float> allocation: 32;

--- a/slint-ui/ui/views/install-view.slint
+++ b/slint-ui/ui/views/install-view.slint
@@ -23,6 +23,12 @@ export component InstallView inherits VerticalLayout {
     spacing: 16px;
 
     private property <bool> running: InstallState.state == 1 || InstallState.state == 4;
+    // The activity icon turns while the installer runs. The view is created
+    // already running, so the first step is taken in init; the animation
+    // repeats until `running` clears, then the property snaps to rest.
+    private property <angle> spin: 0deg;
+    animate spin { duration: 1500ms; easing: linear; iteration-count: -1; enabled: root.running; }
+    init => { root.spin = 360deg; }
     private property <bool> follow-output: true;
     private property <color> status-color: InstallState.state == 2 ? Theme.c.green
         : InstallState.state == 3 ? Theme.c.red
@@ -125,6 +131,7 @@ export component InstallView inherits VerticalLayout {
                     Icon {
                         size: 24px;
                         tint: root.status-color;
+                        transform-rotation: root.running ? root.spin : 0deg;
                         source: InstallState.state == 2 ? @image-url("../../assets/icons/check.svg")
                             : root.running ? @image-url("../../assets/icons/refresh-cw.svg")
                             : @image-url("../../assets/icons/x.svg");


### PR DESCRIPTION
The alongside default treated "use all available space" the same for an unallocated extent and for another system's partition, so selecting Windows proposed shrinking it to its minimum. Free space is still taken whole; a shrink now proposes half of the filesystem's free space and keeps that system a working margin. The lockfile also picks up the Slint fix for libinput scroll events that carry one axis, which stopped the "value requested for unset axis" flood on the console, and the password popups no longer resize on every keystroke.

- `ShrinkLimits` (used and minimum bytes) and `ShrinkDefaults` in core: hard maximum from the resizer, soft maximum leaving 20 % of the partition or 20 GiB free, proposal of half the free space; unit tests for typical disks
- Resize limit is the resizer's minimum plus 10 % (at least 1 GiB) instead of plus 20 % and 1 GiB
- The "use all available space" checkbox is gone: the slider reaches the resizer's limit, and free space is taken whole by default
- Details line shows the new size, what stays free, and a warning under 15 % free
- Preselection prefers free space, then the partition with the roomiest proposal
- Password popups keep one size: the rating area is always laid out and the previous rating stays until the new score arrives
- The activity icon on the install screen rotates while the installer runs
- The user accounts dialog shows account cards and opens the new-account form only for the first account or on "Add another user"
- Cargo.lock points at the Slint commit that checks `has_axis` before reading scroll values

Testing

- `alongside_review.py` on all four display configurations: proposal 140 GiB for the 450 GiB fixture with 170 GiB used, slider maximum 263 GiB
- `interactions.py` root password and user account flows; `review.py` users scene on all sizes
- `sudo target/debug/examples/alongside_fixture` in ext4, ntfs and swap modes: PASS with the new margin
- Scroll fix checked on the live medium via the replaced `/usr/local/bin/azfs`


