### PR TITLE
Fail over between mirrors quickly and rank them on a sustained transfer

### DIFF
--- a/core/examples/rank_mirrors.rs
+++ b/core/examples/rank_mirrors.rs
@@ -1,0 +1,30 @@
+//! Rank Arch mirrors the way the installer does and print the result.
+//!
+//! Usage: `cargo run -p archinstall-zfs-core --example rank_mirrors [COUNTRY...]`
+//! Writes the mirrorlist to a temporary file and prints it; nothing on the
+//! host is changed.
+use archinstall_zfs_core::system::mirrors::{RankOptions, refresh};
+use std::time::Instant;
+
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info,archinstall_zfs_core=debug")
+        .init();
+    let countries: Vec<String> = std::env::args().skip(1).collect();
+    let opts = RankOptions {
+        countries,
+        ..RankOptions::default()
+    };
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("mirrorlist");
+    let started = Instant::now();
+    let ranked = refresh(&path, &opts).await?;
+    println!(
+        "ranked {} mirrors in {:.1}s",
+        ranked.len(),
+        started.elapsed().as_secs_f64()
+    );
+    print!("{}", std::fs::read_to_string(&path)?);
+    Ok(())
+}

--- a/core/src/install.rs
+++ b/core/src/install.rs
@@ -247,6 +247,9 @@ async fn install(
         let cancel = cancel.clone();
         let download_config = download_config.clone();
         tokio::task::spawn_blocking(move || {
+            if let Err(error) = crate::system::mirrors::refresh_live_once() {
+                tracing::warn!(%error, "keeping the medium's mirrorlist");
+            }
             crate::zfs_setup::initialize_zfs(
                 &*runner,
                 distro,

--- a/core/src/installer/mirrors.rs
+++ b/core/src/installer/mirrors.rs
@@ -1,161 +1,35 @@
 use std::path::Path;
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Context, Result};
 
-use crate::system::cmd::{CommandRunner, check_exit};
+use crate::system::mirrors::{RankOptions, refresh_blocking};
 
-/// Configure pacman mirrors on the target using reflector with country filters.
-/// Runs reflector directly (not chrooted) and writes to target's mirrorlist.
-pub fn configure_mirrors(
-    runner: &dyn CommandRunner,
-    target: &Path,
-    countries: &[String],
-) -> Result<()> {
+/// Write a measured mirrorlist for the target, restricted to `countries`
+/// (names or codes). Without countries the target keeps the copy of the
+/// live medium's list, which was ranked the same way without a filter.
+pub fn configure_mirrors(target: &Path, countries: &[String]) -> Result<()> {
     if countries.is_empty() {
         return Ok(());
     }
-
-    tracing::info!(?countries, "configuring mirrors with reflector");
-
-    let mirrorlist = format!("{}/etc/pacman.d/mirrorlist", target.display());
-
-    let mut args: Vec<&str> = vec![
-        "--latest",
-        "20",
-        "--protocol",
-        "https",
-        "--sort",
-        "rate",
-        "--save",
-        &mirrorlist,
-    ];
-
-    // Add --country for each region
-    for country in countries {
-        args.push("--country");
-        args.push(country);
-    }
-
-    let output = runner.run("reflector", &args)?;
-    check_exit(&output, "reflector (mirror config)")?;
-
+    tracing::info!(?countries, "ranking mirrors for the target");
+    let opts = RankOptions {
+        countries: countries.to_vec(),
+        ..RankOptions::default()
+    };
+    refresh_blocking(&target.join("etc/pacman.d/mirrorlist"), opts)
+        .wrap_err("mirror ranking for the target failed")?;
     tracing::info!("mirrors configured for target");
     Ok(())
-}
-
-/// List available reflector countries by running `reflector --list-countries`.
-/// Returns a sorted list of country names.
-pub fn list_mirror_countries(runner: &dyn CommandRunner) -> Vec<String> {
-    let output = match runner.run("reflector", &["--list-countries"]) {
-        Ok(o) if o.success() => o,
-        _ => return Vec::new(),
-    };
-
-    // reflector --list-countries outputs lines like:
-    //   Australia       AU     25
-    //   Austria         AT     12
-    // We want the country name (first column before the 2-letter code).
-    output
-        .stdout
-        .lines()
-        .filter_map(|line| {
-            let line = line.trim();
-            // Skip header lines and empty lines
-            if line.is_empty() || line.starts_with('-') || line.starts_with("Country") {
-                return None;
-            }
-            // Extract the country name: everything before the two-letter code
-            // and the count. The columns are padded to align, so split on runs
-            // of whitespace — splitting on individual characters leaves the
-            // padding behind and returns "Australia              AU".
-            let fields: Vec<&str> = line.split_whitespace().collect();
-            if fields.len() < 3 {
-                return None;
-            }
-            let name = fields[..fields.len() - 2].join(" ");
-            (!name.is_empty()).then_some(name)
-        })
-        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::system::cmd::tests::{CannedResponse, RecordingRunner};
 
     #[test]
-    fn no_countries_means_no_reflector_run() {
-        let runner = RecordingRunner::new(vec![]);
-        configure_mirrors(&runner, Path::new("/mnt"), &[]).unwrap();
-        assert!(runner.calls().is_empty());
-    }
-
-    #[test]
-    fn each_country_becomes_its_own_flag() {
-        let runner = RecordingRunner::new(vec![CannedResponse::default()]);
-        configure_mirrors(
-            &runner,
-            Path::new("/mnt"),
-            &["Germany".to_string(), "France".to_string()],
-        )
-        .unwrap();
-
-        let calls = runner.calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].program, "reflector");
-        assert_eq!(
-            calls[0].args.iter().filter(|a| *a == "--country").count(),
-            2
-        );
-        assert!(calls[0].args.contains(&"Germany".to_string()));
-        assert!(calls[0].args.contains(&"France".to_string()));
-        // The mirrorlist must be written inside the target, not on the host.
-        assert!(
-            calls[0]
-                .args
-                .contains(&"/mnt/etc/pacman.d/mirrorlist".to_string())
-        );
-    }
-
-    #[test]
-    fn a_failing_reflector_stops_the_install() {
-        let runner = RecordingRunner::new(vec![CannedResponse {
-            exit_code: 1,
-            stderr: "no mirrors matched".into(),
-            ..Default::default()
-        }]);
-        let err = configure_mirrors(&runner, Path::new("/mnt"), &["Nowhere".to_string()])
-            .expect_err("a mirrorlist that was not written must not pass silently");
-        assert!(err.to_string().contains("reflector"));
-    }
-
-    #[test]
-    fn country_names_are_taken_from_the_listing() {
-        let runner = RecordingRunner::new(vec![CannedResponse {
-            stdout: "Country                Code    Count\n\
-                     -------                ----    -----\n\
-                     Australia              AU         25\n\
-                     Bosnia and Herzegovina BA          1\n\
-                     United States          US        180\n"
-                .into(),
-            ..Default::default()
-        }]);
-
-        let countries = list_mirror_countries(&runner);
-
-        // Multi-word names must survive: the code splits from the right.
-        assert_eq!(
-            countries,
-            vec!["Australia", "Bosnia and Herzegovina", "United States"]
-        );
-    }
-
-    #[test]
-    fn a_failing_listing_yields_no_countries() {
-        let runner = RecordingRunner::new(vec![CannedResponse {
-            exit_code: 127,
-            ..Default::default()
-        }]);
-        assert!(list_mirror_countries(&runner).is_empty());
+    fn no_countries_means_the_target_keeps_the_copied_list() {
+        let target = tempfile::tempdir().unwrap();
+        configure_mirrors(target.path(), &[]).unwrap();
+        assert!(!target.path().join("etc/pacman.d/mirrorlist").exists());
     }
 }

--- a/core/src/installer/mod.rs
+++ b/core/src/installer/mod.rs
@@ -243,7 +243,7 @@ impl Installer {
 
         // Mirror config
         if let Some(ref regions) = self.config.mirror_regions {
-            mirrors::configure_mirrors(&*self.runner, &self.target, regions)?;
+            mirrors::configure_mirrors(&self.target, regions)?;
         }
 
         // Network

--- a/core/src/system/async_download.rs
+++ b/core/src/system/async_download.rs
@@ -30,8 +30,14 @@ pub struct DownloadConfig {
     pub backoff_base: Duration,
     /// Connection timeout (default: 10s).
     pub connect_timeout: Duration,
-    /// Idle timeout — abort if no data received for this long (default: 30s).
+    /// Idle timeout — give up on a mirror when no data arrives for this
+    /// long (default: 10 s, pacman's low-speed rule).
     pub idle_timeout: Duration,
+    /// A transfer slower than this, averaged over `slow_window`, is
+    /// abandoned for the next mirror (default: 4 KiB/s over 15 s). The
+    /// partial file is kept, so a slow mirror never loses progress.
+    pub min_speed_bps: u64,
+    pub slow_window: Duration,
     /// Where downloaded packages are kept.
     ///
     /// `None` puts them in the target's own package cache, which is where a
@@ -68,7 +74,9 @@ impl Default for DownloadConfig {
             retries_per_mirror: 3,
             backoff_base: Duration::from_secs(1),
             connect_timeout: Duration::from_secs(10),
-            idle_timeout: Duration::from_secs(30),
+            idle_timeout: Duration::from_secs(10),
+            min_speed_bps: 4 * 1024,
+            slow_window: Duration::from_secs(15),
             cache_dir: cache_dir_from_environment(),
         }
     }
@@ -85,6 +93,10 @@ pub enum PackageState {
         speed_bps: u64,
         mirror: String,
         attempt: u32,
+        /// When the last chunk arrived (or the attempt began). A row that
+        /// has not moved for [`STALE_AFTER`] is waiting on its mirror, and
+        /// its last speed no longer describes anything.
+        updated: Instant,
     },
     Verifying {
         filename: String,
@@ -100,7 +112,21 @@ pub enum PackageState {
     },
 }
 
+/// A download without progress for this long counts as stalled in the
+/// aggregates and the interface.
+pub const STALE_AFTER: Duration = Duration::from_secs(3);
+
 impl PackageState {
+    /// Current transfer rate, zero once the transfer has stalled.
+    pub fn live_speed_bps(&self) -> u64 {
+        match self {
+            Self::Downloading {
+                speed_bps, updated, ..
+            } if updated.elapsed() < STALE_AFTER => *speed_bps,
+            _ => 0,
+        }
+    }
+
     /// Bytes of this package that are on disk.
     ///
     /// Taken from the package's own state rather than accumulated as chunks
@@ -128,6 +154,9 @@ pub enum PackageProgress {
         active_downloads: usize,
         completed: usize,
         failed: usize,
+        /// What the downloader is doing about a mirror that stopped
+        /// delivering, for the status line; empty while transfers flow.
+        note: String,
     },
     /// Installing/upgrading packages locally.
     Installing {
@@ -149,6 +178,7 @@ impl Default for PackageProgress {
             active_downloads: 0,
             completed: 0,
             failed: 0,
+            note: String::new(),
         }
     }
 }
@@ -157,13 +187,9 @@ impl PackageProgress {
     /// Overall download speed in bytes/sec (only meaningful in Downloading phase).
     pub fn total_speed_bps(&self) -> u64 {
         match self {
-            Self::Downloading { packages, .. } => packages
-                .iter()
-                .filter_map(|p| match p {
-                    PackageState::Downloading { speed_bps, .. } => Some(*speed_bps),
-                    _ => None,
-                })
-                .sum(),
+            Self::Downloading { packages, .. } => {
+                packages.iter().map(PackageState::live_speed_bps).sum()
+            }
             _ => 0,
         }
     }
@@ -221,6 +247,7 @@ pub fn start_downloads(
         active_downloads: 0,
         completed: 0,
         failed: 0,
+        note: String::new(),
     };
 
     let (tx, rx) = if let Some(ref tx) = progress_tx {
@@ -275,9 +302,72 @@ pub async fn download_packages(
 /// Shared state for coordinating progress updates.
 struct SharedProgress {
     tx: Arc<watch::Sender<DownloadProgress>>,
+    /// Mirrors that stalled or refused, shared by every download so one
+    /// bad mirror is tried once, not once per file. Counts failures.
+    mirrors: std::sync::Mutex<std::collections::HashMap<String, u32>>,
+}
+
+/// `servers` in their configured order, with mirrors that have failed
+/// moved behind those that have not; more failures sort later.
+fn order_by_health(
+    servers: &[String],
+    failures: &std::collections::HashMap<String, u32>,
+) -> Vec<String> {
+    let mut ordered: Vec<(u32, usize, &String)> = servers
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (failures.get(s).copied().unwrap_or(0), i, s))
+        .collect();
+    ordered.sort();
+    ordered.into_iter().map(|(_, _, s)| s.clone()).collect()
+}
+
+fn mirror_host(server: &str) -> &str {
+    server
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .split('/')
+        .next()
+        .unwrap_or(server)
 }
 
 impl SharedProgress {
+    fn new(tx: Arc<watch::Sender<DownloadProgress>>) -> Self {
+        Self {
+            tx,
+            mirrors: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    fn ordered_servers(&self, servers: &[String]) -> Vec<String> {
+        let failures = self.mirrors.lock().expect("mirror health lock");
+        order_by_health(servers, &failures)
+    }
+
+    /// Record a failed transfer from `server` and tell the status line.
+    fn penalize(&self, server: &str, reason: &str, more_mirrors: bool) {
+        *self
+            .mirrors
+            .lock()
+            .expect("mirror health lock")
+            .entry(server.to_string())
+            .or_default() += 1;
+        let note = if more_mirrors {
+            format!("{}: {reason}; trying the next mirror", mirror_host(server))
+        } else {
+            format!("{}: {reason}; retrying", mirror_host(server))
+        };
+        self.set_note(note);
+    }
+
+    fn set_note(&self, note: String) {
+        self.tx.send_modify(|progress| {
+            if let PackageProgress::Downloading { note: current, .. } = progress {
+                *current = note;
+            }
+        });
+    }
+
     /// Record `state` for package `index` and recompute the aggregates.
     ///
     /// The counters are derived from the package vector instead of being
@@ -335,7 +425,19 @@ async fn run_downloads(
         "downloading {total_count} packages"
     );
 
-    let shared = Arc::new(SharedProgress { tx });
+    let shared = Arc::new(SharedProgress::new(tx));
+    // Nothing updates a stalled package, so wake the interface periodically
+    // to re-evaluate which rows are still moving.
+    let ticker = {
+        let tx = shared.tx.clone();
+        tokio::spawn(async move {
+            let mut every = tokio::time::interval(Duration::from_secs(1));
+            loop {
+                every.tick().await;
+                tx.send_modify(|_| {});
+            }
+        })
+    };
 
     // No overall request timeout on purpose: a kernel or firmware package is
     // hundreds of megabytes and may legitimately take many minutes on a slow
@@ -365,6 +467,8 @@ async fn run_downloads(
         .buffer_unordered(config.concurrency)
         .collect()
         .await;
+
+    ticker.abort();
 
     let mut errors = Vec::new();
     for result in results {
@@ -419,11 +523,12 @@ async fn download_single(
 
     let download_started = std::time::Instant::now();
 
-    // Try each mirror
+    // Each round walks the mirrors, healthiest first, and moves on at the
+    // first stall; only a round that fails everywhere waits before the next.
     let mut last_error = None;
-    for server in &task.servers {
-        // Retry on same mirror with exponential backoff
-        for attempt in 1..=config.retries_per_mirror {
+    for attempt in 1..=config.retries_per_mirror {
+        let servers = shared.ordered_servers(&task.servers);
+        for (position, server) in servers.iter().enumerate() {
             let url = format!("{}/{}", server, task.filename);
 
             shared.update_package(
@@ -435,6 +540,7 @@ async fn download_single(
                     speed_bps: 0,
                     mirror: server.clone(),
                     attempt,
+                    updated: Instant::now(),
                 },
             );
 
@@ -474,6 +580,7 @@ async fn download_single(
                         speed_bps = speed_bps,
                     );
                     tracing::info!(file = %task.filename, "download complete");
+                    shared.set_note(String::new());
                     return Ok(());
                 }
                 Err(e) => {
@@ -488,21 +595,21 @@ async fn download_single(
                         bail!("download cancelled");
                     }
 
-                    tracing::debug!(
+                    tracing::warn!(
                         file = %task.filename,
                         server,
                         attempt,
-                        "attempt failed: {e}"
+                        "mirror failed: {e}"
                     );
+                    shared.penalize(server, &e.to_string(), position + 1 < servers.len());
                     last_error = Some(e);
-
-                    // Exponential backoff before retry (on same mirror)
-                    if attempt < config.retries_per_mirror {
-                        let delay = config.backoff_base * 2u32.pow(attempt - 1);
-                        tokio::time::sleep(delay).await;
-                    }
                 }
             }
+        }
+        // Every mirror failed this round: wait before walking them again.
+        if attempt < config.retries_per_mirror {
+            let delay = config.backoff_base * 2u32.pow(attempt - 1);
+            tokio::time::sleep(delay).await;
         }
     }
 
@@ -553,10 +660,18 @@ async fn download_file_with_progress(
         tracing::debug!(file = filename, existing_size, "attempting resume");
     }
 
-    let resp = request
-        .send()
-        .await
-        .wrap_err_with(|| format!("HTTP request failed: {url}"))?;
+    // connect_timeout covers the TCP handshake only. A mirror that accepts
+    // the connection and never answers would park this await for good, and
+    // cancellation could not reach it: bound the wait for the response
+    // headers and watch the token here as well.
+    let resp = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => bail!("download cancelled"),
+        sent = tokio::time::timeout(config.idle_timeout, request.send()) => match sent {
+            Ok(sent) => sent.wrap_err_with(|| format!("HTTP request failed: {url}"))?,
+            Err(_) => bail!("no response from {mirror} within {:?}", config.idle_timeout),
+        },
+    };
 
     let status = resp.status();
     if !status.is_success() && status != reqwest::StatusCode::PARTIAL_CONTENT {
@@ -597,6 +712,7 @@ async fn download_file_with_progress(
 
     // Speed tracking: sliding window
     let mut speed_tracker = SpeedTracker::new();
+    let transfer_started = Instant::now();
 
     loop {
         tokio::select! {
@@ -634,6 +750,19 @@ async fn download_file_with_progress(
 
                         bytes_downloaded += len;
                         speed_tracker.record(len);
+                        // A trickle keeps the idle timeout from firing but is
+                        // no better than a stall: leave it for another mirror
+                        // and resume from here.
+                        if transfer_started.elapsed() >= config.slow_window
+                            && speed_tracker.speed_bps() < config.min_speed_bps
+                        {
+                            drop(file);
+                            bail!(
+                                "too slow ({} KiB/s over {:?}, {bytes_downloaded} of {total_size} bytes)",
+                                speed_tracker.speed_bps() / 1024,
+                                config.slow_window
+                            );
+                        }
 
                         // Update progress state
                         shared.update_package(index, PackageState::Downloading {
@@ -643,6 +772,7 @@ async fn download_file_with_progress(
                             speed_bps: speed_tracker.speed_bps(),
                             mirror: mirror.to_string(),
                             attempt,
+                            updated: Instant::now(),
                         });
                     }
                     Some(Err(e)) => {
@@ -882,12 +1012,14 @@ mod tests {
                 speed_bps: 10,
                 mirror: "mirror".into(),
                 attempt: 1,
+                updated: Instant::now(),
             }],
             total_bytes: 100,
             downloaded_bytes: 50,
             active_downloads: 1,
             completed: 0,
             failed: 0,
+            note: String::new(),
         };
 
         assert_eq!(progress.total_speed_bps(), 10);
@@ -903,6 +1035,7 @@ mod tests {
             active_downloads: 0,
             completed: 0,
             failed: 0,
+            note: String::new(),
         };
 
         assert!(progress.eta().is_none());
@@ -920,8 +1053,9 @@ mod tests {
             active_downloads: 0,
             completed: 0,
             failed: 0,
+            note: String::new(),
         });
-        (SharedProgress { tx: Arc::new(tx) }, rx)
+        (SharedProgress::new(Arc::new(tx)), rx)
     }
 
     fn counters(progress: &PackageProgress) -> (usize, usize, usize, u64) {
@@ -967,6 +1101,7 @@ mod tests {
             speed_bps: 0,
             mirror: "https://mirror.example".into(),
             attempt: 1,
+            updated: Instant::now(),
         };
 
         shared.update_package(0, downloading(100));
@@ -1006,6 +1141,7 @@ mod tests {
             speed_bps: 0,
             mirror: "https://mirror.example".into(),
             attempt,
+            updated: Instant::now(),
         };
 
         // First mirror stalls after 80 bytes, second starts over.
@@ -1029,11 +1165,32 @@ mod tests {
     }
 
     #[test]
+    fn failed_mirrors_sort_behind_healthy_ones_in_configured_order() {
+        let servers: Vec<String> = ["https://a/x", "https://b/x", "https://c/x"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mut failures = std::collections::HashMap::new();
+        assert_eq!(order_by_health(&servers, &failures), servers);
+        failures.insert("https://a/x".to_string(), 2);
+        failures.insert("https://b/x".to_string(), 1);
+        assert_eq!(
+            order_by_health(&servers, &failures),
+            ["https://c/x", "https://b/x", "https://a/x"]
+        );
+        assert_eq!(
+            mirror_host("https://frankfurt.mirror.pkgbuild.com/core/os/x86_64"),
+            "frankfurt.mirror.pkgbuild.com"
+        );
+    }
+
+    #[test]
     fn test_download_config_default() {
         let config = DownloadConfig::default();
         assert_eq!(config.concurrency, 5);
         assert_eq!(config.retries_per_mirror, 3);
         assert_eq!(config.connect_timeout, Duration::from_secs(10));
-        assert_eq!(config.idle_timeout, Duration::from_secs(30));
+        assert_eq!(config.idle_timeout, Duration::from_secs(10));
+        assert_eq!(config.min_speed_bps, 4 * 1024);
     }
 }

--- a/core/src/system/mirrors.rs
+++ b/core/src/system/mirrors.rs
@@ -1,0 +1,415 @@
+//! Mirror selection measured the way packages are fetched.
+//!
+//! reflector rates a mirror by one small download, which cannot tell a path
+//! that is throttled after its first few hundred kilobytes from a fast one;
+//! the installer then spent minutes on mirrors that had rated best. Here the
+//! candidates from the official status list are first sorted by how quickly
+//! they answer, and the closest are then timed on a sustained transfer of the
+//! same kind the package downloader performs. The result is written as a
+//! pacman mirrorlist and is the order the downloader starts from.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use color_eyre::eyre::{Context, Result, bail};
+use futures::stream::{self, StreamExt};
+use serde::Deserialize;
+
+pub const STATUS_URL: &str = "https://archlinux.org/mirrors/status/json/";
+/// A small object every mirror serves; only its headers are awaited.
+const PROBE_PATH: &str = "core/os/x86_64/core.db";
+/// A large object every mirror serves; its first megabytes are sampled.
+const SAMPLE_PATH: &str = "extra/os/x86_64/extra.db";
+/// A sample shorter than this measured nothing worth ranking.
+const MIN_SAMPLE_BYTES: u64 = 64 * 1024;
+
+/// One entry of the mirror status list.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct MirrorStatus {
+    pub url: String,
+    pub protocol: String,
+    #[serde(default)]
+    pub country: String,
+    #[serde(default)]
+    pub country_code: String,
+    #[serde(default)]
+    pub active: bool,
+    /// Share of recent checks the mirror passed, 0..=1.
+    #[serde(default)]
+    pub completion_pct: f64,
+    /// Seconds behind the upstream master; missing when never synced. The
+    /// status list reports small negative values for mirrors that are ahead
+    /// of the check, so this is signed.
+    #[serde(default)]
+    pub delay: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct StatusFile {
+    urls: Vec<MirrorStatus>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RankOptions {
+    /// Country names or codes to restrict to; empty means anywhere.
+    pub countries: Vec<String>,
+    /// Mirrors further behind upstream than this are not candidates.
+    pub max_delay: Duration,
+    /// Minimum share of passed checks, 0..=1.
+    pub min_completion: f64,
+    /// How long a mirror may take to answer the probe.
+    pub probe_timeout: Duration,
+    /// How many of the quickest-answering mirrors get a throughput sample.
+    pub sample_count: usize,
+    /// How much of the sample object to request.
+    pub sample_bytes: u64,
+    /// How long one sample may run; shorter when the bytes arrive first.
+    pub sample_time: Duration,
+    /// Parallel probes and parallel samples.
+    pub probe_concurrency: usize,
+    pub sample_concurrency: usize,
+    /// How many mirrors the written list keeps.
+    pub keep: usize,
+}
+
+impl Default for RankOptions {
+    fn default() -> Self {
+        Self {
+            countries: Vec::new(),
+            max_delay: Duration::from_secs(12 * 3600),
+            min_completion: 0.95,
+            probe_timeout: Duration::from_secs(3),
+            sample_count: 24,
+            sample_bytes: 8 * 1024 * 1024,
+            sample_time: Duration::from_secs(5),
+            probe_concurrency: 32,
+            sample_concurrency: 6,
+            keep: 10,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankedMirror {
+    pub url: String,
+    pub country: String,
+    pub latency: Duration,
+    pub bytes_per_sec: u64,
+}
+
+/// Mirrors from `status` that are worth measuring, in status-list order.
+pub fn candidates(status: &[MirrorStatus], opts: &RankOptions) -> Vec<MirrorStatus> {
+    let wanted: Vec<String> = opts
+        .countries
+        .iter()
+        .map(|c| c.trim().to_ascii_lowercase())
+        .filter(|c| !c.is_empty())
+        .collect();
+    status
+        .iter()
+        .filter(|m| m.active && m.protocol == "https" && m.url.ends_with('/'))
+        .filter(|m| m.completion_pct >= opts.min_completion)
+        .filter(|m| {
+            m.delay
+                .is_some_and(|d| Duration::from_secs(d.max(0) as u64) <= opts.max_delay)
+        })
+        .filter(|m| {
+            wanted.is_empty()
+                || wanted.contains(&m.country.to_ascii_lowercase())
+                || wanted.contains(&m.country_code.to_ascii_lowercase())
+        })
+        .cloned()
+        .collect()
+}
+
+pub async fn fetch_status(client: &reqwest::Client) -> Result<Vec<MirrorStatus>> {
+    let file: StatusFile = client
+        .get(STATUS_URL)
+        .timeout(Duration::from_secs(15))
+        .send()
+        .await
+        .wrap_err("cannot reach the Arch Linux mirror status")?
+        .error_for_status()
+        .wrap_err("mirror status request failed")?
+        .json()
+        .await
+        .wrap_err("cannot read the mirror status")?;
+    Ok(file.urls)
+}
+
+/// Time to the response headers of a small object.
+async fn probe(
+    client: &reqwest::Client,
+    mirror: &MirrorStatus,
+    opts: &RankOptions,
+) -> Option<Duration> {
+    let started = Instant::now();
+    let response = client
+        .get(format!("{}{PROBE_PATH}", mirror.url))
+        .header(reqwest::header::RANGE, "bytes=0-0")
+        .timeout(opts.probe_timeout)
+        .send()
+        .await
+        .ok()?;
+    response.status().is_success().then(|| started.elapsed())
+}
+
+/// Bytes per second over a bounded slice of a large object.
+async fn sample(
+    client: &reqwest::Client,
+    mirror: &MirrorStatus,
+    opts: &RankOptions,
+) -> Option<u64> {
+    let started = Instant::now();
+    let response = client
+        .get(format!("{}{SAMPLE_PATH}", mirror.url))
+        .header(
+            reqwest::header::RANGE,
+            format!("bytes=0-{}", opts.sample_bytes - 1),
+        )
+        .timeout(opts.probe_timeout)
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let mut received = 0u64;
+    let mut body = response.bytes_stream();
+    loop {
+        let remaining = opts.sample_time.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, body.next()).await {
+            Ok(Some(Ok(chunk))) => received += chunk.len() as u64,
+            Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
+        }
+    }
+    if received < MIN_SAMPLE_BYTES {
+        return None;
+    }
+    let seconds = started.elapsed().as_secs_f64().max(0.25);
+    Some((received as f64 / seconds) as u64)
+}
+
+/// Probe every candidate, sample the quickest to answer, and return the
+/// mirrors that delivered, fastest first.
+pub async fn rank(
+    client: &reqwest::Client,
+    candidates: Vec<MirrorStatus>,
+    opts: &RankOptions,
+) -> Vec<RankedMirror> {
+    tracing::info!(count = candidates.len(), "probing mirrors");
+    let mut probed: Vec<(Duration, MirrorStatus)> = stream::iter(candidates)
+        .map(|m| async move { probe(client, &m, opts).await.map(|latency| (latency, m)) })
+        .buffer_unordered(opts.probe_concurrency.max(1))
+        .filter_map(|r| async move { r })
+        .collect()
+        .await;
+    probed.sort_by_key(|(latency, _)| *latency);
+    probed.truncate(opts.sample_count);
+    tracing::info!(count = probed.len(), "measuring mirror throughput");
+    let mut ranked: Vec<RankedMirror> = stream::iter(probed)
+        .map(|(latency, m)| async move {
+            let bytes_per_sec = sample(client, &m, opts).await?;
+            tracing::debug!(url = %m.url, bytes_per_sec, latency_ms = latency.as_millis() as u64, "mirror measured");
+            Some(RankedMirror {
+                url: m.url,
+                country: m.country,
+                latency,
+                bytes_per_sec,
+            })
+        })
+        .buffer_unordered(opts.sample_concurrency.max(1))
+        .filter_map(|r| async move { r })
+        .collect()
+        .await;
+    ranked.sort_by(|a, b| {
+        b.bytes_per_sec
+            .cmp(&a.bytes_per_sec)
+            .then(a.latency.cmp(&b.latency))
+    });
+    ranked
+}
+
+/// A pacman mirrorlist of the first `keep` mirrors.
+pub fn mirrorlist(ranked: &[RankedMirror], keep: usize) -> String {
+    let mut out = String::from(
+        "# Written by archinstall_zfs: mirrors measured on a sustained transfer,\n# fastest first.\n",
+    );
+    for m in ranked.iter().take(keep) {
+        out.push_str(&format!(
+            "# {} — {} KiB/s, {} ms\nServer = {}$repo/os/$arch\n",
+            if m.country.is_empty() {
+                "?"
+            } else {
+                &m.country
+            },
+            m.bytes_per_sec / 1024,
+            m.latency.as_millis(),
+            m.url
+        ));
+    }
+    out
+}
+
+/// Fetch the status, rank, and replace the mirrorlist at `path` atomically.
+/// The existing file is left alone when nothing could be measured.
+pub async fn refresh(path: &Path, opts: &RankOptions) -> Result<Vec<RankedMirror>> {
+    let client = reqwest::Client::builder()
+        .user_agent("archinstall-zfs-rs")
+        .connect_timeout(opts.probe_timeout)
+        .build()
+        .wrap_err("failed to create HTTP client")?;
+    let status = fetch_status(&client).await?;
+    let candidates = candidates(&status, opts);
+    if candidates.is_empty() {
+        bail!("no mirror in the status list matches {:?}", opts.countries);
+    }
+    let ranked = rank(&client, candidates, opts).await;
+    if ranked.is_empty() {
+        bail!("no mirror delivered data; the current mirrorlist is kept");
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let temporary = path.with_extension("azfs.tmp");
+    std::fs::write(&temporary, mirrorlist(&ranked, opts.keep))
+        .wrap_err_with(|| format!("cannot write {}", temporary.display()))?;
+    std::fs::rename(&temporary, path)
+        .wrap_err_with(|| format!("cannot replace {}", path.display()))?;
+    tracing::info!(
+        best = %ranked[0].url,
+        kib_per_sec = ranked[0].bytes_per_sec / 1024,
+        kept = ranked.len().min(opts.keep),
+        "mirrorlist written"
+    );
+    Ok(ranked)
+}
+
+pub const LIVE_MIRRORLIST: &str = "/etc/pacman.d/mirrorlist";
+
+/// Rank mirrors for the live medium once per process: the wizard does it
+/// while the user is still on the welcome step, and the pipeline's own call
+/// then costs nothing. A failure keeps the medium's list and is retried by
+/// the next caller.
+pub fn refresh_live_once() -> Result<()> {
+    static DONE: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    if DONE.get().is_some() {
+        return Ok(());
+    }
+    refresh_blocking(Path::new(LIVE_MIRRORLIST), RankOptions::default())?;
+    let _ = DONE.set(());
+    Ok(())
+}
+
+/// [`refresh`] for callers without an async context. Runs on its own
+/// thread with its own runtime, so it is safe inside `spawn_blocking`.
+pub fn refresh_blocking(path: &Path, opts: RankOptions) -> Result<Vec<RankedMirror>> {
+    let path = path.to_path_buf();
+    std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .wrap_err("cannot start a runtime for mirror ranking")?
+            .block_on(refresh(&path, &opts))
+    })
+    .join()
+    .map_err(|_| color_eyre::eyre::eyre!("mirror ranking thread panicked"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(url: &str, country: &str, code: &str) -> MirrorStatus {
+        MirrorStatus {
+            url: url.into(),
+            protocol: "https".into(),
+            country: country.into(),
+            country_code: code.into(),
+            active: true,
+            completion_pct: 1.0,
+            delay: Some(600),
+        }
+    }
+
+    #[test]
+    fn candidates_keep_only_current_https_mirrors_of_the_wanted_countries() {
+        let mut stale = status("https://stale.example/", "Germany", "DE");
+        stale.delay = Some(2 * 24 * 3600);
+        let mut flaky = status("https://flaky.example/", "Germany", "DE");
+        flaky.completion_pct = 0.5;
+        let mut plain = status("http://plain.example/", "Germany", "DE");
+        plain.protocol = "http".into();
+        let mut never = status("https://never.example/", "Germany", "DE");
+        never.delay = None;
+        let list = vec![
+            status("https://de.example/", "Germany", "DE"),
+            status("https://nl.example/", "Netherlands", "NL"),
+            stale,
+            flaky,
+            plain,
+            never,
+        ];
+        let opts = RankOptions::default();
+        let urls = |v: Vec<MirrorStatus>| v.into_iter().map(|m| m.url).collect::<Vec<_>>();
+        assert_eq!(
+            urls(candidates(&list, &opts)),
+            ["https://de.example/", "https://nl.example/"]
+        );
+        let by_name = RankOptions {
+            countries: vec!["netherlands".into()],
+            ..RankOptions::default()
+        };
+        assert_eq!(urls(candidates(&list, &by_name)), ["https://nl.example/"]);
+        let by_code = RankOptions {
+            countries: vec!["de".into()],
+            ..RankOptions::default()
+        };
+        assert_eq!(urls(candidates(&list, &by_code)), ["https://de.example/"]);
+    }
+
+    #[test]
+    fn the_status_file_parses_the_fields_the_ranking_needs() {
+        let json = r#"{"cutoff": 86400, "urls": [
+            {"url": "https://mirror.example/archlinux/", "protocol": "https", "country": "Finland",
+             "country_code": "FI", "active": true, "completion_pct": 1.0, "delay": 1234,
+             "score": 1.5, "isos": true, "ipv4": true, "ipv6": true, "details": "x"},
+            {"url": "https://ahead.example/", "protocol": "https", "country": "Finland",
+             "country_code": "FI", "active": true, "completion_pct": 1.0, "delay": -59},
+            {"url": "rsync://mirror.example/archlinux/", "protocol": "rsync", "country": "",
+             "country_code": "", "active": true, "completion_pct": 1.0, "delay": null}
+        ]}"#;
+        let file: StatusFile = serde_json::from_str(json).unwrap();
+        assert_eq!(file.urls.len(), 3);
+        assert_eq!(file.urls[0].country_code, "FI");
+        assert_eq!(file.urls[2].delay, None);
+        // The rsync entry is dropped; the one reported ahead of the check stays.
+        assert_eq!(candidates(&file.urls, &RankOptions::default()).len(), 2);
+    }
+
+    #[test]
+    fn the_mirrorlist_keeps_the_fastest_and_pacman_syntax() {
+        let ranked = vec![
+            RankedMirror {
+                url: "https://fast.example/archlinux/".into(),
+                country: "Finland".into(),
+                latency: Duration::from_millis(40),
+                bytes_per_sec: 20 * 1024 * 1024,
+            },
+            RankedMirror {
+                url: "https://slow.example/".into(),
+                country: String::new(),
+                latency: Duration::from_millis(300),
+                bytes_per_sec: 100 * 1024,
+            },
+        ];
+        let text = mirrorlist(&ranked, 1);
+        assert!(text.contains("Server = https://fast.example/archlinux/$repo/os/$arch\n"));
+        assert!(!text.contains("slow.example"));
+        assert!(text.contains("# Finland — 20480 KiB/s, 40 ms"));
+        assert!(mirrorlist(&ranked, 5).contains("# ? — 100 KiB/s, 300 ms"));
+    }
+}

--- a/core/src/system/mod.rs
+++ b/core/src/system/mod.rs
@@ -4,6 +4,7 @@ pub mod cmd;
 pub(crate) mod conf;
 pub mod fs;
 pub mod gpu;
+pub mod mirrors;
 pub mod net;
 pub mod pacman;
 pub mod sysinfo;

--- a/core/src/zfs_setup.rs
+++ b/core/src/zfs_setup.rs
@@ -135,58 +135,6 @@ pub fn ensure_reflector_finished_and_stopped(runner: &dyn CommandRunner) -> Resu
     Ok(())
 }
 
-/// Check if the mirrorlist is stale and refresh it with reflector.
-/// The testing ISO bakes in a mirrorlist at build time; if the ISO is old,
-/// pacman downloads will be extremely slow or fail entirely.
-pub fn refresh_mirrors_if_stale(runner: &dyn CommandRunner) -> Result<()> {
-    let mirrorlist = std::path::Path::new("/etc/pacman.d/mirrorlist");
-    if !mirrorlist.exists() {
-        return Ok(());
-    }
-
-    // Check the age of the mirrorlist
-    let stale = match std::fs::metadata(mirrorlist) {
-        Ok(meta) => match meta.modified() {
-            Ok(mtime) => {
-                let age = std::time::SystemTime::now()
-                    .duration_since(mtime)
-                    .unwrap_or_default();
-                // Consider stale if older than 24 hours
-                age.as_secs() > 86400
-            }
-            Err(_) => true,
-        },
-        Err(_) => true,
-    };
-
-    if !stale {
-        tracing::info!("mirrorlist is fresh, skipping reflector");
-        return Ok(());
-    }
-
-    tracing::info!("mirrorlist is stale, refreshing with reflector...");
-    let output = runner.run(
-        "reflector",
-        &[
-            "--latest",
-            "20",
-            "--protocol",
-            "https",
-            "--sort",
-            "rate",
-            "--save",
-            "/etc/pacman.d/mirrorlist",
-        ],
-    )?;
-    if output.success() {
-        tracing::info!("mirrors refreshed successfully");
-    } else {
-        tracing::warn!("reflector failed: {}", output.stderr.trim());
-        // Not fatal — old mirrors may still work, just slowly
-    }
-    Ok(())
-}
-
 pub fn install_zfs_on_host(
     kernel: &str,
     precompiled: bool,
@@ -223,13 +171,12 @@ pub fn initialize_zfs(
     cancel: &tokio_util::sync::CancellationToken,
     download_config: DownloadConfig,
 ) -> Result<()> {
-    // 1. Wait for reflector and stop it
+    // 1. Wait for reflector and stop it, so it cannot overwrite the ranked
+    //    mirrorlist behind the installer's back. Ranking itself happens in
+    //    `system::mirrors`, called by the interfaces before this step.
     ensure_reflector_finished_and_stopped(runner)?;
 
-    // 2. Refresh mirrors if the mirrorlist is stale
-    refresh_mirrors_if_stale(runner)?;
-
-    // 3. Check if ZFS is already available
+    // 2. Check if ZFS is already available
     let module_ok = check_zfs_module(runner).unwrap_or(false);
     let utils_ok = check_zfs_utils(runner).unwrap_or(false);
     if module_ok && utils_ok {
@@ -333,8 +280,6 @@ mod tests {
             // stop reflector.service
             CannedResponse::default(),
             // stop reflector.timer
-            CannedResponse::default(),
-            // refresh_mirrors_if_stale: reflector (may or may not be called depending on FS state)
             CannedResponse::default(),
             // check_zfs_module: lsmod (contains zfs)
             CannedResponse {

--- a/slint-ui/src/controllers/install.rs
+++ b/slint-ui/src/controllers/install.rs
@@ -217,6 +217,7 @@ fn spawn_download_pump(app: &App, mut rx: tokio::sync::watch::Receiver<PackagePr
                     active_downloads,
                     completed,
                     failed,
+                    ref note,
                 } => {
                     let is_active = total_bytes > 0
                         && (active_downloads > 0
@@ -234,22 +235,42 @@ fn spawn_download_pump(app: &App, mut rx: tokio::sync::watch::Receiver<PackagePr
                         .eta()
                         .map(format_duration)
                         .unwrap_or_else(|| "--:--".to_string());
-                    let status = format!(
+                    let mut status = format!(
                         "Downloads {}/{} | {} | ETA {}",
                         completed,
                         packages.len(),
                         speed_str,
                         eta_str,
                     );
+                    if !note.is_empty() {
+                        status.push_str(" · ");
+                        status.push_str(note);
+                    }
 
+                    // Transfers that move come first; a row that shows no
+                    // bytes is waiting on a mirror, which is what it says.
+                    let mut rows: Vec<&PackageState> = packages
+                        .iter()
+                        .filter(|p| {
+                            matches!(
+                                p,
+                                PackageState::Downloading { .. } | PackageState::Verifying { .. }
+                            )
+                        })
+                        .collect();
+                    rows.sort_by_key(|p| match p {
+                        PackageState::Downloading { downloaded, .. } => {
+                            std::cmp::Reverse((p.live_speed_bps(), *downloaded))
+                        }
+                        _ => std::cmp::Reverse((u64::MAX, u64::MAX)),
+                    });
                     let mut dl_items = Vec::new();
-                    for pkg in packages {
+                    for pkg in rows {
                         match pkg {
                             PackageState::Downloading {
                                 filename,
                                 downloaded,
                                 total,
-                                speed_bps,
                                 ..
                             } => {
                                 let pkg_pct = if *total > 0 {
@@ -257,10 +278,16 @@ fn spawn_download_pump(app: &App, mut rx: tokio::sync::watch::Receiver<PackagePr
                                 } else {
                                     0
                                 };
+                                let live = pkg.live_speed_bps();
+                                let speed = if live == 0 {
+                                    "waiting for mirror".to_string()
+                                } else {
+                                    format_speed(live)
+                                };
                                 dl_items.push(DownloadInfo {
                                     filename: truncate_str(filename, 30).into(),
                                     pct: pkg_pct,
-                                    speed: format_speed(*speed_bps).into(),
+                                    speed: speed.into(),
                                     state: 0,
                                 });
                             }

--- a/slint-ui/src/controllers/welcome.rs
+++ b/slint-ui/src/controllers/welcome.rs
@@ -151,11 +151,13 @@ fn start_zfs_init(app: &App, config: &GlobalConfig) {
         let w = weak.clone();
         let _ = w.upgrade_in_event_loop(|app| {
             app.global::<WelcomeState>()
-                .set_zfs_install_status(SharedString::from("Checking reflector..."));
+                .set_zfs_install_status(SharedString::from("Measuring mirrors..."));
         });
 
         archinstall_zfs_core::zfs_setup::ensure_reflector_finished_and_stopped(&*runner).ok();
-        archinstall_zfs_core::zfs_setup::refresh_mirrors_if_stale(&*runner).ok();
+        if let Err(error) = archinstall_zfs_core::system::mirrors::refresh_live_once() {
+            tracing::warn!(%error, "keeping the medium's mirrorlist");
+        }
 
         let w = weak.clone();
         let _ = w.upgrade_in_event_loop(|app| {

--- a/slint-ui/src/main.rs
+++ b/slint-ui/src/main.rs
@@ -86,7 +86,7 @@ fn setup_logging(ui_log_tx: crossbeam_channel::Sender<(String, i32)>) -> Result<
 
     let file_appender = tracing_appender::rolling::never("/tmp", "archinstall-zfs.log");
     let file_filter = tracing_subscriber::EnvFilter::new(
-        "trace,h2=warn,hyper=warn,reqwest=warn,rustls=warn,pacman=info",
+        "trace,h2=warn,hyper=warn,reqwest=warn,rustls=warn,pacman=info,calloop=info,i_slint_backend_linuxkms=info,i_slint_core=info,i_slint_renderer_skia=info",
     );
     let file_layer = tracing_subscriber::fmt::layer()
         .with_writer(file_appender)

--- a/slint-ui/src/preview.rs
+++ b/slint-ui/src/preview.rs
@@ -347,12 +347,42 @@ fn progress(app: &App, state: i32) {
     install.set_download_active(state == 1);
     install.set_download_pct(62);
     install.set_download_status("62% · 24.8 MiB/s · 18 seconds remaining".into());
-    install.set_download_items(ModelRc::new(VecModel::from(vec![DownloadInfo {
-        filename: "linux-7.2.3.arch1-3-x86_64.pkg.tar.zst".into(),
-        pct: 62,
-        speed: "24.8 MiB/s".into(),
-        state: 0,
-    }])));
+    // The panel lists every transfer in flight; the fixture shows a full set
+    // of parallel downloads including a stalled one and one being verified.
+    let row = |filename: &str, pct: i32, speed: &str, state: i32| DownloadInfo {
+        filename: filename.into(),
+        pct,
+        speed: speed.into(),
+        state,
+    };
+    install.set_download_items(ModelRc::new(VecModel::from(vec![
+        row(
+            "linux-7.2.3.arch1-3-x86_64.pkg.tar.zst",
+            62,
+            "24.8 MiB/s",
+            0,
+        ),
+        row(
+            "linux-firmware-intel-20260810-2-any.pkg.tar.zst",
+            41,
+            "9.1 MiB/s",
+            0,
+        ),
+        row(
+            "gcc-16.2.1+r23+gd564253eb6c8-1-x86_64.pkg.tar.zst",
+            88,
+            "6.4 MiB/s",
+            0,
+        ),
+        row("perl-5.42.2-2-x86_64.pkg.tar.zst", 17, "3.2 MiB/s", 0),
+        row("systemd-261.2-1-x86_64.pkg.tar.zst", 100, "", 1),
+        row(
+            "glibc-2.44+r24+g16be1518495f-1-x86_64.pkg.tar.zst",
+            0,
+            "waiting for mirror",
+            0,
+        ),
+    ])));
     // Enough realistic output to review scrolling, wrapping and persistent actions.
     // All messages describe the preview fixture; no commands are executed here.
     let mut messages = vec![

--- a/slint-ui/src/tracing_layer.rs
+++ b/slint-ui/src/tracing_layer.rs
@@ -30,19 +30,21 @@ impl<S: Subscriber> Layer<S> for UiLogLayer {
         let mut visitor = MessageVisitor::default();
         event.record(&mut visitor);
 
-        let prefix = match level {
-            4 => "ERROR",
-            3 => "WARN ",
-            1 => "DEBUG",
-            0 => "TRACE",
-            _ => "INFO ",
+        // Pad after the bracket so messages line up without a stray space
+        // inside "[INFO ]".
+        let (name, pad) = match level {
+            4 => ("ERROR", ""),
+            3 => ("WARN", " "),
+            1 => ("DEBUG", ""),
+            0 => ("TRACE", ""),
+            _ => ("INFO", " "),
         };
 
         let msg = visitor.message.unwrap_or_default();
         let line = if visitor.fields.is_empty() {
-            format!("[{prefix}] {msg}")
+            format!("[{name}]{pad} {msg}")
         } else {
-            format!("[{prefix}] {msg} {}", visitor.fields.join(" "))
+            format!("[{name}]{pad} {msg} {}", visitor.fields.join(" "))
         };
 
         let _ = self.tx.try_send((line, level));

--- a/slint-ui/ui/views/install-view.slint
+++ b/slint-ui/ui/views/install-view.slint
@@ -37,9 +37,23 @@ export component InstallView inherits VerticalLayout {
         vertical-alignment: center;
     }
 
+    // Following the log is deferred to a timer rather than done inside the
+    // change handlers: moving content-y re-estimates the virtualized list's
+    // content-height, whose change handler would move content-y again, and
+    // the runtime cuts such chains off after ten rounds with a warning per
+    // frame. The timer runs once per batch of changes, outside that pass.
     property <int> scroll-trigger: InstallState.log-messages.length;
-    changed scroll-trigger => {
-        root.follow-latest();
+    changed scroll-trigger => { root.queue-follow(); }
+    follow-timer := Timer {
+        interval: 16ms;
+        running: false;
+        triggered => {
+            self.running = false;
+            root.follow-latest();
+        }
+    }
+    function queue-follow() {
+        if root.follow-output { follow-timer.running = true; }
     }
     function follow-latest() {
         if root.follow-output {
@@ -81,8 +95,8 @@ export component InstallView inherits VerticalLayout {
             log-view := ListView {
                 vertical-stretch: 1;
                 min-height: 0px;
-                changed content-height => { root.follow-latest(); }
-                changed visible-height => { root.follow-latest(); }
+                changed content-height => { root.queue-follow(); }
+                changed visible-height => { root.queue-follow(); }
                 scrolled => {
                     root.follow-output = self.content-y <= -max(0px, self.content-height - self.visible-height) + 2px;
                 }
@@ -207,10 +221,12 @@ export component InstallView inherits VerticalLayout {
                         border-radius: 2px;
                     }
                 }
-                ListView {
-                    height: min(3, InstallState.download-items.length) * 20px;
-                    for dl in InstallState.download-items: Rectangle {
-                        height: 20px;
+                // Every transfer in flight, each with its own bar: at most
+                // the configured parallelism, so no scrolling is needed.
+                VerticalLayout {
+                    spacing: 4px;
+                    for dl in InstallState.download-items: VerticalLayout {
+                        spacing: 2px;
                         HorizontalLayout {
                             spacing: 12px;
                             Text {
@@ -225,9 +241,24 @@ export component InstallView inherits VerticalLayout {
                             Text {
                                 text: dl.state == 1 ? "Verifying"
                                     : dl.state == 2 ? "Done" : dl.pct + "%  " + dl.speed;
-                                color: dl.state == 2 ? Theme.c.green : Theme.c.subtext0;
+                                color: dl.state == 2 ? Theme.c.green
+                                    : dl.state == 0 && dl.speed == "waiting for mirror" ? Theme.c.yellow
+                                    : Theme.c.subtext0;
                                 font-size: 11px;
                                 vertical-alignment: center;
+                            }
+                        }
+                        Rectangle {
+                            height: 3px;
+                            background: Theme.c.mantle;
+                            border-radius: 1.5px;
+                            clip: true;
+                            Rectangle {
+                                x: 0; y: 0;
+                                height: parent.height;
+                                width: parent.width * clamp(dl.pct / 100, 0, 1);
+                                background: dl.state == 1 ? Theme.c.green : Theme.c.teal;
+                                border-radius: 1.5px;
                             }
                         }
                     }


### PR DESCRIPTION
An install on a laptop spent minutes at "0/187, -- B/s" because reflector had ranked two mirrors first that delivered 2 KiB/s, and every package retried them three times with a 30 s idle timeout before moving on. Cancelling then hung, since the wait for response headers had no timeout and was outside the cancellation select. This changes how mirrors are chosen and how the downloader gives up on one.

- Mirror ranking in `system::mirrors`: candidates from the official status list, a parallel response-time probe, then a sustained sample of extra.db for the quickest; the fastest ten become the mirrorlist. Runs in about 20 s; reflector is no longer invoked (its units are still stopped)
- Downloader: mirrors that stall are demoted for all packages, each round walks every mirror before backing off, idle timeout 10 s, transfers under 4 KiB/s over 15 s move on and resume, and the response-header wait is bounded and cancellable
- Progress: a note about the mirror being skipped, rows ordered by live speed, stalled rows say "waiting for mirror", stale speeds no longer count
- Install screen: every transfer in flight has its own bar, no scrolling; log auto-scroll deferred to a timer so change handlers no longer chain
- File log no longer records the event loop's trace lines; level tags read `[INFO]` with padding after the bracket

Testing

- `cargo run --example rank_mirrors` on the development host: 369 candidates, 24 sampled, top mirror 10.9 MiB/s, 18 s
- Preview install scene reviewed with a full set of parallel rows including a stalled and a verifying one
- `review.py` install/done/failed/cancelled scenes on all sizes
